### PR TITLE
Fix compiler bug for index #101

### DIFF
--- a/src/be_code.c
+++ b/src/be_code.c
@@ -317,7 +317,7 @@ static void free_suffix(bfuncinfo *finfo, bexpdesc *e)
         be_code_freeregs(finfo, 1);
     }
     /* release object register */
-    if (e->v.ss.tt == ETREG && (int)e->v.ss.obj >= nlocal) {
+    if (e->v.ss.tt == ETREG && (int)e->v.ss.obj >= nlocal && (e->v.ss.obj + 1 >= finfo->freereg)) {
         be_code_freeregs(finfo, 1);
     }
 }

--- a/tests/suffix.be
+++ b/tests/suffix.be
@@ -9,3 +9,20 @@ var pairs = {
 for i : 0 .. keys.size() - 1
     assert(pairs[keys[i]] == 'value' .. i + 1)
 end
+
+#- test cases related to #101 -#
+class C var l end
+c=C()
+c.l=[0,1,2]
+
+def t_101_nok_1() return c.l[0..1] end
+def t_101_ok_1() var l2 = c.l return l2[0..1] end
+
+t_i = 0
+def t_101_nok_2() return c.l[t_i] end
+def t_101_ok_2() return c.l[0] end
+
+assert(t_101_nok_1() == [0, 1])
+assert(t_101_ok_1() == [0, 1])
+assert(t_101_nok_2() == 0)
+assert(t_101_ok_2() == 0)


### PR DESCRIPTION
This changes prevents from erroneously freeing a register that is not at the top.

See #101