### PR TITLE
Fix closure issue #105

### DIFF
--- a/tests/closure.be
+++ b/tests/closure.be
@@ -1,0 +1,13 @@
+#- test for issue #105 -#
+
+l=[]
+def tick()
+  var start=100
+  for i : 1..3
+    l.push(def () return [i, start] end)
+  end
+end
+tick()
+assert(l[0]() == [1, 100])
+assert(l[1]() == [2, 100])
+assert(l[2]() == [3, 100])


### PR DESCRIPTION
See comments in #105.

This new version of `be_upvals_close()` does a complete traversal of the `vm->upvalist` to close items, instead of stopping at the first item below `level`.

The traversal only touches open upvals, so performance impact of full traversal is negligible.

Unit test added.