### PR TITLE
Update be_api.c, be_data_remove 

### DIFF
--- a/src/be_api.c
+++ b/src/be_api.c
@@ -582,7 +582,7 @@ int be_data_remove(bvm *vm, int index)
         }
         break;
     case BE_LIST:
-        if (!var_isint(k)) {
+        if (var_isint(k)) {
             blist *list = cast(blist*, var_toobj(o));
             return be_list_remove(list, var_toint(k));
         }


### PR DESCRIPTION
It won't remove the value at specified index unless the change proposed is in place, please have a look!
```rb
l = [1, 2, 3, 4, 5]
assert(l[0] == 1)
assert(l[1] == 2)
assert(l[2] == 3)
assert(l[3] == 4)
assert(l[4] == 5)

print(l)

it = l.iter()
assert(it.next() == 1)
assert(it.next() == 2)
assert(it.next() == 3)
assert(it.next() == 4)
assert(it.next() == 5)
assert(it.next() == nil)

l.insert(0, 10)
assert(l[0] == 10)
print (l)
l.remove(0)
print (l)
```