### PR TITLE
Fix debug.attrdump crash

### DIFF
--- a/src/be_debuglib.c
+++ b/src/be_debuglib.c
@@ -40,7 +40,9 @@ static void dump_module(bmodule *module)
 
 static void dump_class(bclass *class)
 {
-    dump_map(class->members);
+    if (class->members) {
+        dump_map(class->members);
+    }
 }
 
 static void dump_instanse(binstance *ins)

--- a/tests/debug.be
+++ b/tests/debug.be
@@ -1,0 +1,4 @@
+import debug
+
+class A end
+debug.attrdump(A)   #- should not crash -#


### PR DESCRIPTION
`debug.attrdump()` would crash when the class or the instance has no members.

Added test case for it.