### PR TITLE
Add GC debug mode

### DIFF
--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -137,6 +137,14 @@
  **/
 #define BE_USE_DEBUG_HOOK               1
 
+/* Macro: BE_USE_DEBUG_GC
+ * Enable GC debug mode. This causes an actual gc after each
+ * allocation. It's much slower and should not be used
+ * in production code.
+ * Default: 0
+ **/
+#define BE_USE_DEBUG_GC                  0
+
 /* Macro: BE_USE_XXX_MODULE
  * These macros control whether the related module is compiled.
  * When they are true, they will enable related modules. At this

--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -492,9 +492,15 @@ static void reset_fixedlist(bvm *vm)
 
 void be_gc_auto(bvm *vm)
 {
+#if BE_USE_DEBUG_GC
+    if (vm->gc.status & GC_PAUSE) { /* force gc each time it's possible */
+        be_gc_collect(vm);
+    }
+#else
     if (vm->gc.status & GC_PAUSE && vm->gc.usage > vm->gc.threshold) {
         be_gc_collect(vm);
     }
+#endif
 }
 
 size_t be_gc_memcount(bvm *vm)

--- a/src/be_mem.c
+++ b/src/be_mem.c
@@ -53,6 +53,10 @@ static void* _realloc(void *ptr, size_t old_size, size_t new_size)
         return malloc(new_size);
     }
     be_assert(new_size == 0);
+
+#if BE_USE_DEBUG_GC
+    memset(ptr, 0xFF, old_size); /* fill the structure with invalid pointers */
+#endif
     free(ptr);
     return NULL;
 }

--- a/src/be_mem.c
+++ b/src/be_mem.c
@@ -10,6 +10,7 @@
 #include "be_vm.h"
 #include "be_gc.h"
 #include <stdlib.h>
+#include <string.h>
 
 #define GC_ALLOC    (1 << 2) /* GC in alloc */
 


### PR DESCRIPTION
I found an easy way to exercise the bug from #94.

When enabling `#define BE_USE_DEBUG_GC 1`, a full gc is performed after each allocation and freed memory is fulled with invalid data.

It appears that the bug is wider than thought initially. For example running the default version with BE_USE_DEBUG_GC enabled:

```
Berry 0.1.10 (build in Mar 27 2021, 09:15:27)
[clang 12.0.0 (clang-1200.0.32.27)] on Darwin (default)
> ()
syntax_error: ������������������������������������������������
>
```

I will explore deeper, but it looks like we must put GC on hold when adding to `map` and maybe `list` structures.