### PR TITLE
Compile option to use named globals

### DIFF
--- a/src/be_code.h
+++ b/src/be_code.h
@@ -31,6 +31,7 @@ void be_code_closure(bfuncinfo *finfo, bexpdesc *e, int idx);
 void be_code_close(bfuncinfo *finfo, int isret);
 void be_code_class(bfuncinfo *finfo, bexpdesc *dst, bclass *c);
 void be_code_ret(bfuncinfo *finfo, bexpdesc *e);
+int be_code_nglobal(bfuncinfo *finfo, bexpdesc *k);
 void be_code_member(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2);
 void be_code_index(bfuncinfo *finfo, bexpdesc *c, bexpdesc *k);
 void be_code_setsuper(bfuncinfo *finfo, bexpdesc *c, bexpdesc *s);

--- a/src/be_debug.c
+++ b/src/be_debug.c
@@ -62,6 +62,9 @@ void be_print_inst(binstruction ins, int pc)
     case OP_OR: case OP_XOR: case OP_SHL: case OP_SHR:
         logbuf("%s\tR%d\tR%d\tR%d", opc2str(op), IGET_RA(ins), IGET_RKB(ins), IGET_RKC(ins));
         break;
+    case OP_GETNGBL: case OP_SETNGBL:
+        logbuf("%s\tR%d\tR%d", opc2str(op), IGET_RA(ins), IGET_RKB(ins));
+        break;
     case OP_GETGBL: case OP_SETGBL:
         logbuf("%s\tR%d\tG%d", opc2str(op), IGET_RA(ins), IGET_Bx(ins));
         break;

--- a/src/be_opcodes.h
+++ b/src/be_opcodes.h
@@ -52,4 +52,6 @@ OPCODE(IMPORT),     /*  A, B, C  |   IF (A == C) import module name as RK(B) to 
 OPCODE(EXBLK),      /*  A, Bx    |   ... */
 OPCODE(CATCH),      /*  A, B, C  |   ... */
 OPCODE(RAISE),      /*  A, B, C  |   ... */
-OPCODE(CLASS)       /*  Bx       |   init class in K[Bx] */
+OPCODE(CLASS),      /*  Bx       |   init class in K[Bx] */
+OPCODE(GETNGBL),    /*  A, B     |   R(A) <- GLOBAL[B] by name */
+OPCODE(SETNGBL)     /*  A, B     |   R(A) -> GLOBAL[B] by name */

--- a/src/be_parser.h
+++ b/src/be_parser.h
@@ -25,7 +25,8 @@ typedef enum {
     ETUPVAL,
     ETMEMBER,
     ETINDEX,
-    ETREG
+    ETREG,
+    ETNGLOBAL
 } exptype_t;
 
 typedef struct {

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -10,6 +10,15 @@
 
 #include "be_object.h"
 
+#define comp_is_named_gbl(vm)       ((vm)->compopt & (1<<COMP_NAMED_GBL))
+#define comp_set_named_gbl(vm)      ((vm)->compopt |= (1<<COMP_NAMED_GBL))
+#define comp_clear_named_gbl(vm)    ((vm)->compopt &= ~(1<<COMP_NAMED_GBL))
+
+/* Compilation options */
+typedef enum {
+    COMP_NAMED_GBL = 0x00, /* compile with named globals */
+} compoptmask;
+
 typedef struct {
     struct {
         bmap *vtab; /* global variable index table */
@@ -86,6 +95,7 @@ struct bvm {
     bmap *ntvclass; /* native class table */
     blist *registry; /* registry list */
     struct bgc gc;
+    bbyte compopt; /* compilation options */
 #if BE_USE_OBSERVABILITY_HOOK
     bobshook obshook;
 #endif


### PR DESCRIPTION
**This feature makes code solidification much easier.**

Currently Berry globals are accessed by index number in the table of globals. Unfortunately this makes code solidification impossible per se, since solidified code can't know in advance the index for each global.

Module `global` is a workaround to access to globals by name, but it makes code cumbersome and different for solidified and normal code.

This proposal adds a compile option (disabled by default) to have Berry code access to globals by name (string) instead of index number (int). This makes code perfectly suitable for solidification.

I checked if I could reuse `SETGBL` and `SETGBL` but I found no clean way. So my proposal is to introduce two new opcodes `SETNGBL` and `GETNGBL` for (N)amed globals.

The Berry compiler will emit those opcodes only if `comp_set_named_gbl(vm);` is set. It is disabled by default. There might be a performance hit, but in the case of Tasmota it's negligible. This option is enabled with `-g` CLI option.

Example: (standard Berry)
```python
> a=1
> f=compile("a=a+1")
> import debug
> debug.codedump(f)
source 'string', function 'main':
; line 1
  0000  GETGBL	R0	G23
  0001  ADD	R0	R0	R256
  0002  SETGBL	R0	G23
  0003  RET	0	R0

```

Example with `./berry -g` option:
```python
> a=1
> f=compile("a=a+1")
> import debug
> debug.codedump(f)
source 'string', function 'main':
; line 1
  0000  GETNGBL	R0	R256
  0001  ADD	R0	R0	R257
  0002  SETNGBL	R0	R256
  0003  RET	0	R0
```

Same example with full solidification `./berry -g`:
```python
> a=1
> f=compile("a=a+1")
> import solidify
> solidify.dump(f)

/********************************************************************
** Solidified function: main
********************************************************************/
be_local_closure(main,   /* name */
  be_nested_proto(
    1,                          /* nstack */
    0,                          /* argc */
    0,                          /* has upvals */
    NULL,                       /* no upvals */
    0,                          /* has sup protos */
    NULL,                       /* no sub protos */
    1,                          /* has constants */
    ( &(const bvalue[ 2]) {     /* constants */
      { { .s=be_nested_const_str("a", -468965076, 1) }, BE_STRING},
      { { .i=1 }, BE_INT},
    }),
    (be_nested_const_str("main", -359603704, 4)),
    (be_nested_const_str("string", 398550328, 6)),
    ( &(const binstruction[ 4]) {  /* code */
      0xB8020000,  //  0000  GETNGBL	R0	R256
      0x00000101,  //  0001  ADD	R0	R0	R257
      0xBC020000,  //  0002  SETNGBL	R0	R256
      0x80000000,  //  0003  RET	0	R0
    })
  )
);
/*******************************************************************/
```


