### PR TITLE
Fix mod real for floats

### DIFF
--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -563,7 +563,11 @@ newframe: /* a new call frame */
             if (var_isint(a) && var_isint(b)) {
                 var_setint(dst, ibinop(%, a, b));
             } else if (var_isreal(a) && var_isreal(b)) {
-							var_setreal(dst,fmod(var_toreal(a),var_toreal(b)));
+#if BE_USE_SINGLE_FLOAT
+                var_setreal(dst,fmodf(var_toreal(a),var_toreal(b)));
+#else
+                var_setreal(dst,fmod(var_toreal(a),var_toreal(b)));
+#endif
             } else if (var_isinstance(a)) {
                 ins_binop(vm, "%", ins);
             } else {

--- a/tests/lexer.be
+++ b/tests/lexer.be
@@ -1,7 +1,7 @@
 import math
 
 def check(a, b)
-    assert(math.abs(a - b) < 1e-10)
+    assert(math.abs(a - b) < 1e-6)
 end
 
 def test_source(src, msg)


### PR DESCRIPTION
Changes suggested to #89:
- remove tab
- use `fmodf()` when `#define BE_USE_SINGLE_FLOAT             1`
- relax precision on test `lexec.be` to make test pass when using float instead of double
