### PR TITLE
Mark be_raise as noreturn

### DIFF
--- a/src/be_api.c
+++ b/src/be_api.c
@@ -976,6 +976,7 @@ BERRY_API int be_pcall(bvm *vm, int argc)
     return be_protectedcall(vm, f, argc);
 }
 
+__attribute__((noreturn))
 BERRY_API void be_raise(bvm *vm, const char *except, const char *msg)
 {
     be_pushstring(vm, except);
@@ -987,6 +988,9 @@ BERRY_API void be_raise(bvm *vm, const char *except, const char *msg)
     be_pop(vm, 2);
     be_save_stacktrace(vm);
     be_throw(vm, BE_EXCEPTION);
+#ifdef __GNUC__
+    __builtin_unreachable();
+#endif
 }
 
 BERRY_API void be_stop_iteration(bvm *vm)

--- a/src/berry.h
+++ b/src/berry.h
@@ -393,6 +393,7 @@ BERRY_API int be_pcall(bvm *vm, int argc);
 BERRY_API void be_exit(bvm *vm, int status);
 
 /* exception APIs */
+__attribute__((noreturn))
 BERRY_API void be_raise(bvm *vm, const char *except, const char *msg);
 BERRY_API int be_getexcept(bvm *vm, int code);
 BERRY_API void be_dumpvalue(bvm *vm, int index);


### PR DESCRIPTION
Mark `be_raise()` as `noreturn` which prevents GCC warnings when you end a function with `be_raise()` instead of `return`