### PR TITLE
Improvements to named globals

### DIFF
--- a/src/be_api.c
+++ b/src/be_api.c
@@ -208,6 +208,12 @@ BERRY_API bbool be_isinstance(bvm *vm, int index)
     return var_isinstance(v);
 }
 
+BERRY_API bbool be_ismodule(bvm *vm, int index)
+{
+    bvalue *v = be_indexof(vm, index);
+    return var_ismodule(v);
+}
+
 BERRY_API bbool be_islist(bvm *vm, int index)
 {
     bvalue *v = be_indexof(vm, index);
@@ -602,23 +608,18 @@ BERRY_API bbool be_getbuiltin(bvm *vm, const char *name)
 
 BERRY_API bbool be_setmember(bvm *vm, int index, const char *k)
 {
-    int res = BE_NIL;
     bvalue *o = be_indexof(vm, index);
+    bvalue *v = be_indexof(vm, -1);
     if (var_isinstance(o)) {
         bstring *key = be_newstr(vm, k);
-        bvalue *v = be_indexof(vm, -1);
         binstance *obj = var_toobj(o);
-        res = be_instance_setmember(vm, obj, key, v);
+        return be_instance_setmember(vm, obj, key, v);
     } else if (var_ismodule(o)) {
         bstring *key = be_newstr(vm, k);
         bmodule *mod = var_toobj(o);
-        bvalue *v = be_module_bind(vm, mod, key);
-        if (v) {
-            *v = *be_indexof(vm, -1);
-            return btrue;
-        }
+        return be_module_setmember(vm, mod, key, v);
     }
-    return res != BE_NIL;
+    return bfalse;
 }
 
 BERRY_API bbool be_copy(bvm *vm, int index)
@@ -644,16 +645,15 @@ static int ins_member(bvm *vm, int index, const char *k, bbool onlyins)
     if (var_isinstance(o)) {
         binstance *obj = var_toobj(o);
         type = be_instance_member(vm, obj, be_newstr(vm, k), top);
-        if (type == BE_NONE) {
-            type = BE_NIL;
-        }
+    } else if (var_isclass(o) && !onlyins) {
+        bclass *cl = var_toobj(o);
+        type = be_class_member(vm, cl, be_newstr(vm, k), top);
     } else if (var_ismodule(o) && !onlyins) {
         bmodule *module = var_toobj(o);
-        bvalue *v = be_module_attr(vm, module, be_newstr(vm, k));
-        if (v != NULL) {
-            *top = *v;
-            type = v->type;
-        }
+        type = be_module_attr(vm, module, be_newstr(vm, k), top);
+    }
+    if (type == BE_NONE) {
+        type = BE_NIL;
     }
     return type;
 }

--- a/src/be_module.h
+++ b/src/be_module.h
@@ -34,8 +34,8 @@ typedef struct bmodule {
 bmodule* be_module_new(bvm *vm);
 void be_module_delete(bvm *vm, bmodule *module);
 int be_module_load(bvm *vm, bstring *path);
-bvalue* be_module_attr(bvm *vm, bmodule *module, bstring *attr);
-bvalue* be_module_bind(bvm *vm, bmodule *module, bstring *attr);
+int be_module_attr(bvm *vm, bmodule *module, bstring *attr, bvalue *dst);
+bbool be_module_setmember(bvm *vm, bmodule *module, bstring *attr, bvalue *src);
 const char* be_module_name(bmodule *module);
 bbool be_module_setname(bmodule *module, bstring *name);
 

--- a/src/be_opcodes.h
+++ b/src/be_opcodes.h
@@ -53,5 +53,5 @@ OPCODE(EXBLK),      /*  A, Bx    |   ... */
 OPCODE(CATCH),      /*  A, B, C  |   ... */
 OPCODE(RAISE),      /*  A, B, C  |   RAISE(B,C) B is code, C is description. A==0 only B provided, A==1 B and C are provided, A==2 rethrow with both parameters already on stack */
 OPCODE(CLASS),      /*  Bx       |   init class in K[Bx] */
-OPCODE(GETNGBL),    /*  A, B     |   R(A) <- GLOBAL[B] by name */
-OPCODE(SETNGBL)     /*  A, B     |   R(A) -> GLOBAL[B] by name */
+OPCODE(GETNGBL),    /*  A, B     |   R(A) <- GLOBAL[RK(B)] by name */
+OPCODE(SETNGBL)     /*  A, B     |   R(A) -> GLOBAL[RK(B)] by name */

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -461,6 +461,14 @@ static void new_var(bparser *parser, bstring *name, bexpdesc *var)
             push_error(parser,
                 "too many global variables (in '%s')", str(name));
         }
+        if (comp_is_named_gbl(parser->vm)) {
+            /* change to ETNGLBAL */
+            bexpdesc key;
+            init_exp(&key, ETSTRING, 0);
+            key.v.s = name;
+            init_exp(var, ETNGLOBAL, 0);
+            var->v.idx = be_code_nglobal(parser->finfo, &key);
+        }
     }
 }
 
@@ -528,23 +536,45 @@ static void singlevar(bparser *parser, bexpdesc *var)
     }
 }
 
+/* parse a vararg argument in the form `def f(a, *b) end` */
+/* Munch the '*', read the token, create variable and declare the function as vararg */
+static void func_vararg(bparser *parser) {
+    bexpdesc v;
+    bstring *str;
+    match_token(parser, OptMul); /* skip '*' */
+    str = next_token(parser).u.s;
+    match_token(parser, TokenId); /* match and skip ID */
+    new_var(parser, str, &v); /* new variable */
+    parser->finfo->proto->varg = 1;   /* set varg flag */
+}
+
 /* Parse function or method definition variable list */
 /* Create an implicit local variable for each argument starting at R0 */
 /* Update function proto argc to the expected number or arguments */
 /* Raise an exception if multiple arguments have the same name */
+/* New: vararg support */
 static void func_varlist(bparser *parser)
 {
     bexpdesc v;
     bstring *str;
-    /* '(' [ID {',' ID}] ')' */
+    /* '(' [ ID {',' ID}] ')' or */
+    /* '(' '*' ID ')' or */
+    /* '(' [ ID {',' ID}] ',' '*' ID ')' */
     match_token(parser, OptLBK); /* skip '(' */
-    if (match_id(parser, str) != NULL) {
+    if (next_type(parser) == OptMul) {
+        func_vararg(parser);
+    } else if (match_id(parser, str) != NULL) {
         new_var(parser, str, &v); /* new variable */
         while (match_skip(parser, OptComma)) { /* ',' */
-            str = next_token(parser).u.s;
-            match_token(parser, TokenId); /* match and skip ID */
-            /* new local variable */
-            new_var(parser, str, &v);
+            if (next_type(parser) == OptMul) {
+                func_vararg(parser);
+                break;
+            } else {
+                str = next_token(parser).u.s;
+                match_token(parser, TokenId); /* match and skip ID */
+                /* new local variable */
+                new_var(parser, str, &v);
+            }
         }
     }
     match_token(parser, OptRBK); /* skip ')' */

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -274,26 +274,10 @@ static void obj_method(bvm *vm, bvalue *o, bstring *attr, bvalue *dst)
     }
 }
 
-static int obj_attribute(bvm *vm, bvalue *o, bvalue *c, bvalue *dst)
+static int obj_attribute(bvm *vm, bvalue *o, bstring *attr, bvalue *dst)
 {
-    bvalue instance = *o; /* save instance to send it later to member */
-    bstring *attr = var_tostr(c);
     binstance *obj = var_toobj(o);
     int type = be_instance_member(vm, obj, attr, dst);
-    if (type == BE_NONE) { /* if no method found, try virtual */
-        /* get method 'member' */
-        int type2 = be_instance_member(vm, obj, str_literal(vm, "member"), vm->top);
-        if (basetype(type2) == BE_FUNCTION) {
-            bvalue *top = vm->top;
-            top[1] = instance; /* move instance to argv[0] */
-            top[2] = *c; /* move method name to argv[1] */
-            vm->top += 3;   /* prevent collection results */
-            be_dofunc(vm, top, 2); /* call method 'member' */
-            vm->top -= 3;
-            *dst = *vm->top;   /* copy result to R(A) */
-            type = var_type(dst);
-        }
-    }
     if (type == BE_NONE) {
         vm_error(vm, "attribute_error",
             "the '%s' object has no attribute '%s'",
@@ -311,6 +295,19 @@ static int class_attribute(bvm *vm, bvalue *o, bvalue *c, bvalue *dst)
         vm_error(vm, "attribute_error",
             "the '%s' class has no static attribute '%s'",
             str(obj->name), str(attr));
+    }
+    return type;
+}
+
+static int module_attribute(bvm *vm, bvalue *o, bvalue *c, bvalue *dst)
+{
+    bstring *attr = var_tostr(c);
+    bmodule *module = var_toobj(o);
+    int type = be_module_attr(vm, module, attr, dst);
+    if (type == BE_NONE) {
+        vm_error(vm, "attribute_error",
+            "module '%s' has no member '%s'",
+            be_module_name(module), str(attr));
     }
     return type;
 }
@@ -528,12 +525,8 @@ newframe: /* a new call frame */
             bvalue *b = RKB();
             if (var_isstr(b)) {
                 bstring *name = var_tostr(b);
-                int idx = be_global_find(vm, name);
-                if (idx > -1) {
-                    *be_global_var(vm, idx) = *v;
-                } else {
-                    vm_error(vm, "attribute_error", "'%s' undeclared", str(name));
-                }
+                int idx = be_global_new(vm, name);
+                *be_global_var(vm, idx) = *v;
             } else {
                 vm_error(vm, "internal_error", "global name must be a string");
             }
@@ -792,35 +785,14 @@ newframe: /* a new call frame */
         opcase(GETMBR): {
             bvalue *a = RA(), *b = RKB(), *c = RKC();
             if (var_isinstance(b) && var_isstr(c)) {
-                obj_attribute(vm, b, c, a);
+                obj_attribute(vm, b, var_tostr(c), a);
                 reg = vm->reg;
             } else if (var_isclass(b) && var_isstr(c)) {
                 class_attribute(vm, b, c, a);
                 reg = vm->reg;
             } else if (var_ismodule(b) && var_isstr(c)) {
-                bstring *attr = var_tostr(c);
-                bmodule *module = var_toobj(b);
-                bvalue *v = be_module_attr(vm, module, attr);
-                if (v) {
-                    *a = *v;
-                } else {
-                    bvalue *member = be_module_attr(vm, module, str_literal(vm, "member"));
-                    var_setnil(a);
-                    if (member && var_basetype(member) == BE_FUNCTION) {
-                        bvalue *top = vm->top;
-                        top[0] = *member;
-                        top[1] = *c; /* move name to argv[0] */
-                        vm->top += 2;   /* prevent collection results */
-                        be_dofunc(vm, top, 1); /* call method 'method' */
-                        vm->top -= 2;
-                        *a = *vm->top;   /* copy result to R(A) */
-                    }
-                    if (var_basetype(a) == BE_NIL) {
-                        vm_error(vm, "attribute_error",
-                            "module '%s' has no attribute '%s'",
-                            be_module_name(module), str(attr));
-                    }
-                }
+                module_attribute(vm, b, c, a);
+                reg = vm->reg;
             } else {
                 attribute_error(vm, "attribute", b, c);
             }
@@ -829,49 +801,23 @@ newframe: /* a new call frame */
         opcase(GETMET): {
             bvalue *a = RA(), *b = RKB(), *c = RKC();
             if (var_isinstance(b) && var_isstr(c)) {
-                bvalue self = *b;
-                bstring *attr = var_tostr(c);
                 binstance *obj = var_toobj(b);
-                int type = obj_attribute(vm, b, c, a);
+                int type = obj_attribute(vm, b, var_tostr(c), a);
                 reg = vm->reg;
                 if (basetype(type) == BE_FUNCTION) {
                     /* check if the object is a superinstance, if so get the lowest possible subclass */
                     while (obj->sub) {
                         obj = obj->sub;
                     }
-                    var_setobj(&self, var_type(&self), obj);  /* replace superinstance by lowest subinstance */
-                    a[1] = self;
+                    var_setinstance(&a[1], obj);  /* replace superinstance by lowest subinstance */
                 } else {
                     vm_error(vm, "attribute_error",
                         "class '%s' has no method '%s'",
-                        str(be_instance_name(obj)), str(attr));
+                        str(be_instance_name(obj)), str(var_tostr(c)));
                 }
             } else if (var_ismodule(b) && var_isstr(c)) {
-                bstring *attr = var_tostr(c);
-                bmodule *module = var_toobj(b);
-                bvalue *src = be_module_attr(vm, module, attr);
-                if (src) {
-                    var_settype(a, NOT_METHOD);
-                    a[1] = *src;
-                } else {
-                    bvalue *member = be_module_attr(vm, module, str_literal(vm, "member"));
-                    var_setnil(a);
-                    if (member && var_basetype(member) == BE_FUNCTION) {
-                        bvalue *top = vm->top;
-                        top[0] = *member;
-                        top[1] = *c; /* move name to argv[0] */
-                        vm->top += 2;   /* prevent collection results */
-                        be_dofunc(vm, top, 1); /* call method 'method' */
-                        vm->top -= 2;
-                        var_settype(a, NOT_METHOD);
-                        a[1] = *vm->top;   /* copy result to R(A) */
-                    }
-                    if (var_basetype(a) == BE_NIL) {
-                        vm_error(vm, "attribute_error",
-                            "module '%s' has no method '%s'",
-                            be_module_name(module), str(attr));
-                    }
-                }
+                module_attribute(vm, b, c, &a[1]);
+                var_settype(a, NOT_METHOD);
             } else {
                 attribute_error(vm, "method", b, c);
             }
@@ -902,23 +848,10 @@ newframe: /* a new call frame */
             if (var_ismodule(a) && var_isstr(b)) {
                 bmodule *obj = var_toobj(a);
                 bstring *attr = var_tostr(b);
-                bvalue tmp = *c; /* stack may change */
-                bvalue *v = be_module_bind(vm, obj, attr);
-                if (v != NULL) {
-                    *v = tmp;
+                if (be_module_setmember(vm, obj, attr, c)) {
                     dispatch();
-                }
-                /* if it failed, try 'setmeemner' */
-                bvalue *member = be_module_attr(vm, obj, str_literal(vm, "setmember"));
-                if (member && var_basetype(member) == BE_FUNCTION) {
-                    bvalue *top = vm->top;
-                    top[0] = *member;
-                    top[1] = *b; /* move name to argv[0] */
-                    top[2] = tmp; /* move value to argv[1] */
-                    vm->top += 3;   /* prevent collection results */
-                    be_dofunc(vm, top, 2); /* call method 'setmember' */
-                    vm->top -= 3;
-                    dispatch();
+                } else {
+                    // fall through exception below
                 }
             }
             attribute_error(vm, "writable attribute", a, b);
@@ -1103,14 +1036,10 @@ newframe: /* a new call frame */
                 break;
             }
             case BE_MODULE: {
-                bmodule *f = var_toobj(var);
-                bvalue *member = be_module_attr(vm, f, str_literal(vm, "()"));
-                if (member && var_basetype(member) == BE_FUNCTION) {
-                    *var = *member;
-                    goto recall; /* call '()' method */
-                } else {
-                    call_error(vm, var);
-                }
+                bvalue attr;
+                var_setstr(&attr, str_literal(vm, "()"));
+                module_attribute(vm, var, &attr, var);  /* exception if not found */
+                goto recall; /* call '()' method */
                 break;
             }
             default:

--- a/tools/grammar/berry.bytecode
+++ b/tools/grammar/berry.bytecode
@@ -21,7 +21,7 @@ bytecode_file:  -- little endian
 
 header: 8
     magic_number: 3 -- 0xbecdfe (berry code file)
-    version: 1      -- update with file structure definition
+    version: 2      -- update with file structure definition
     integer_size: .1
     float_size: .1
     -- reserved space
@@ -30,7 +30,7 @@ main_function -> function
 
 global_desc:
     builtin_count: 4
-    global_count: 4
+    global_count: 4 -- excluding builtins
     global_name -> [
             string
         ](global_count)
@@ -43,7 +43,8 @@ function:
             string
         argc: 1   -- arguments count
         nstack: 1 -- number of stack size by this function
-        extra: 2  -- extra data
+        varg: 1
+        extra: 1  -- extra data
     bytecode:
         code_size: 4
         code_array -> [ -- bytecode array


### PR DESCRIPTION
- Removed some remaining SETGBL when creating a new global, defining a new function or a new class. Now using SETNGBL when named globals are enabled
- Changed `be_getmember()`, `be_setmember()` and `be_getmethod()` to support virtual members. Previously only VM opcodes would support virtual members

Update in bytecode format, v2
- Changed bytecode format to support vararg. Unfortunately the code did not follow the ebnf grammar, and the 2 reserved bytes for a proto were missing.
- Changed internal version from 1 to 2. v1 can still be loaded.
- When named global mode is on, bytecode does not contain the dictionary of globals, making bytecode file much smaller

Tested in production code in Tasmota