### PR TITLE
Add hook to load custom classes and libs

### DIFF
--- a/default/be_modtab.c
+++ b/default/be_modtab.c
@@ -55,3 +55,14 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
     /* user-defined modules register end */
     NULL /* do not remove */
 };
+
+/* this code loads the native class definitions */
+BERRY_API void be_load_custom_libs(bvm *vm)
+{
+    (void)vm;   /* prevent a compiler warning */
+    
+    /* add here custom libs */
+#if !BE_USE_PRECOMPILED_OBJECT
+    /* be_load_xxxlib(vm); */
+#endif
+}

--- a/src/be_libs.c
+++ b/src/be_libs.c
@@ -14,6 +14,8 @@ extern void be_load_rangelib(bvm *vm);
 extern void be_load_filelib(bvm *vm);
 extern void be_load_byteslib(bvm *vm);
 
+extern void be_load_custom_libs(bvm *vm);
+
 void be_loadlibs(bvm *vm)
 {
     be_load_baselib(vm);
@@ -24,4 +26,5 @@ void be_loadlibs(bvm *vm)
     be_load_filelib(vm);
     be_load_byteslib(vm);
 #endif
+    be_load_custom_libs(vm);
 }

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -1066,6 +1066,9 @@ void be_dofunc(bvm *vm, bvalue *v, int argc)
 
 BERRY_API void be_set_obs_hook(bvm *vm, bobshook hook)
 {
+    (void)vm;       /* avoid comiler warning */
+    (void)hook;     /* avoid comiler warning */
+
 #if BE_USE_OBSERVABILITY_HOOK
     vm->obshook = hook;
 #endif


### PR DESCRIPTION
Add a hook in `be_modtabs.c` to add additional customer libs and classes from `be_loadlibs()` without patching core sources.

Also removed warnings about unused parameters.