### PR TITLE
Fix memory leak when BE_DEBUG_VAR_INFO 1

### DIFF
--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -286,6 +286,9 @@ static void free_proto(bvm *vm, bgcobject *obj)
 #if BE_DEBUG_RUNTIME_INFO
         be_free(vm, proto->lineinfo, proto->nlineinfo * sizeof(blineinfo));
 #endif
+#if BE_DEBUG_VAR_INFO
+        be_free(vm, proto->varinfo, proto->nvarinfo * sizeof(bvarinfo));
+#endif
         be_free(vm, proto, sizeof(bproto));
     }
 }


### PR DESCRIPTION
Fix memory leak when `#define BE_DEBUG_VAR_INFO 1`, it appears that `proto->varinfo` is never deallocated.

Before:

```
> import gc
> def f() gc.collect() print(gc.allocated()) end
> f() f()
2612
2612
> f() f()
2644
2644
> f() f()
2676
2676
>
```

After fix:

```
> import gc
> def f() gc.collect() print(gc.allocated()) end
> f() f()
2484
2484
> f() f()
2484
2484
> f() f()
2484
2484
>
```