### PR TITLE
Add module solidify

### DIFF
--- a/default/be_modtab.c
+++ b/default/be_modtab.c
@@ -18,6 +18,7 @@ be_extern_native_module(os);
 be_extern_native_module(sys);
 be_extern_native_module(debug);
 be_extern_native_module(gc);
+be_extern_native_module(solidify);
 
 /* user-defined modules declare start */
 
@@ -49,6 +50,9 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
 #endif
 #if BE_USE_GC_MODULE
     &be_native_module(gc),
+#endif
+#if BE_USE_SOLIDIFY_MODULE
+    &be_native_module(solidify),
 #endif
     /* user-defined modules register start */
 

--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -159,6 +159,7 @@
 #define BE_USE_SYS_MODULE               1
 #define BE_USE_DEBUG_MODULE             1
 #define BE_USE_GC_MODULE                1
+#define BE_USE_SOLIDIFY_MODULE          1
 
 /* Macro: BE_EXPLICIT_XXX
  * If these macros are defined, the corresponding function will

--- a/src/be_api.c
+++ b/src/be_api.c
@@ -35,6 +35,17 @@ static void class_init(bvm *vm, bclass *c, const bnfuncinfo *lib)
             }
             ++lib;
         }
+        if (lib->function == (bntvfunc) BE_CLOSURE) {
+            /* next section is closures */
+            ++lib;
+            while (lib->name) {
+                if (lib->function) { /* method */
+                    bstring *s = be_newstr(vm, lib->name);
+                    be_closure_method_bind(vm, c, s, (bclosure*) lib->function);
+                }
+                ++lib;
+            }
+        }
         be_map_release(vm, c->members); /* clear space */
     }
 }
@@ -346,6 +357,13 @@ BERRY_API void be_pushvalue(bvm *vm, int index)
     be_incrtop(vm);
 }
 
+BERRY_API void be_pushclosure(bvm *vm, void *cl)
+{
+    bvalue *reg = be_incrtop(vm);
+    bclosure * closure = (bclosure*) cl;
+    var_setclosure(reg, closure);
+}
+
 BERRY_API void be_pushntvclosure(bvm *vm, bntvfunc f, int nupvals)
 {
     /* to create a native closure and then push the top registor,
@@ -370,6 +388,12 @@ BERRY_API void be_pushclass(bvm *vm, const char *name, const bnfuncinfo *lib)
     var_setstr(dst, s);
     c = class_auto_make(vm, s, lib);
     var_setclass(vm->top - 1, c);
+}
+
+BERRY_API void be_pushntvclass(bvm *vm, const struct bclass * c)
+{
+    bvalue *top = be_incrtop(vm);
+    var_setclass(top, (bclass *) c);
 }
 
 BERRY_API void be_pushcomptr(bvm *vm, void *ptr)

--- a/src/be_class.c
+++ b/src/be_class.c
@@ -92,6 +92,15 @@ void be_prim_method_bind(bvm *vm, bclass *c, bstring *name, bntvfunc f)
     attr->type = MT_PRIMMETHOD;
 }
 
+void be_closure_method_bind(bvm *vm, bclass *c, bstring *name, bclosure *cl)
+{
+    bvalue *attr;
+    check_members(vm, c);
+    attr = be_map_insertstr(vm, c->members, name, NULL);
+    attr->v.gc = (bgcobject*) cl;
+    attr->type = MT_METHOD;
+}
+
 /* get the closure method count that need upvalues */
 int be_class_closure_count(bclass *c)
 {

--- a/src/be_class.h
+++ b/src/be_class.h
@@ -52,6 +52,7 @@ int be_class_attribute(bvm *vm, bclass *c, bstring *attr);
 void be_member_bind(bvm *vm, bclass *c, bstring *name);
 void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p);
 void be_prim_method_bind(bvm *vm, bclass *c, bstring *name, bntvfunc f);
+void be_closure_method_bind(bvm *vm, bclass *c, bstring *name, bclosure *cl);
 int be_class_closure_count(bclass *c);
 void be_class_upvalue_init(bvm *vm, bclass *c);
 bbool be_class_newobj(bvm *vm, bclass *c, bvalue *argv, int argc);

--- a/src/be_constobj.h
+++ b/src/be_constobj.h
@@ -47,9 +47,19 @@ extern "C" {
     .type = BE_REAL                                             \
 }
 
+#define be_const_str(_str) {                                    \
+    .v.s = (bstring*)(_str),                                    \
+    .type = BE_STRING                                           \
+}
+
 #define be_const_class(_class) {                                \
     .v.c = &(_class),                                           \
     .type = BE_CLASS                                            \
+}
+
+#define be_const_closure(_closure) {                            \
+    .v.c = &(_closure),                                         \
+    .type = BE_CLOSURE                                          \
 }
 
 #define be_const_module(_module) {                              \
@@ -126,9 +136,19 @@ const bntvmodule be_native_module(_module) = {                  \
     BE_REAL                                                     \
 }
 
+#define be_const_str(_string) {                                 \
+    bvaldata(bstring(_string)),                                 \
+    BE_STRING                                                   \
+}
+
 #define be_const_class(_class) {                                \
     bvaldata(&(_class)),                                        \
     BE_CLASS                                                    \
+}
+
+#define be_const_closure(_closure) {                            \
+    bvaldata(&(_closure)),                                      \
+    BE_CLOSURE                                                  \
 }
 
 #define be_const_module(_module) {                              \

--- a/src/be_debug.c
+++ b/src/be_debug.c
@@ -46,7 +46,7 @@ static const char* opc2str(bopcode op)
     return op < array_count(opc_tab) ? opc_tab[op] : "ERROP";
 }
 
-static void print_inst(binstruction ins, int pc)
+void be_print_inst(binstruction ins, int pc)
 {
     char __lbuf[INST_BUF_SIZE];
     bopcode op = IGET_OP(ins);
@@ -145,7 +145,7 @@ void be_dumpclosure(bclosure *cl)
             logfmt("; line %d\n", (++lineinfo)->linenumber);
         }
 #endif
-        print_inst(*code++, pc);
+        be_print_inst(*code++, pc);
     }
 }
 #endif

--- a/src/be_debug.h
+++ b/src/be_debug.h
@@ -21,4 +21,8 @@ void be_callhook(bvm *vm, int mask);
 bbool be_debug_varname(bvm *vm, int level, int index);
 bbool be_debug_upvname(bvm *vm, int level, int index);
 
+#if BE_USE_DEBUG_MODULE
+void be_print_inst(binstruction ins, int pc);
+#endif
+
 #endif

--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -1,0 +1,203 @@
+/********************************************************************
+** Copyright (c) 2018-2020 Guan Wenliang
+** This file is part of the Berry default interpreter.
+** skiars@qq.com, https://github.com/Skiars/berry
+** See Copyright Notice in the LICENSE file or at
+** https://github.com/Skiars/berry/blob/master/LICENSE
+********************************************************************/
+#include "be_object.h"
+#include "be_module.h"
+#include "be_string.h"
+#include "be_vector.h"
+#include "be_class.h"
+#include "be_debug.h"
+#include "be_map.h"
+#include "be_vm.h"
+#include "be_decoder.h"
+#include <string.h>
+#include <stdio.h>
+
+#if BE_USE_SOLIDIFY_MODULE
+
+#ifndef INST_BUF_SIZE
+#define INST_BUF_SIZE   96
+#endif
+
+#define logbuf(...)     snprintf(__lbuf, sizeof(__lbuf), __VA_ARGS__)
+
+#define logfmt(...)                     \
+    do {                                \
+        char __lbuf[INST_BUF_SIZE];     \
+        logbuf(__VA_ARGS__);            \
+        be_writestring(__lbuf);         \
+    } while (0)
+
+/* output only valid types for ktab, or NULL */
+static const char * m_type_ktab(int type)
+{
+    switch (type){
+        case BE_NIL:    return "BE_NIL";
+        case BE_INT:    return "BE_INT";
+        case BE_REAL:   return "BE_REAL";
+        case BE_BOOL:   return "BE_BOOL";
+        case BE_STRING: return "BE_STRING";
+        default:        return NULL;
+    }
+}
+
+static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int builtins)
+{
+    // const char * func_name = str(pr->name);
+    const char * func_source = str(pr->source);
+
+    if (pr->nproto > 0) {
+        for (int32_t i = 0; i < pr->nproto; i++) {
+            size_t sub_len = strlen(func_name) + 10;
+            char sub_name[sub_len];
+            snprintf(sub_name, sizeof(sub_name), "%s_%d", func_name, i);
+            m_solidify_proto(vm, pr->ptab[i], sub_name, builtins);
+        }
+    }
+
+    logfmt("\n/********** Solidified proto: %s */\n", func_name);
+
+    if (pr->nproto > 0) {
+        logfmt("static const bproto *%s_subproto[%i] = {\n", func_name, pr->nproto);
+        for (int32_t i = 0; i < pr->nproto; i++) {
+            logfmt("  &%s_%d_proto,\n", func_name, i);
+            // logfmt("  be_local_const_upval(%i, %i),\n", pr->upvals[i].instack, pr->upvals[i].idx); TODO
+        }
+        logfmt("};\n\n");
+    }
+
+    if (pr->nupvals > 0) {
+        logfmt("static const bupvaldesc %s_upvals[%i] = {\n", func_name, pr->nupvals);
+        for (int32_t i = 0; i < pr->nupvals; i++) {
+            logfmt("  be_local_const_upval(%i, %i),\n", pr->upvals[i].instack, pr->upvals[i].idx);
+            // logfmt("// upval[%d] = { .instack = %i, .idx = %i }\n", i, pr->upvals[i].instack, pr->upvals[i].idx);
+        }
+        logfmt("};\n\n");
+    }
+
+    /* create static strings for name and source */
+    logfmt("be_define_local_const_str(%s_str_name, \"%s\", %i, %u);\n",
+            func_name, str(pr->name), be_strhash(pr->name), str_len(pr->name));
+    logfmt("be_define_local_const_str(%s_str_source, \"%s\", %i, %u);\n",
+            func_name, func_source, be_strhash(pr->source), str_len(pr->source));
+    
+    /* create static strings first */
+    for (int i = 0; i < pr->nconst; i++) {
+        if (pr->ktab[i].type == BE_STRING) {
+            logfmt("be_define_local_const_str(%s_str_%i, \"",
+                    func_name, i);
+            be_writestring(str(pr->ktab[i].v.s));
+            size_t len = strlen(str(pr->ktab[i].v.s));
+            if (len >= 255) {
+                be_raise(vm, "internal_error", "Strings greater than 255 chars not supported yet");
+            }
+            logfmt("\", %i, %zu);\n", be_strhash(pr->ktab[i].v.s), len >= 255 ? 255 : len);
+        }
+    }
+    logfmt("\n");
+
+    if (pr->nconst > 0) {
+        logfmt("static const bvalue %s_ktab[%i] = {\n", func_name, pr->nconst);
+        for (int k = 0; k < pr->nconst; k++) {
+            int type = pr->ktab[k].type;
+            const char *type_name = m_type_ktab(type);
+            if (type_name == NULL) {
+                char error[64];
+                snprintf(error, sizeof(error), "Unsupported type in function constants: %i", type);
+                be_raise(vm, "internal_error", error);
+            }
+            if (type == BE_STRING) {
+                logfmt("  { { .s=be_local_const_str(%s_str_%i) }, %s},\n", func_name, k, type_name);
+            } else if (type == BE_INT) {
+                logfmt("  { { .i=%" BE_INT_FMTLEN "i }, %s},\n", pr->ktab[k].v.i, type_name);
+            } else if (type == BE_REAL) {
+    #if BE_USE_SINGLE_FLOAT
+                logfmt("  { { .p=(void*)0x%08X }, %s},\n", (uint32_t) pr->ktab[k].v.p, type_name);
+    #else
+                logfmt("  { { .p=(void*)0x%016llX }, %s},\n", (uint64_t) pr->ktab[k].v.p, type_name);
+    #endif
+            } else if (type == BE_BOOL) {
+                logfmt("  { { .b=%i }, %s},\n", pr->ktab[k].v.b, type_name);
+            }
+        }
+        logfmt("};\n\n");
+    }
+
+    logfmt("static const uint32_t %s_code[%i] = {\n", func_name, pr->codesize);
+    for (int pc = 0; pc < pr->codesize; pc++) {
+        uint32_t ins = pr->code[pc];
+        logfmt("  0x%04X,  //", ins);
+        be_print_inst(ins, pc);
+        bopcode op = IGET_OP(ins);
+        if (op == OP_GETGBL || op == OP_SETGBL) {
+            // check if the global is in built-ins
+            int glb = IGET_Bx(ins);
+            if (glb > builtins) {
+                // not supported
+                logfmt("\n===== unsupported global G%d\n", glb);
+                be_raise(vm, "internal_error", "Unsupported access to non-builtin global");
+            }
+        }
+    }
+    logfmt("};\n\n");
+
+    logfmt("be_define_local_proto(%s, %d, %d, %d, %d, %d);\n",
+          func_name, pr->nstack, pr->argc, (pr->nconst > 0) ? 1 : 0, (pr->nproto > 0) ? 1 : 0, (pr->nupvals > 0) ? 1 : 0);
+}
+
+static void m_solidify_closure(bvm *vm, bclosure *cl, int builtins)
+{   
+    bproto *pr = cl->proto;
+    const char * func_name = str(pr->name);
+
+    if (cl->nupvals > 0) {
+        be_raise(vm, "internal_error", "Unsupported upvals in closure");
+    }
+
+    logfmt("\n");
+    logfmt("/********************************************************************\n");
+    logfmt("** Solidified function: %s\n", func_name);
+    logfmt("********************************************************************/\n");
+
+    m_solidify_proto(vm, pr, func_name, builtins);
+
+    // closure
+    logfmt("be_define_local_closure(%s);\n\n", func_name);
+
+    logfmt("/*******************************************************************/\n\n");
+}
+
+#define be_builtin_count(vm) \
+    be_vector_count(&(vm)->gbldesc.builtin.vlist)
+
+static int m_dump(bvm *vm)
+{
+    if (be_top(vm) >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        if (var_isclosure(v)) {
+            m_solidify_closure(vm, var_toobj(v), be_builtin_count(vm));
+        }
+    }
+    be_return_nil(vm);
+}
+
+#if !BE_USE_PRECOMPILED_OBJECT
+be_native_module_attr_table(solidify) {
+    be_native_module_function("dump", m_dump),
+};
+
+be_define_native_module(solidify, NULL);
+#else
+/* @const_object_info_begin
+module solidify (scope: global, depend: BE_USE_SOLIDIFY_MODULE) {
+    dump, func(m_dump)
+}
+@const_object_info_end */
+#include "../generate/be_fixed_solidify.h"
+#endif
+
+#endif /* BE_USE_SOLIFIDY_MODULE */

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -1066,6 +1066,9 @@ void be_dofunc(bvm *vm, bvalue *v, int argc)
 
 BERRY_API void be_set_obs_hook(bvm *vm, bobshook hook)
 {
+    (void)vm;       /* avoid comiler warning */
+    (void)hook;     /* avoid comiler warning */
+
 #if BE_USE_OBSERVABILITY_HOOK
     vm->obshook = hook;
 #endif

--- a/tools/coc/block_builder.cpp
+++ b/tools/coc/block_builder.cpp
@@ -27,6 +27,12 @@ block_builder::block_builder(const object_block *object, const macro_table *macr
     if (depend(object, macro)) {
         m_block.type = object->type;
         m_block.attr = object->attr;
+
+        auto it = object->attr.find("name");
+        if (it != object->attr.end()) {
+            m_strtab.push_back(it->second);
+        }
+        
         for (auto i : object->data) {
             if (i.second.depend.empty() || macro->query(i.second.depend)) {
                 m_block.data[i.first] = i.second.value;


### PR DESCRIPTION
Add module `solidify` to solidify Berry functions. This is a follow-up of #78 and has been field tested on Tasmota for weeks.

Example:
```
> import solidify
> def hello() print("Hello") end
> solidify.dump(f)

/********************************************************************
** Solidified function: hello
********************************************************************/

/********** Solidified proto: hello */
be_define_local_const_str(hello_str_name, "hello", 1335831723, 5);
be_define_local_const_str(hello_str_source, "stdin", -1529146723, 5);
be_define_local_const_str(hello_str_0, "Hello", -178507445, 5);

static const bvalue hello_ktab[1] = {
  { { .s=be_local_const_str(hello_str_0) }, BE_STRING},
};

static const uint32_t hello_code[4] = {
  0x6000000F,  //  0000  GETGBL	R0	G15
  0x58040000,  //  0001  LDCONST	R1	K0
  0x7C000200,  //  0002  CALL	R0	1
  0x80000000,  //  0003  RET	0	R0
};

be_define_local_proto(hello, 2, 0, 1, 0, 0);
be_define_local_closure(hello);

/*******************************************************************/
```

Example for a class definition:
```
/********************************************************************
 * Demo of solidified berry code in class
 *******************************************************************/
#include "be_constobj.h"

/********************************************************************
** Solidified function: hello
********************************************************************/

/********** Solidified proto: hello */
be_define_local_const_str(hello_str_name, "hello", 1335831723, 5);
be_define_local_const_str(hello_str_source, "stdin", -1529146723, 5);
be_define_local_const_str(hello_str_0, "Hello", -178507445, 5);

static const bvalue hello_ktab[1] = {
  { { .s=be_local_const_str(hello_str_0) }, BE_STRING},
};

static const uint32_t hello_code[4] = {
  0x6000000F,  //  0000  GETGBL	R0	G15
  0x58040000,  //  0001  LDCONST	R1	K0
  0x7C000200,  //  0002  CALL	R0	1
  0x80000000,  //  0003  RET	0	R0
};

be_define_local_proto(hello, 2, 0, 1, 0, 0);
be_define_local_closure(hello);

/*******************************************************************/

#if BE_USE_PRECOMPILED_OBJECT
#include "../generate/be_fixed_be_class_demo_class.h"
#endif

void be_load_demo_class(bvm *vm) {
#if !BE_USE_PRECOMPILED_OBJECT
    static const bnfuncinfo members[] = {
        { "x", NULL },
        /* variables and native functions */

        { NULL, (bntvfunc) BE_CLOSURE }, /* mark section for berry closures */
        { "hello", (bntvfunc) &hello_closure },
        
        { NULL, NULL }
    };
    be_regclass(vm, "demo_class", members);
#else
    be_pushntvclass(vm, &be_class_demo_class);
    be_setglobal(vm, "demo_class");
    be_pop(vm, 1);
#endif
}
/* @const_object_info_begin

class be_class_demo_class (scope: global, name: demo_class) {
    x, var

    hello, closure(hello_closure)
}
@const_object_info_end */
```

Including Berry solidified in pre-compiled module is not yet supported, I will need to double-check that it works.

Limitations:
- it work for any function, including sub-protos
- upvals are not supported
- access to global variables is not supported

In case of unsupported features, the solidification is stopped with an error; no invalid code is produced.