### PR TITLE
Static initializer for class members

### DIFF
--- a/tests/class_const.be
+++ b/tests/class_const.be
@@ -67,3 +67,27 @@ assert(type(a.h) == 'function')
 assert_attribute_error("a.g(1,2)")
 assert(a.h(1) == 'instance')
 # A.h(1) - error
+
+#- test static initializers -#
+class A
+    static a = 1, b, c = 3.5, d = 42, e = "foo", f = [1], g = {}
+    var aa,ab
+end
+
+assert(A.a == 1)
+assert(A.b == nil)
+assert(A.c == 3.5)
+assert(A.d == 42)
+assert(A.e == "foo")
+assert(A.f == [1])
+
+a = A()
+assert(a.a == 1)
+assert(a.b == nil)
+assert(a.c == 3.5)
+assert(a.d == 42)
+assert(a.e == "foo")
+assert(a.f == [1])
+assert(a.g == A.g)
+assert(a.aa == nil)
+assert(a.ab == nil)

--- a/tools/grammar/berry.ebnf
+++ b/tools/grammar/berry.ebnf
@@ -17,7 +17,7 @@ func_body = '(' [arg_field {',' arg_field}] ')' block 'end';
 arg_field = ['*'] ID;
 (* class define statement *)
 class_stmt = 'class' ID [':' ID] class_block 'end';
-class_block = {'var' ID {',' ID} | 'static' ID {',' ID} | func_stmt};
+class_block = {'var' ID {',' ID} | 'static' ID ['=' expr] {',' ID ['=' expr] } | func_stmt};
 import_stmt = 'import' (ID (['as' ID] | {',' ID}) | STRING 'as' ID);
 (* exceptional handling statement *)
 try_stmt = 'try' block except_block {except_block} 'end';

--- a/tools/plugins/vscode/skiars.berry-0.1.0/syntaxes/berry.json
+++ b/tools/plugins/vscode/skiars.berry-0.1.0/syntaxes/berry.json
@@ -67,7 +67,7 @@
         "keywords": {
             "patterns": [{
                 "name": "keyword.berry",
-                "match": "\\b(var|def|class|true|false|nil|self|super|import|as)\\b"
+                "match": "\\b(var|static|def|class|true|false|nil|self|super|import|as)\\b"
             }]
         },
         "identifier": {


### PR DESCRIPTION
Here is a first try to implement inline static class initializers

```python
> class A static a = 42 end
> A.a
42
```

Code is generated after the class initializer code is identical to explicit initializers:
```python
> import debug
> debug.codedump(compile("class A static a = 42, b = 1 end"))
source 'string', function 'main':
; line 1
  0000  LDCONST	R0	K0
  0001  SETGBL	R0	G24
  0002  CLASS	K0
  0003  GETGBL	R0	G24
  0004  LDINT	R1	42
  0005  SETMBR	R0	R257	R1
  0006  GETGBL	R0	G24
  0007  SETMBR	R0	R258	R259
  0008  RET	0	R0

> debug.codedump(compile("class A static a, b end A.a = 42 A.b = 1"))
source 'string', function 'main':
; line 1
  0000  LDCONST	R0	K0
  0001  SETGBL	R0	G24
  0002  CLASS	K0
  0003  GETGBL	R0	G24
  0004  LDINT	R1	42
  0005  SETMBR	R0	R257	R1
  0006  GETGBL	R0	G24
  0007  SETMBR	R0	R258	R259
  0008  RET	0	R0
```

However we could think of an optimization, as to remove redundant `GETGBL	R0	G24`

Ideally it should be:
```python
source 'string', function 'main':
; line 1
  0000  LDCONST	R0	K0
  0001  SETGBL	R0	G24
  0002  CLASS	K0
  0003  LDINT	R1	42
  0004  SETMBR	R0	R257	R1
  0005  SETMBR	R0	R258	R259
  0006  RET	0	R0
```

But my understanding of code generator it too limited.