### PR TITLE
Fix bug in conditional

### DIFF
--- a/src/be_debug.c
+++ b/src/be_debug.c
@@ -111,7 +111,7 @@ void be_print_inst(binstruction ins, int pc)
         logbuf("%s\tK%d", opc2str(op), IGET_Bx(ins));
         break;
     case OP_CLOSE: case OP_LDNIL:
-        logbuf("%s\t%d", opc2str(op), IGET_RA(ins));
+        logbuf("%s\tR%d", opc2str(op), IGET_RA(ins));
         break;
     case OP_RAISE:
         logbuf("%s\t%d\t%c%d\t%c%d", opc2str(op), IGET_RA(ins),

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -97,7 +97,7 @@ static void match_notoken(bparser *parser, btokentype type)
     }
 }
 
-/* check that if the expdesc is a symbol, it is avalid one or raise an exception */
+/* check that if the expdesc is a symbol, it is a valid one or raise an exception */
 static void check_symbol(bparser *parser, bexpdesc *e)
 {
     if (e->type == ETVOID && e->v.s == NULL) { /* error when token is not a symbol */
@@ -106,7 +106,7 @@ static void check_symbol(bparser *parser, bexpdesc *e)
     }
 }
 
-/* check that the value in `e` is valid for a variable, i.e. conatins a value or a valid symbol */
+/* check that the value in `e` is valid for a variable, i.e. contains a value or a valid symbol */
 static void check_var(bparser *parser, bexpdesc *e)
 {
     check_symbol(parser, e); /* check the token is a symbol */
@@ -989,6 +989,7 @@ static void cond_expr(bparser *parser, bexpdesc *e)
     if (next_type(parser) == OptQuestion) {
         int jf, jl = NO_JUMP; /* jump list */
         bfuncinfo *finfo = parser->finfo;
+        check_var(parser, e);  /* check if valid */
         scan_next_token(parser); /* skip '?' */
         be_code_jumpbool(finfo, e, bfalse); /* go if true */
         jf = e->f;


### PR DESCRIPTION
Following code should not work since global `v` is not declared
```
> v ? 1 : 0
0
```

With fix:
```
> v ? 1 : 0
syntax_error: stdin:1: 'v' undeclared (first use in this function)
```

It appears that a `check_var()` was missing to check that the condition is a valid var.

Also fixed a bug in disassembler, `R` prefix was missing for `LDNIL`:
```
> def f() var a end
> import debug
> debug.codedump(f)

# before
source 'stdin', function 'f':
; line 1
  0000  LDNIL	0
  0001  RET	0

# after
source 'stdin', function 'f':
; line 1
  0000  LDNIL	R0
  0001  RET	0