### PR TITLE
Add option to `super()` to specify class

### DIFF
--- a/tests/super_leveled.be
+++ b/tests/super_leveled.be
@@ -1,0 +1,44 @@
+#- test for leveled use of super() -#
+
+#- setup -#
+class A   def r() return 'a' end def f() return self.r() end end
+class B:A def r() return 'b' end def f() return super(self,A).f() + 'b' end end
+class C:B def r() return 'c' end def f() return super(self,B).f() + 'c' end end
+a=A()
+b=B()
+c=C()
+
+#- regular behavior -#
+assert(classname(a) == 'A')
+assert(classname(b) == 'B')
+assert(classname(c) == 'C')
+assert(a.r() == 'a')
+assert(b.r() == 'b')
+assert(c.r() == 'c')
+assert(a.f() == 'a')
+
+#- standard use of super() -#
+assert(super(a) == nil)
+assert(super(A) == nil)
+assert(classname(super(B)) == 'A')
+assert(classname(super(C)) == 'B')
+assert(classname(super(super(C))) == 'A')
+assert(super(super(super(C))) == nil)
+
+#- super() levele -#
+assert(super(a,A) == a)
+assert(classname(super(a,A)) == 'A')
+assert(classname(super(b,B)) == 'B')
+assert(classname(super(c,C)) == 'C')
+assert(classname(super(c,B)) == 'B')
+assert(classname(super(c,A)) == 'A')
+assert(super(c,map) == nil) #- not a parent class -#
+
+#- wrapping it all -#
+assert(a.f() == 'a')
+assert(b.f() == 'bb')
+
+#- the last one is tricky:
+   c.f() -> calls f() in class B -> calls f() in class A -> calls r() of overall class hence C
+-#
+assert(c.f() == 'cbc')


### PR DESCRIPTION
Follow-up of #107.

With the change in #107, it is now unfortunately not possible to call a method from a superclass if the calling class is itself a parent class.

Ex:
```
class A   def init() print("a") end end
class B:A def init() super(self).init() end end
class C:B def init() super(self).init() end end
c=C()  # crash because of infinite loop
```

Explanation:
- calling C:init() on instance<C>
- in C:init() self is instance<C>, calls super(instance<C>) = instance\<B>, so it calls B:init()
- in B:init() self is instance<C> (#107), calls super(instance<C>) = instance\<B>, so it calls B:init()
- infinite loop

This PR adds an option in `super()` to explicitly select the parent class whom method we want.

Now the example looks like:
 ```
> class A   def init() print("a") end end
> class B:A def init() super(self, A).init() end end
> class C:B def init() super(self, B).init() end end
> c=C()  # no crash
a
>
```

Explanation:
- calling C:init() on instance<C>
- in C:init() self is instance<C>, calls super(instance<C>, B) = instance\<B>, so it calls B:init()
- in B:init() self is instance<C> (#107), calls super(instance<C>, A) = instance\<A>, so it calls A:init()
- in A:init() self is instance<C>, print and return

#### `super(instance | class) -> instance or class or nil`
#### `super(instance, class) -> instance or nil`

When called with a single argument, `super()` is unchanged and returns the parent class or an instance of the parent class.

When called with 2 parameters, search in the parent chain for an instance of class `class` or `nil` if the class is not a parent class of the instance:

Example:
```
> class A   def init() print("a") end end
> class B:A def init() super(self, A).init() end end
> class C:B def init() super(self, B).init() end end
> c=C()  # no crash
a
> super(c)
<instance: B()>
> super(c, B)
<instance: B()>
> super(c, A)
<instance: A()>
```
