### PR TITLE
Set strings as temporarily fixed

### DIFF
--- a/src/be_class.c
+++ b/src/be_class.c
@@ -59,8 +59,10 @@ int be_class_attribute(bvm *vm, bclass *c, bstring *attr)
 void be_member_bind(bvm *vm, bclass *c, bstring *name)
 {
     bvalue *attr;
+    set_fixed(name);
     check_members(vm, c);
     attr = be_map_insertstr(vm, c->members, name, NULL);
+    restore_fixed(name);
     attr->v.i = c->nvar++;
     attr->type = MT_VARIABLE;
 }
@@ -69,8 +71,10 @@ void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p)
 {
     bclosure *cl;
     bvalue *attr;
+    set_fixed(name);
     check_members(vm, c);
     attr = be_map_insertstr(vm, c->members, name, NULL);
+    restore_fixed(name);
     var_setnil(attr);
     cl = be_newclosure(vm, p->nupvals);
     cl->proto = p;
@@ -80,8 +84,10 @@ void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p)
 void be_prim_method_bind(bvm *vm, bclass *c, bstring *name, bntvfunc f)
 {
     bvalue *attr;
+    set_fixed(name);
     check_members(vm, c);
     attr = be_map_insertstr(vm, c->members, name, NULL);
+    restore_fixed(name);
     attr->v.nf = f;
     attr->type = MT_PRIMMETHOD;
 }

--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -120,6 +120,20 @@ void be_gc_unfix(bvm *vm, bgcobject *obj)
     }
 }
 
+bbool be_gc_fix_set(bvm *vm, bgcobject *obj, bbool fix)
+{
+    (void)vm;
+    bbool was_fixed = gc_isfixed(obj);
+    if (!gc_isconst(obj)) {
+        if (fix) {
+            gc_setfixed(obj);
+        } else {
+            gc_clearfixed(obj);
+        }
+    }
+    return was_fixed;
+}
+
 static void mark_gray(bvm *vm, bgcobject *obj)
 {
     if (obj && gc_iswhite(obj) && !gc_isconst(obj)) {

--- a/src/be_gc.h
+++ b/src/be_gc.h
@@ -49,6 +49,9 @@ if (!gc_isconst(o)) { \
 #define be_isgcobj(o)       be_isgctype(var_type(o))
 #define be_gcnew(v, t, s)   be_newgcobj((v), (t), sizeof(s))
 
+#define set_fixed(s)        bbool _was_fixed = be_gc_fix_set(vm, cast(bgcobject*, (s)), 1)
+#define restore_fixed(s)    be_gc_fix_set(vm, cast(bgcobject*, (s)), _was_fixed);
+
 /* the GC mark uses bit4:0 of the `object->marked` field,
  * so other bits can be used for special flags (ex-mark). */
 typedef enum {
@@ -68,6 +71,7 @@ bgcobject *be_newgcobj(bvm *vm, int type, size_t size);
 bgcobject* be_gc_newstr(bvm *vm, size_t size, int islong);
 void be_gc_fix(bvm *vm, bgcobject *obj);
 void be_gc_unfix(bvm *vm, bgcobject *obj);
+bbool be_gc_fix_set(bvm *vm, bgcobject *obj, bbool fix);
 void be_gc_collect(bvm *vm);
 void be_gc_auto(bvm *vm);
 

--- a/src/be_map.c
+++ b/src/be_map.c
@@ -315,7 +315,10 @@ bvalue* be_map_insertstr(bvm *vm, bmap *map, bstring *key, bvalue *value)
 {
     bvalue v;
     var_setstr(&v, key);
-    return be_map_insert(vm, map, &v, value);
+    set_fixed(key);
+    bvalue * r = be_map_insert(vm, map, &v, value);
+    restore_fixed(key);
+    return r;
 }
 
 void be_map_removestr(bvm *vm, bmap *map, bstring *key)


### PR DESCRIPTION
Fix for #94 

I added macros to save the `GC_FIXED` states of object, and I set map keys to `GC_FIXED` before calling `be_map_insert()` as the resizing of the map may cause a GC, and before calling `check_members()` that may call `be_map_new()` and trigger a GC.

It does not solve other GC issues with strings.