### PR TITLE
Better display of constants in codedump

### DIFF
--- a/src/be_debug.c
+++ b/src/be_debug.c
@@ -60,16 +60,20 @@ void be_print_inst(binstruction ins, int pc)
     case OP_GETMBR: case OP_SETMBR:  case OP_GETMET:
     case OP_GETIDX: case OP_SETIDX: case OP_AND:
     case OP_OR: case OP_XOR: case OP_SHL: case OP_SHR:
-        logbuf("%s\tR%d\tR%d\tR%d", opc2str(op), IGET_RA(ins), IGET_RKB(ins), IGET_RKC(ins));
+        logbuf("%s\tR%d\t%c%d\t%c%d", opc2str(op), IGET_RA(ins),
+                isKB(ins) ? 'K' : 'R', IGET_RKB(ins) & KR_MASK,
+                isKC(ins) ? 'K' : 'R', IGET_RKC(ins) & KR_MASK);
         break;
     case OP_GETNGBL: case OP_SETNGBL:
-        logbuf("%s\tR%d\tR%d", opc2str(op), IGET_RA(ins), IGET_RKB(ins));
+        logbuf("%s\tR%d\t%c%d", opc2str(op), IGET_RA(ins),
+                isKB(ins) ? 'K' : 'R', IGET_RKB(ins) & KR_MASK);
         break;
     case OP_GETGBL: case OP_SETGBL:
         logbuf("%s\tR%d\tG%d", opc2str(op), IGET_RA(ins), IGET_Bx(ins));
         break;
     case OP_MOVE: case OP_SETSUPER: case OP_NEG: case OP_FLIP: case OP_IMPORT:
-        logbuf("%s\tR%d\tR%d", opc2str(op), IGET_RA(ins), IGET_RKB(ins));
+        logbuf("%s\tR%d\t%c%d", opc2str(op), IGET_RA(ins),
+                isKB(ins) ? 'K' : 'R', IGET_RKB(ins) & KR_MASK);
         break;
     case OP_JMP:
         logbuf("%s\t\t#%.4X", opc2str(op), IGET_sBx(ins) + pc + 1);
@@ -84,7 +88,12 @@ void be_print_inst(binstruction ins, int pc)
         logbuf("%s\tR%d\t%d\t%d", opc2str(op),  IGET_RA(ins), IGET_RKB(ins), IGET_RKC(ins));
         break;
     case OP_RET:
-        logbuf("%s\t%d\tR%d", opc2str(op), IGET_RA(ins), IGET_RKB(ins));
+        if (IGET_RA(ins)) {
+            logbuf("%s\t%d\t%c%d", opc2str(op), IGET_RA(ins),
+                isKB(ins) ? 'K' : 'R', IGET_RKB(ins) & KR_MASK);
+        } else {
+            logbuf("%s\t%d", opc2str(op), IGET_RA(ins)); /* RET 0 does not take an additional parameter */
+        }
         break;
     case OP_GETUPV: case OP_SETUPV:
         logbuf("%s\tR%d\tU%d", opc2str(op), IGET_RA(ins), IGET_Bx(ins));
@@ -105,7 +114,9 @@ void be_print_inst(binstruction ins, int pc)
         logbuf("%s\t%d", opc2str(op), IGET_RA(ins));
         break;
     case OP_RAISE:
-        logbuf("%s\t%d\tR%d\tR%d", opc2str(op), IGET_RA(ins), IGET_RKB(ins), IGET_RKC(ins));
+        logbuf("%s\t%d\t%c%d\t%c%d", opc2str(op), IGET_RA(ins),
+                isKB(ins) ? 'K' : 'R', IGET_RKB(ins) & KR_MASK,
+                isKC(ins) ? 'K' : 'R', IGET_RKC(ins) & KR_MASK);
         break;
     case OP_EXBLK:
         if (IGET_RA(ins)) {

--- a/src/be_decoder.h
+++ b/src/be_decoder.h
@@ -46,6 +46,9 @@
 #define IsBx_MAX                cast_int(IBx_MASK >> 1)
 #define IsBx_MIN                cast_int(-IsBx_MAX - 1)
 
+/* mask for K/R values */
+#define KR_MASK                 ((1 << (IRKB_BITS-1)) - 1)
+
 /* get field */
 #define IGET_OP(i)              cast(bopcode, INS_GETx(i, IOP_MASK, IOP_POS))
 #define IGET_RA(i)              INS_GETx(i, IRA_MASK, IRA_POS)


### PR DESCRIPTION
Improve display of constants when using `debug.codedump()`. Now displays `K1` instead of `R257`.

Also display `RET 0` indstead of `RET 0 R0` when no value is returned.

Before:
```
> def f(a) a += 1 return "foo" end
> def g() end
> import debug

> debug.codedump(f)
source 'stdin', function 'f':
; line 1
  0000  ADD	R0	R0	R256
  0001  RET	1	R257

> debug.codedump(g)
source 'stdin', function 'g':
; line 1
  0000  RET	0	R0
```

After
```
> def f(a) a += 1 return "foo" end
> def g() end
> import debug

> debug.codedump(f)
source 'stdin', function 'f':
; line 1
  0000  ADD	R0	R0	K0
  0001  RET	1	K1

> debug.codedump(g)
source 'stdin', function 'g':
; line 1
  0000  RET	0
```