### PR TITLE
Fix list merge

### DIFF
--- a/src/be_listlib.c
+++ b/src/be_listlib.c
@@ -304,13 +304,15 @@ static int m_merge(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc >= 2) {
+        be_newobject(vm, "list"); /* stack contains instance and .p */
         be_getmember(vm, 1, ".p");
+        be_data_merge(vm, -2);
         be_getmember(vm, 2, ".p");
         if (!be_islist(vm, -1)) {
             be_raise(vm, "type_error", "operand must be a list");
         }
-        be_data_merge(vm, -2);
-        be_pop(vm, argc + 1);
+        be_data_merge(vm, -3);
+        be_pop(vm, 3);
     }
     be_return(vm); /* return self */
 }

--- a/tests/list.be
+++ b/tests/list.be
@@ -63,3 +63,12 @@ l.pop()
 assert(l == [0, '3'])
 l.pop(0)
 assert(l == ['3'])
+
+l1 = [0, 1]
+l2 = [2, 3]
+assert(l1+l2==[0, 1, 2, 3])
+assert(l1 == [0, 1])
+assert(l2 == [2, 3])
+assert(l1+[2] == [0, 1, 2])
+assert([-1]+l1 == [-1, 0, 1])
+assert(l1 == [0, 1])


### PR DESCRIPTION
Fix for #85 

List merge now creates a new list:

```
> a=[1]
> b=[2]
> a+b
[1, 2]
> a
[1]
> b
[2]
```

However I was not able to fix `..` because I realized that it is used by the parser and expects the side-effect of appending to the first list. I guess that the fix is deeper.