### PR TITLE
Fix wrongly GCed string in exception

### DIFF
--- a/src/be_lexer.c
+++ b/src/be_lexer.c
@@ -572,7 +572,6 @@ void be_lexer_deinit(blexer *lexer)
 {
     be_free(lexer->vm, lexer->buf.s, lexer->buf.size);
     keyword_unregiste(lexer->vm);
-    be_stackpop(lexer->vm, 1); /* pop strtab */
 }
 
 int be_lexer_scan_next(blexer *lexer)

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -1520,7 +1520,7 @@ bclosure* be_parser_source(bvm *vm,
     mainfunc(&parser, cl);
     be_lexer_deinit(&parser.lexer);
     be_global_release_space(vm); /* clear global space */
-    be_stackpop(vm, 1);
+    be_stackpop(vm, 2); /* pop strtab */
     scan_next_token(&parser); /* clear lexer */
     return cl;
 }

--- a/tests/lexergc.be
+++ b/tests/lexergc.be
@@ -1,0 +1,12 @@
+#- check the gc bug fixed in #110 -#
+#- Berry must be compiled with `#define BE_USE_DEBUG_GC 1` -#
+#- for the initial bug to happen -#
+
+code = "()"  #- this code triggers a lexer exception -#
+
+try
+    compile(code)
+    assert(false)   #- this should never be reached -#
+except .. as e, m
+    assert(m == "string:1: unexpected symbol near ')'")
+end


### PR DESCRIPTION
I found a last (hopefully) bug in GC that would wrongly free a string that is still used.

When encountering a lexer error, the flow goes:
```
void be_lexerror(blexer *lexer, const char *msg)
{
    bvm *vm = lexer->vm;
    const char *error = be_pushfstring(vm,
        "%s:%d: %s", lexer->fname, lexer->linenumber, msg);
    be_lexer_deinit(lexer);
    be_raise(vm, "syntax_error", error);
}

[...]

void be_lexer_deinit(blexer *lexer)
{
    be_free(lexer->vm, lexer->buf.s, lexer->buf.size);
    keyword_unregiste(lexer->vm);
    be_stackpop(lexer->vm, 1); /* pop strtab */
}
```
So the `error` string is pushed on the stack. But `be_lexer_deinit()` actually pops it out of the stack (not sure why) which makes it GCable when it is used in `be_raise()` - which happens if GC debug mode is on.

I removed the stack pop from `be_lexer_deinit()` and moved it to `be_parser_source()` where it belongs.

Fixes #94