### PR TITLE
Add virtual methods and members, module global

### DIFF
--- a/default/be_modtab.c
+++ b/default/be_modtab.c
@@ -15,6 +15,7 @@ be_extern_native_module(json);
 be_extern_native_module(math);
 be_extern_native_module(time);
 be_extern_native_module(os);
+be_extern_native_module(global);
 be_extern_native_module(sys);
 be_extern_native_module(debug);
 be_extern_native_module(gc);
@@ -41,6 +42,9 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
 #endif
 #if BE_USE_OS_MODULE
     &be_native_module(os),
+#endif
+#if BE_USE_GLOBAL_MODULE
+    &be_native_module(global),
 #endif
 #if BE_USE_SYS_MODULE
     &be_native_module(sys),

--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -156,6 +156,7 @@
 #define BE_USE_MATH_MODULE              1
 #define BE_USE_TIME_MODULE              1
 #define BE_USE_OS_MODULE                1
+#define BE_USE_GLOBAL_MODULE            1
 #define BE_USE_SYS_MODULE               1
 #define BE_USE_DEBUG_MODULE             1
 #define BE_USE_GC_MODULE                1

--- a/src/be_globallib.c
+++ b/src/be_globallib.c
@@ -1,0 +1,86 @@
+/********************************************************************
+** Copyright (c) 2018-2021 Guan Wenliang & Stephan Hadinger
+** This file is part of the Berry default interpreter.
+** skiars@qq.com, https://github.com/Skiars/berry
+** See Copyright Notice in the LICENSE file or at
+** https://github.com/Skiars/berry/blob/master/LICENSE
+********************************************************************/
+#include "be_object.h"
+#include "be_module.h"
+#include "be_string.h"
+#include "be_vector.h"
+#include "be_class.h"
+#include "be_debug.h"
+#include "be_map.h"
+#include "be_vm.h"
+#include <string.h>
+
+#if BE_USE_GLOBAL_MODULE
+
+#define global(vm)      ((vm)->gbldesc.global)
+
+static void dump_map_keys(bvm *vm, bmap *map)
+{
+    if (!map) { return; }   /* protect agains potential null pointer */
+    bmapnode *node;
+    bmapiter iter = be_map_iter();
+    while ((node = be_map_next(map, &iter)) != NULL) {
+        if (var_isstr(&node->key)) {
+            bstring *s = var_tostr(&node->key);
+            be_pushstring(vm, str(s));
+            be_data_push(vm, -2);
+            be_pop(vm, 1);
+        }
+    }
+}
+
+static int m_globals(bvm *vm)
+{
+    be_newobject(vm, "list");
+    dump_map_keys(vm, global(vm).vtab);
+    be_pop(vm, 1);
+    be_return(vm);
+}
+
+static int m_findglobal(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1 && be_isstring(vm, 1)) {
+        const char * name = be_tostring(vm, 1);
+        be_getglobal(vm, name);
+        be_return(vm);
+    }
+    be_return_nil(vm);
+}
+
+static int m_setglobal(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 2 && be_isstring(vm, 1)) {
+        const char * name = be_tostring(vm, 1);
+        be_setglobal(vm, name);
+        be_return(vm);
+    }
+    be_return_nil(vm);
+}
+
+#if !BE_USE_PRECOMPILED_OBJECT
+be_native_module_attr_table(global) {
+    be_native_module_function("()", m_globals),
+    be_native_module_function("member", m_findglobal),
+    be_native_module_function("setmember", m_setglobal),
+};
+
+be_define_native_module(global, NULL);
+#else
+/* @const_object_info_begin
+module global (scope: global, depend: BE_USE_GLOBAL_MODULE) {
+    (), func(m_globals)
+    member, func(m_findglobal)
+    setmember, func(m_setglobal)
+}
+@const_object_info_end */
+#include "../generate/be_fixed_global.h"
+#endif
+
+#endif /* BE_USE_INTROSPECT_MODULE */

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -267,10 +267,26 @@ static void obj_method(bvm *vm, bvalue *o, bstring *attr, bvalue *dst)
     }
 }
 
-static int obj_attribute(bvm *vm, bvalue *o, bstring *attr, bvalue *dst)
+static int obj_attribute(bvm *vm, bvalue *o, bvalue *c, bvalue *dst)
 {
+    bvalue instance = *o; /* save instance to send it later to member */
+    bstring *attr = var_tostr(c);
     binstance *obj = var_toobj(o);
     int type = be_instance_member(vm, obj, attr, dst);
+    if (basetype(type) == BE_NIL) { /* if no method found, try virtual */
+        /* get method 'member' */
+        int type2 = be_instance_member(vm, obj, str_literal(vm, "member"), vm->top);
+        if (basetype(type2) == BE_FUNCTION) {
+            bvalue *top = vm->top;
+            top[1] = instance; /* move instance to argv[0] */
+            top[2] = *c; /* move method name to argv[1] */
+            vm->top += 3;   /* prevent collection results */
+            be_dofunc(vm, top, 2); /* call method 'member' */
+            vm->top -= 3;
+            *dst = *vm->top;   /* copy result to R(A) */
+            type = var_type(dst);
+        }
+    }
     if (basetype(type) == BE_NIL) {
         vm_error(vm, "attribute_error",
             "the '%s' object has no attribute '%s'",
@@ -723,7 +739,8 @@ newframe: /* a new call frame */
         opcase(GETMBR): {
             bvalue *a = RA(), *b = RKB(), *c = RKC();
             if (var_isinstance(b) && var_isstr(c)) {
-                obj_attribute(vm, b, var_tostr(c), a);
+                obj_attribute(vm, b, c, a);
+                reg = vm->reg;
             } else if (var_ismodule(b) && var_isstr(c)) {
                 bstring *attr = var_tostr(c);
                 bmodule *module = var_toobj(b);
@@ -731,9 +748,22 @@ newframe: /* a new call frame */
                 if (v) {
                     *a = *v;
                 } else {
-                    vm_error(vm, "attribute_error",
-                        "module '%s' has no attribute '%s'",
-                        be_module_name(module), str(attr));
+                    bvalue *member = be_module_attr(vm, module, str_literal(vm, "member"));
+                    var_setnil(a);
+                    if (member && var_basetype(member) == BE_FUNCTION) {
+                        bvalue *top = vm->top;
+                        top[0] = *member;
+                        top[1] = *c; /* move name to argv[0] */
+                        vm->top += 2;   /* prevent collection results */
+                        be_dofunc(vm, top, 1); /* call method 'method' */
+                        vm->top -= 2;
+                        *a = *vm->top;   /* copy result to R(A) */
+                    }
+                    if (var_basetype(a) == BE_NIL) {
+                        vm_error(vm, "attribute_error",
+                            "module '%s' has no attribute '%s'",
+                            be_module_name(module), str(attr));
+                    }
                 }
             } else {
                 attribute_error(vm, "attribute", b, c);
@@ -746,12 +776,10 @@ newframe: /* a new call frame */
                 bvalue self = *b;
                 bstring *attr = var_tostr(c);
                 binstance *obj = var_toobj(b);
-                int type = obj_attribute(vm, b, var_tostr(c), a);
-                if (type == MT_METHOD || type == MT_PRIMMETHOD) {
+                int type = obj_attribute(vm, b, c, a);
+                reg = vm->reg;
+                if (basetype(type) == BE_FUNCTION) {
                     a[1] = self;
-                } else if (var_basetype(a) == BE_FUNCTION) {
-                    a[1] = *a;
-                    var_settype(a, NOT_METHOD);
                 } else {
                     vm_error(vm, "attribute_error",
                         "class '%s' has no method '%s'",
@@ -765,9 +793,23 @@ newframe: /* a new call frame */
                     var_settype(a, NOT_METHOD);
                     a[1] = *src;
                 } else {
-                    vm_error(vm, "attribute_error",
-                        "module '%s' has no method '%s'",
-                        be_module_name(module), str(attr));
+                    bvalue *member = be_module_attr(vm, module, str_literal(vm, "member"));
+                    var_setnil(a);
+                    if (member && var_basetype(member) == BE_FUNCTION) {
+                        bvalue *top = vm->top;
+                        top[0] = *member;
+                        top[1] = *c; /* move name to argv[0] */
+                        vm->top += 2;   /* prevent collection results */
+                        be_dofunc(vm, top, 1); /* call method 'method' */
+                        vm->top -= 2;
+                        var_settype(a, NOT_METHOD);
+                        a[1] = *vm->top;   /* copy result to R(A) */
+                    }
+                    if (var_basetype(a) == BE_NIL) {
+                        vm_error(vm, "attribute_error",
+                            "module '%s' has no method '%s'",
+                            be_module_name(module), str(attr));
+                    }
                 }
             } else {
                 attribute_error(vm, "method", b, c);
@@ -793,6 +835,18 @@ newframe: /* a new call frame */
                 bvalue *v = be_module_bind(vm, obj, attr);
                 if (v != NULL) {
                     *v = tmp;
+                    dispatch();
+                }
+                /* if it failed, try 'setmeemner' */
+                bvalue *member = be_module_attr(vm, obj, str_literal(vm, "setmember"));
+                if (member && var_basetype(member) == BE_FUNCTION) {
+                    bvalue *top = vm->top;
+                    top[0] = *member;
+                    top[1] = *b; /* move name to argv[0] */
+                    top[2] = tmp; /* move value to argv[1] */
+                    vm->top += 3;   /* prevent collection results */
+                    be_dofunc(vm, top, 2); /* call method 'setmember' */
+                    vm->top -= 3;
                     dispatch();
                 }
             }
@@ -974,6 +1028,17 @@ newframe: /* a new call frame */
                 push_native(vm, var, argc, mode);
                 f(vm); /* call C primitive function */
                 ret_native(vm);
+                break;
+            }
+            case BE_MODULE: {
+                bmodule *f = var_toobj(var);
+                bvalue *member = be_module_attr(vm, f, str_literal(vm, "()"));
+                if (member && var_basetype(member) == BE_FUNCTION) {
+                    *var = *member;
+                    goto recall; /* call '()' method */
+                } else {
+                    call_error(vm, var);
+                }
                 break;
             }
             default:

--- a/tests/global.be
+++ b/tests/global.be
@@ -1,0 +1,52 @@
+#- test module global -#
+
+def assert_syntax_error(code)
+    try
+        f = compile(code)
+        assert(false, 'unexpected execution flow')
+    except .. as e, m
+        assert(e == 'syntax_error')
+    end
+end
+def assert_attribute_error(f)
+    try
+        f()
+        assert(false, 'unexpected execution flow')
+    except .. as e, m
+        assert(e == 'attribute_error')
+    end
+end
+def findinlist(l, e)
+    var i
+    for i: 0..size(l)-1
+        if l[i] == e return i end
+    end
+    return nil
+end
+
+#- set the scene -#
+global_a = 1
+global_b = "bb"
+assert(global_a == 1)
+assert(global_b == "bb")
+
+assert_syntax_error("c") #- compilation fails because c does not exist -#
+
+import global
+
+assert(global.global_a == 1)
+assert(global.global_b == "bb")
+
+global.global_c = 3
+#- now compilation against 'c' global -#
+f = compile("return global_c")
+assert(f() == 3)
+
+#- check that access to non-existent global returns an exception -#
+assert_attribute_error(/-> global.d)
+
+#- check the glbal list -#
+assert(findinlist(global(), 'global_a') != nil)
+assert(findinlist(global(), 'global_b') != nil)
+assert(findinlist(global(), 'global_c') != nil)
+assert(findinlist(global(), 'global_d') == nil)

--- a/tests/virtual_methods.be
+++ b/tests/virtual_methods.be
@@ -1,0 +1,66 @@
+#- basic initialization -#
+
+def assert_attribute_error(f)
+    try
+        f()
+        assert(false, 'unexpected execution flow')
+    except .. as e, m
+        assert(e == 'attribute_error')
+    end
+end
+
+class T1
+    var a, b
+    def init()
+        self.a = 1
+        self.b = 2
+    end
+    def f() return true end
+    def g() return false end
+end
+t = T1()
+
+#- warm up -#
+assert(t.a == 1)
+assert(t.b == 2)
+assert(t.f() == true)
+assert(t.g() == false)
+
+#- test normal errors when method does not exist -#
+assert_attribute_error(/-> t.h())
+assert_attribute_error(/-> t.c)
+
+class T2 : T1
+    def member(n)
+        if (n == 'f1') return / n -> n end
+        if (n == 'f2') return /-> 4 end
+        if (n == 'a1') return 10 end
+    end
+end
+t2 = T2()
+
+#- test non-regression -#
+assert(t2.a == 1)
+assert(t2.b == 2)
+assert(t2.f() == true)
+assert(t2.g() == false)
+assert_attribute_error(/-> t2.h())
+
+#- try virtual methods -#
+assert(t2.f1() == t2)
+assert(t2.f2() == 4)
+assert(t2.a1 == 10)
+
+#- module -#
+m = module("m")
+
+m.a = 1
+assert(m.a == 1)
+assert_attribute_error(/-> m.b)
+
+m.member = def(n)
+    if n == "b" return 2 end
+end
+
+assert(m.b == 2)
+assert_attribute_error(/-> m.c)

--- a/tests/virtual_methods2.be
+++ b/tests/virtual_methods2.be
@@ -1,0 +1,28 @@
+#- virtual attributes -#
+class Ta
+    var a, b, virtual_c
+    def init()
+        self.a = 1
+        self.b = 2
+        self.virtual_c = 3
+    end
+    def member(n)
+        if n == 'c' return self.virtual_c end
+        return nil
+    end
+    def setmember(n, v)
+        if n == 'c' self.virtual_c = v return true end
+        return false
+    end
+end
+ta = Ta()
+
+assert(ta.a == 1)
+assert(ta.b == 2)
+assert(ta.c == 3)
+ta.a = 10
+assert(ta.a == 10)
+assert(ta.c == 3)
+ta.c = 30
+assert(ta.c == 30)
+assert(ta.virtual_c == 30)


### PR DESCRIPTION
# Add virtual members and methods

This feature is inspired from Python's `__getattr__()` / `__setattr__()` and allows to create dynamic virtual members and methods, to class instances and to modules.

The motivation comes from LVGL integration to Berry in Tasmota. The integration needs hundreds of constants in a module and thousands of methods mapped to C functions. Statically creation of attributes and methods does work but consumes a significant amount of code space.

@Skiars this has been thoroughly tested in Tasmota and looks very stable. Yet I would appreciate a code review from your side.


This proposed features allows to create two methods: `member(name:string) -> any` and `setmember(name:string, value:any) -> nil`

Example:

```python
class T
    var a
    def init()
        self.a = 'a'
    end

    def member(name)
        return "member "+name
    end

    def setmember(name, value)
        print("Set '"+name+"': "+str(value))
    end
end
t=T()
```

Now let's try it:
```python
> t.a
'a'
> t.b
'member b'
> t.foo
'member foo'
> t.bar = 2
Set 'bar': 2
```

This works for modules too:
```
m = module()
m.a = 1
m.member = def (name)
    return "member "+name
end
m.setmember(name, value)
    print("Set '"+name+"': "+str(value))
end
```

Trying:
```
> m.a
1
> m.b
'member b'
> m.c = 3   # the allocation is valid so `setmember()` is not called
> m.c
3
```

Precedence:
- when reading a method/member, the actual member is returned; `member(name)` is called only if the native attribute does not exist.
- when writing a method/member, the native attribute is written if valid, or the native attribute is created if the module is writable. Only if writing fails, `setmember(name, value)` is called. Hence `setmember` is only called for non-writable modules.

## module `global`

As a direct example, I'm proposing a new optional module `global` that allows dynamic access to global variables. This allows to work-around compilations errors while compiling code that uses a global that does not exist yet (for example if compile is called to create globals).

Example:

```python
> import global
> a = 1
> global.a
1
>
> b
syntax_error: stdin:1: 'b' undeclared (first use in this function)
> global.b = 2
> b
2
```

Additionally I allowed modules to be callable if they implement the `()` member.

```python
> import global
> a = 1
> global.b = 2
> global()
['_argv', 'b', 'global', 'a']
```