### PR TITLE
Doc and naming fixes

### DIFF
--- a/src/be_object.c
+++ b/src/be_object.c
@@ -29,7 +29,7 @@ const char* be_vtype2str(bvalue *v)
     case BE_MAP: return "map";
     case BE_INSTANCE: return "instance";
     case BE_MODULE: return "module";
-    case BE_INDEX: return "index";
+    case BE_INDEX: return "var";
     default: return "invalid type";
     }
 }

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -1255,7 +1255,7 @@ static void class_static_assignment_expr(bparser *parser, bexpdesc *e, bstring *
 static void classstatic_stmt(bparser *parser, bclass *c, bexpdesc *e)
 {
     bstring *name;
-    /* 'static' ID {',' ID} */
+    /* 'static' ID ['=' expr] {',' ID ['=' expr] } */
     scan_next_token(parser); /* skip 'static' */
     if (match_id(parser, name) != NULL) {
         check_class_attr(parser, c, name);


### PR DESCRIPTION
Fixing a regression, instance variables should be displayed as `<var>` and not `<index>`

Fixed grammar in `classstatic_stmt()`