### PR TITLE
Fix wrong gc count

### DIFF
--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -310,7 +310,7 @@ static void free_ntvclos(bvm *vm, bgcobject *obj)
         while (count--) {
             be_free(vm, *uv++, sizeof(bupval));
         }
-        be_free(vm, f, sizeof(bntvclos));
+        be_free(vm, f, sizeof(bntvclos) + sizeof(bupval*) * f->nupvals);
     }
 }
 


### PR DESCRIPTION
When deallocating a `ntvvclos`, the size of the upvals pointers if forgotten. Hence the `gc.usage` is wrong and seem to indicate a false memory leak.

The allocation is done here: (`be_func.c`)

```

bntvclos* be_newntvclosure(bvm *vm, bntvfunc cf, int nupvals)
{
    size_t size = sizeof(bntvclos) + sizeof(bupval*) * nupvals;
    bgcobject *gco = be_newgcobj(vm, BE_NTVCLOS, size);
    bntvclos *f = cast_ntvclos(gco);
    if (f) {
        f->f = cf;
        f->nupvals = (bbyte)nupvals;
        if (nupvals) {
            var_setntvclos(vm->top, f);
            be_incrtop(vm);
            init_upvals(vm, f); /* may be GC */
            be_stackpop(vm, 1);
        }
    }
    return f;
}
```