### PR TITLE
Provide a more compact solidified representation

### DIFF
--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -122,7 +122,7 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
     logfmt("%*s( &(const binstruction[%2d]) {  /* code */\n", indent, "", pr->codesize);
     for (int pc = 0; pc < pr->codesize; pc++) {
         uint32_t ins = pr->code[pc];
-        logfmt("%*s  0x%04X,  //", indent, "", ins);
+        logfmt("%*s  0x%08X,  //", indent, "", ins);
         be_print_inst(ins, pc);
         bopcode op = IGET_OP(ins);
         if (op == OP_GETGBL || op == OP_SETGBL) {

--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -45,63 +45,44 @@ static const char * m_type_ktab(int type)
     }
 }
 
-static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int builtins)
+static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int builtins, int indent)
 {
     // const char * func_name = str(pr->name);
     const char * func_source = str(pr->source);
 
+    logfmt("%*sbe_nested_proto(\n", indent, "");
+    indent += 2;
+
+    logfmt("%*s%d,                          /* nstack */\n", indent, "", pr->nstack);
+    logfmt("%*s%d,                          /* argc */\n", indent, "", pr->argc);
+    logfmt("%*s%d,                          /* has upvals */\n", indent, "", (pr->nupvals > 0) ? 1 : 0);
+
+    if (pr->nupvals > 0) {
+        logfmt("%*s( &(const bupvaldesc[%2d]) {  /* upvals */\n", indent, "", pr->nupvals);
+        for (int32_t i = 0; i < pr->nupvals; i++) {
+            logfmt("%*s  be_local_const_upval(%i, %i),\n", indent, "", pr->upvals[i].instack, pr->upvals[i].idx);
+        }
+        logfmt("%*s}),\n", indent, "");
+    } else {
+        logfmt("%*sNULL,                       /* no upvals */\n", indent, "");
+    }
+
+    logfmt("%*s%d,                          /* has sup protos */\n", indent, "", (pr->nproto > 0) ? 1 : 0);
     if (pr->nproto > 0) {
         for (int32_t i = 0; i < pr->nproto; i++) {
             size_t sub_len = strlen(func_name) + 10;
             char sub_name[sub_len];
             snprintf(sub_name, sizeof(sub_name), "%s_%d", func_name, i);
-            m_solidify_proto(vm, pr->ptab[i], sub_name, builtins);
+            m_solidify_proto(vm, pr->ptab[i], sub_name, builtins, indent);
+            logfmt(",\n");
         }
+    } else {
+        logfmt("%*sNULL,                       /* no sub protos */\n", indent, "");
     }
 
-    logfmt("\n/********** Solidified proto: %s */\n", func_name);
-
-    if (pr->nproto > 0) {
-        logfmt("static const bproto *%s_subproto[%i] = {\n", func_name, pr->nproto);
-        for (int32_t i = 0; i < pr->nproto; i++) {
-            logfmt("  &%s_%d_proto,\n", func_name, i);
-            // logfmt("  be_local_const_upval(%i, %i),\n", pr->upvals[i].instack, pr->upvals[i].idx); TODO
-        }
-        logfmt("};\n\n");
-    }
-
-    if (pr->nupvals > 0) {
-        logfmt("static const bupvaldesc %s_upvals[%i] = {\n", func_name, pr->nupvals);
-        for (int32_t i = 0; i < pr->nupvals; i++) {
-            logfmt("  be_local_const_upval(%i, %i),\n", pr->upvals[i].instack, pr->upvals[i].idx);
-            // logfmt("// upval[%d] = { .instack = %i, .idx = %i }\n", i, pr->upvals[i].instack, pr->upvals[i].idx);
-        }
-        logfmt("};\n\n");
-    }
-
-    /* create static strings for name and source */
-    logfmt("be_define_local_const_str(%s_str_name, \"%s\", %i, %u);\n",
-            func_name, str(pr->name), be_strhash(pr->name), str_len(pr->name));
-    logfmt("be_define_local_const_str(%s_str_source, \"%s\", %i, %u);\n",
-            func_name, func_source, be_strhash(pr->source), str_len(pr->source));
-    
-    /* create static strings first */
-    for (int i = 0; i < pr->nconst; i++) {
-        if (pr->ktab[i].type == BE_STRING) {
-            logfmt("be_define_local_const_str(%s_str_%i, \"",
-                    func_name, i);
-            be_writestring(str(pr->ktab[i].v.s));
-            size_t len = strlen(str(pr->ktab[i].v.s));
-            if (len >= 255) {
-                be_raise(vm, "internal_error", "Strings greater than 255 chars not supported yet");
-            }
-            logfmt("\", %i, %zu);\n", be_strhash(pr->ktab[i].v.s), len >= 255 ? 255 : len);
-        }
-    }
-    logfmt("\n");
-
+    logfmt("%*s%d,                          /* has constants */\n", indent, "", (pr->nconst > 0) ? 1 : 0);
     if (pr->nconst > 0) {
-        logfmt("static const bvalue %s_ktab[%i] = {\n", func_name, pr->nconst);
+        logfmt("%*s( &(const bvalue[%2d]) {     /* upvals */\n", indent, "", pr->nconst);
         for (int k = 0; k < pr->nconst; k++) {
             int type = pr->ktab[k].type;
             const char *type_name = m_type_ktab(type);
@@ -111,26 +92,37 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
                 be_raise(vm, "internal_error", error);
             }
             if (type == BE_STRING) {
-                logfmt("  { { .s=be_local_const_str(%s_str_%i) }, %s},\n", func_name, k, type_name);
+                logfmt("%*s  { { .s=be_nested_const_str(\"", indent, "");
+                be_writestring(str(pr->ktab[k].v.s));
+                size_t len = strlen(str(pr->ktab[k].v.s));
+                if (len >= 255) {
+                    be_raise(vm, "internal_error", "Strings greater than 255 chars not supported yet");
+                }
+                logfmt("\", %i, %zu) }, %s},\n", be_strhash(pr->ktab[k].v.s), len >= 255 ? 255 : len, type_name);
             } else if (type == BE_INT) {
-                logfmt("  { { .i=%" BE_INT_FMTLEN "i }, %s},\n", pr->ktab[k].v.i, type_name);
+                logfmt("%*s  { { .i=%" BE_INT_FMTLEN "i }, %s},\n", indent, "", pr->ktab[k].v.i, type_name);
             } else if (type == BE_REAL) {
     #if BE_USE_SINGLE_FLOAT
-                logfmt("  { { .p=(void*)0x%08X }, %s},\n", (uint32_t) pr->ktab[k].v.p, type_name);
+                logfmt("%*s  { { .p=(void*)0x%08X }, %s},\n", indent, "", (uint32_t) pr->ktab[k].v.p, type_name);
     #else
-                logfmt("  { { .p=(void*)0x%016llX }, %s},\n", (uint64_t) pr->ktab[k].v.p, type_name);
+                logfmt("%*s  { { .p=(void*)0x%016llX }, %s},\n", indent, "", (uint64_t) pr->ktab[k].v.p, type_name);
     #endif
             } else if (type == BE_BOOL) {
-                logfmt("  { { .b=%i }, %s},\n", pr->ktab[k].v.b, type_name);
+                logfmt("%*s  { { .b=%i }, %s},\n", indent, "", pr->ktab[k].v.b, type_name);
             }
         }
-        logfmt("};\n\n");
+        logfmt("%*s}),\n", indent, "");
+    } else {
+        logfmt("%*sNULL,                       /* no const */\n", indent, "");
     }
 
-    logfmt("static const uint32_t %s_code[%i] = {\n", func_name, pr->codesize);
+    logfmt("%*s(be_nested_const_str(\"%s\", %i, %i)),\n", indent, "", str(pr->name), be_strhash(pr->name), str_len(pr->name));
+    logfmt("%*s(be_nested_const_str(\"%s\", %i, %i)),\n", indent, "", func_source, be_strhash(pr->source), str_len(pr->source));
+
+    logfmt("%*s( &(const binstruction[%2d]) {  /* code */\n", indent, "", pr->codesize);
     for (int pc = 0; pc < pr->codesize; pc++) {
         uint32_t ins = pr->code[pc];
-        logfmt("  0x%04X,  //", ins);
+        logfmt("%*s  0x%04X,  //", indent, "", ins);
         be_print_inst(ins, pc);
         bopcode op = IGET_OP(ins);
         if (op == OP_GETGBL || op == OP_SETGBL) {
@@ -143,10 +135,10 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
             }
         }
     }
-    logfmt("};\n\n");
+    logfmt("%*s})\n", indent, "");
+    indent -= 2;
+    logfmt("%*s)", indent, "");
 
-    logfmt("be_define_local_proto(%s, %d, %d, %d, %d, %d);\n",
-          func_name, pr->nstack, pr->argc, (pr->nconst > 0) ? 1 : 0, (pr->nproto > 0) ? 1 : 0, (pr->nupvals > 0) ? 1 : 0);
 }
 
 static void m_solidify_closure(bvm *vm, bclosure *cl, int builtins)
@@ -163,11 +155,14 @@ static void m_solidify_closure(bvm *vm, bclosure *cl, int builtins)
     logfmt("** Solidified function: %s\n", func_name);
     logfmt("********************************************************************/\n");
 
-    m_solidify_proto(vm, pr, func_name, builtins);
+    int indent = 2;
+    logfmt("be_local_closure(%s,   /* name */\n", func_name);
+
+    m_solidify_proto(vm, pr, func_name, builtins, indent);
+    logfmt("\n");
 
     // closure
-    logfmt("be_define_local_closure(%s);\n\n", func_name);
-
+    logfmt(");\n");
     logfmt("/*******************************************************************/\n\n");
 }
 

--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -82,7 +82,7 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
 
     logfmt("%*s%d,                          /* has constants */\n", indent, "", (pr->nconst > 0) ? 1 : 0);
     if (pr->nconst > 0) {
-        logfmt("%*s( &(const bvalue[%2d]) {     /* upvals */\n", indent, "", pr->nconst);
+        logfmt("%*s( &(const bvalue[%2d]) {     /* constants */\n", indent, "", pr->nconst);
         for (int k = 0; k < pr->nconst; k++) {
             int type = pr->ktab[k].type;
             const char *type_name = m_type_ktab(type);

--- a/src/berry.h
+++ b/src/berry.h
@@ -263,6 +263,18 @@ typedef struct bntvmodule {
         .s = _s                                           \
     }
 
+/* new version for more compact literals */
+#define be_nested_const_str(_s, _hash, _len)  \
+    (bstring*) &(const bcstring) {            \
+        .next = (bgcobject *)NULL,            \
+        .type = BE_STRING,                    \
+        .marked = GC_CONST,                   \
+        .extra = 0,                           \
+        .slen = _len,                         \
+        .hash = 0,                            \
+        .s = _s                               \
+    }
+
 #define be_local_const_str(_name) (bstring*) &be_local_const_str_##_name
 
 /* conditional macro see  https://stackoverflow.com/questions/11632219/c-preprocessor-macro-specialisation-based-on-an-argument */
@@ -316,6 +328,30 @@ typedef struct bntvmodule {
     PROTO_VAR_INFO_BLOCK                                                          \
   }
 
+/* new version for more compact literals */
+#define be_nested_proto(_nstack, _argc, _has_upval, _upvals, _has_subproto, _protos, _has_const, _ktab, _fname, _source, _code)     \
+  & (const bproto) {                                                              \
+    NULL,                       /* bgcobject *next */                             \
+    BE_PROTO,                   /* type BE_PROTO */                               \
+    0x08,                       /* marked outside of GC */                        \
+    (_nstack),                  /* nstack */                                      \
+    BE_IIF(_has_upval)(sizeof(*_upvals)/sizeof(bupvaldesc),0),  /* nupvals */     \
+    (_argc),                    /* argc */                                        \
+    0,                          /* varg */                                        \
+    NULL,                       /* bgcobject *gray */                             \
+    (bupvaldesc*) _upvals,      /* bupvaldesc *upvals */                          \
+    (bvalue*) _ktab,            /* ktab */                                        \
+    (struct bproto**) _protos,  /* bproto **ptab */                               \
+    (binstruction*) _code,      /* code */                                        \
+    _fname,                     /* name */                                        \
+    sizeof(*_code)/sizeof(binstruction),                        /* codesize */    \
+    BE_IIF(_has_const)(sizeof(*_ktab)/sizeof(bvalue),0),        /* nconst */      \
+    BE_IIF(_has_subproto)(sizeof(*_protos)/sizeof(bproto*),0),  /* proto */       \
+    _source,                    /* source */                                      \
+    PROTO_RUNTIME_BLOCK                                                           \
+    PROTO_VAR_INFO_BLOCK                                                          \
+  }
+
 #define be_define_local_closure(_name)        \
   const bclosure _name##_closure = {          \
     NULL,           /* bgcobject *next */     \
@@ -327,6 +363,17 @@ typedef struct bntvmodule {
     { NULL }        /* upvals */              \
   }
 
+/* new version for more compact literals */
+#define be_local_closure(_name, _proto)       \
+  const bclosure _name##_closure = {          \
+    NULL,           /* bgcobject *next */     \
+    BE_CLOSURE,     /* type BE_CLOSURE */     \
+    GC_CONST,       /* marked GC_CONST */     \
+    0,              /* nupvals */             \
+    NULL,           /* bgcobject *gray */     \
+    (bproto*) _proto, /* proto */             \
+    { NULL }        /* upvals */              \
+  }
 
 /* debug hook typedefs */
 #define BE_HOOK_LINE    1


### PR DESCRIPTION
I reworked the module `solidify` to have a more compact representation as a single structure with implicit anonymous sub-structrures.

Previous representation still work.

Example:
```
> def f(x) print("a",3.4,x) end
> import solidify
> solidify.dump(f)

/********************************************************************
** Solidified function: f
********************************************************************/
be_local_closure(f,   /* name */
  be_nested_proto(
    5,                          /* nstack */
    1,                          /* argc */
    0,                          /* has upvals */
    NULL,                       /* no upvals */
    0,                          /* has sup protos */
    NULL,                       /* no sub protos */
    1,                          /* has constants */
    ( &(const bvalue[ 2]) {     /* upvals */
      { { .s=be_nested_const_str("a", -468965076, 1) }, BE_STRING},
      { { .p=(void*)0x400B333333333333 }, BE_REAL},
    }),
    (be_nested_const_str("f", -485742695, 1)),
    (be_nested_const_str("stdin", -1529146723, 5)),
    ( &(const binstruction[ 6]) {  /* code */
      0x6004000F,  //  0000  GETGBL	R1	G15
      0x58080000,  //  0001  LDCONST	R2	K0
      0x580C0001,  //  0002  LDCONST	R3	K1
      0x5C100000,  //  0003  MOVE	R4	R0
      0x7C040600,  //  0004  CALL	R1	3
      0x80000000,  //  0005  RET	0	R0
    })
  )
);
/*******************************************************************/
```