### PR TITLE
Improve inheritance when using `super()`

### DIFF
--- a/src/be_class.c
+++ b/src/be_class.c
@@ -165,6 +165,7 @@ static binstance* newobjself(bvm *vm, bclass *c)
         while (v < end) { var_setnil(v); ++v; }
         obj->_class = c;
         obj->super = NULL;
+        obj->sub = NULL;
     }
     return obj;
 }
@@ -178,6 +179,7 @@ static binstance* newobject(bvm *vm, bclass *c)
     be_incrtop(vm); /* protect new objects from GC */
     for (c = c->super; c; c = c->super) {
         prev->super = newobjself(vm, c);
+        prev->super->sub = prev;
         prev = prev->super;
     }
     be_stackpop(vm, 1);

--- a/src/be_class.h
+++ b/src/be_class.h
@@ -18,11 +18,13 @@
 #define be_class_members(cl)            ((cl)->members)
 #define be_class_super(cl)              ((cl)->super)
 #define be_class_setsuper(self, sup)    ((self)->super = (sup))
+#define be_class_setsub(self, sub)      ((self)->sub = (sub))
 #define be_instance_name(obj)           ((obj)->_class->name)
 #define be_instance_class(obj)          ((obj)->_class)
 #define be_instance_members(obj)        ((obj)->members)
 #define be_instance_member_count(obj)   ((obj)->_class->nvar)
 #define be_instance_super(obj)          ((obj)->super)
+#define be_instance_sub(obj)            ((obj)->sub)
 
 struct bclass {
     bcommon_header;
@@ -41,6 +43,7 @@ struct bclass {
 struct binstance {
     bcommon_header;
     struct binstance *super;
+    struct binstance *sub;
     bclass *_class;
     bgcobject *gray; /* for gc gray list */
     bvalue members[1]; /* members variable data field */

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -779,6 +779,11 @@ newframe: /* a new call frame */
                 int type = obj_attribute(vm, b, c, a);
                 reg = vm->reg;
                 if (basetype(type) == BE_FUNCTION) {
+                    /* check if the object is a superinstance, if so get the lowest possible subclass */
+                    while (obj->sub) {
+                        obj = obj->sub;
+                    }
+                    var_setobj(&self, var_type(&self), obj);  /* replace superinstance by lowest subinstance */
                     a[1] = self;
                 } else {
                     vm_error(vm, "attribute_error",


### PR DESCRIPTION
When calling a method of a parent object, the reference to the parent object is sent instead of the real object (non-parent), hence preventing overriden methods to be called. This makes inheritance much less interesting.

Example:

```
class A    var a def init() self.r() end                         def r() self.a = 1 end end
class B:A  var b def init() super(self).init() end               def r() self.b = 3 end end
b=B()
print("b.a", b.a, "b.d", b.b)
```

returns:
```
b.a 1 b.d nil
```

The problem is the `init()` of `class B` calls `init()` of superclass `A` that calls `self.r()`. The problem here is that since the object is the parent of `b`, only method from `class A` is called instead of the overriden method in `class B`.

I thought a lot about how to solve this, and I didn't want to introduce a new method. The changes are finally very light:
- add a field `sub` to `binstance`, in addition to `super` to indicate if the instance has a sub-object of a sub-class
- when processing `GETMET` opcode, change the current `self` to the lowest sub-object possible, in order to get all possible fields and overridden methods.

I also added test cases.
