### PR TITLE
Support for vararg

### DIFF
--- a/tests/vararg.be
+++ b/tests/vararg.be
@@ -1,0 +1,14 @@
+#- vararg -#
+def f(a,*b) return b end
+
+assert(f() == [])
+assert(f(1) == [])
+assert(f(1,2) == [2])
+assert(f(1,2,3) == [2, 3])
+
+def g(*a) return a end
+
+assert(g() == [])
+assert(g("foo") == ["foo"])
+assert(g("foo", nil) == ["foo", nil])
+assert(g("foo", nil, 2) == ["foo", nil, 2])


### PR DESCRIPTION
It was finally a small change. I didn't update the ebnf grammar because it was already there, although it is applicable only to the last argument.

When declaring the last argument of a function or a method with a preceding `*`, the function is marked as vararg. This means that all parameters starting at this variable are collated in a list that the function can traverse. If no argument is present, the list is empty.

```
> def f(a, *b) return b end
> f()
[]
> f(1,2)
[2]
> f(1,2,3,4)
[2, 3, 4]
```
