### PR TITLE
Add module 'introspect'

### DIFF
--- a/default/be_modtab.c
+++ b/default/be_modtab.c
@@ -20,6 +20,7 @@ be_extern_native_module(sys);
 be_extern_native_module(debug);
 be_extern_native_module(gc);
 be_extern_native_module(solidify);
+be_extern_native_module(introspect);
 be_extern_native_module(strict);
 
 /* user-defined modules declare start */
@@ -58,6 +59,9 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
 #endif
 #if BE_USE_SOLIDIFY_MODULE
     &be_native_module(solidify),
+#endif
+#if BE_USE_INTROSPECT_MODULE
+    &be_native_module(introspect),
 #endif
 #if BE_USE_STRICT_MODULE
     &be_native_module(strict),

--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -161,6 +161,7 @@
 #define BE_USE_DEBUG_MODULE             1
 #define BE_USE_GC_MODULE                1
 #define BE_USE_SOLIDIFY_MODULE          1
+#define BE_USE_INTROSPECT_MODULE        1
 #define BE_USE_STRICT_MODULE            1
 
 /* Macro: BE_EXPLICIT_XXX

--- a/src/be_api.c
+++ b/src/be_api.c
@@ -208,6 +208,12 @@ BERRY_API bbool be_isinstance(bvm *vm, int index)
     return var_isinstance(v);
 }
 
+BERRY_API bbool be_ismodule(bvm *vm, int index)
+{
+    bvalue *v = be_indexof(vm, index);
+    return var_ismodule(v);
+}
+
 BERRY_API bbool be_islist(bvm *vm, int index)
 {
     bvalue *v = be_indexof(vm, index);

--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -1,0 +1,100 @@
+/********************************************************************
+** Copyright (c) 2018-2020 Guan Wenliang
+** This file is part of the Berry default interpreter.
+** skiars@qq.com, https://github.com/Skiars/berry
+** See Copyright Notice in the LICENSE file or at
+** https://github.com/Skiars/berry/blob/master/LICENSE
+********************************************************************/
+#include "be_object.h"
+#include "be_module.h"
+#include "be_string.h"
+#include "be_vector.h"
+#include "be_class.h"
+#include "be_debug.h"
+#include "be_map.h"
+#include "be_vm.h"
+#include <string.h>
+
+#if BE_USE_INTROSPECT_MODULE
+
+#define global(vm)      ((vm)->gbldesc.global)
+#define builtin(vm)     ((vm)->gbldesc.builtin)
+
+static void dump_map_keys(bvm *vm, bmap *map)
+{
+    if (!map) { return; }   /* protect agains potential null pointer */
+    bmapnode *node;
+    bmapiter iter = be_map_iter();
+    while ((node = be_map_next(map, &iter)) != NULL) {
+        if (var_isstr(&node->key)) {
+            bstring *s = var_tostr(&node->key);
+            be_pushstring(vm, str(s));
+            be_data_push(vm, -2);
+            be_pop(vm, 1);
+        }
+    }
+}
+
+static int m_attrlist(bvm *vm)
+{
+    int top = be_top(vm);
+    be_newobject(vm, "list");
+    if (top >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        void *obj = var_toobj(v);
+        switch (var_type(v)) {
+        case BE_NIL: dump_map_keys(vm, global(vm).vtab); break;
+        case BE_MODULE: dump_map_keys(vm, ((bmodule*)obj)->table); break;
+        case BE_CLASS: dump_map_keys(vm, ((bclass*)obj)->members); break;
+        case BE_INSTANCE: dump_map_keys(vm, ((binstance*)obj)->_class->members); break;
+        default: break;
+        }
+    } else {    /* if no parameter, then dump globals */
+        dump_map_keys(vm, global(vm).vtab);
+    }
+    be_pop(vm, 1);
+    be_return(vm);
+}
+
+static int m_findmember(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 2 && (be_isinstance(vm, 1) || be_ismodule(vm, 1) || be_isclass(vm, 1)) && be_isstring(vm, 2)) {
+        be_getmember(vm, 1, be_tostring(vm, 2));
+        be_return(vm);
+    }
+    be_return_nil(vm);
+}
+
+static int m_setmember(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 3 && (be_isinstance(vm, 1) || be_ismodule(vm, 1)) && be_isstring(vm, 2)) {
+        be_setmember(vm, 1, be_tostring(vm, 2));
+        be_return(vm);
+    }
+    be_return_nil(vm);
+}
+
+#if !BE_USE_PRECOMPILED_OBJECT
+be_native_module_attr_table(introspect) {
+    be_native_module_function("members", m_attrlist),
+
+    be_native_module_function("get", m_findmember),
+    be_native_module_function("set", m_setmember),
+};
+
+be_define_native_module(introspect, NULL);
+#else
+/* @const_object_info_begin
+module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
+    members, func(m_attrlist)
+
+    get, func(m_findmember)
+    set, func(m_setmember)
+}
+@const_object_info_end */
+#include "../generate/be_fixed_introspect.h"
+#endif
+
+#endif /* BE_USE_INTROSPECT_MODULE */

--- a/src/berry.h
+++ b/src/berry.h
@@ -449,6 +449,7 @@ BERRY_API bbool be_isfunction(bvm *vm, int index);
 BERRY_API bbool be_isproto(bvm *vm, int index);
 BERRY_API bbool be_isclass(bvm *vm, int index);
 BERRY_API bbool be_isinstance(bvm *vm, int index);
+BERRY_API bbool be_ismodule(bvm *vm, int index);
 BERRY_API bbool be_islist(bvm *vm, int index);
 BERRY_API bbool be_ismap(bvm *vm, int index);
 BERRY_API bbool be_iscomptr(bvm *vm, int index);

--- a/tests/introspect.be
+++ b/tests/introspect.be
@@ -1,0 +1,28 @@
+#- base64 encode -#
+import introspect
+
+#- test for modules -#
+m = module("m")
+m.a = 1
+m.b = def () return "foo" end
+
+assert(introspect.members(m) == ['a', 'b'])
+assert(introspect.get(m, 'a') == 1)
+assert(type(introspect.get(m, 'b')) == 'function')
+
+introspect.set(m, 'a', 2)
+assert(m.a == 2)
+
+#- test for instance -#
+class A var a,b static c=1,d=2 def f() end end
+a=A()
+
+assert(introspect.members(A) == ['a', 'f', 'b', 'c', 'd']) #- class members -#
+assert(introspect.members(a) == ['a', 'f', 'b', 'c', 'd']) #- instance members -#
+
+assert(introspect.get(a, 'c') == 1)
+assert(introspect.get(a, 'd') == 2)
+assert(introspect.get(a, 'a') == nil)
+
+introspect.set(a, 'a', 3)
+assert(a.a == 3)


### PR DESCRIPTION
Add module `introspect` that allows to list, set, get members in instances and modules.

This module is already in use in Tasmota. It is compiled if `BE_USE_INTROSPECT_MODULE` is set.

## module `introspect`

### `introspect.members(instance | class | module) -> list`

`introspect.members()` lists the members of a module, a class or an instance.

```
> class A var a,b def f() end end
> import introspect
> introspect.members(A)
['b', 'a', 'f']
```

### `introspect.get(instance | module, member:string) -> any`

`introspect.get()` allows to retrieve a member by name from an instance or a module. If the member of an instance does not exist, it returns `nil` (which simplifies error handling).

```
> class A var a,b def f() end end
> o=A()
> o.a = 1
> import introspect
> introspect.get(o, 'a')
1
> introspect.get(o, 'f')
<function: 0x7fd17ce04e00>
> introspect.get(o, 'd')

```

### `introspect.set(instance | module, member:string, value:any) -> any`

`introspect.set()` allows to set a member by name for an instance or a module. It returns the value set.

```
> class A var a,b def f() end end
> o=A()
> o.a = 1
> introspect.set(o, 'a', 10)
10
> o.a
10
```
