### PR TITLE
Memory allocated by `bytes()` is now accounted in Berry's heap

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -419,26 +419,17 @@ static void buf_add_hex(buf_impl* buf, const char *hex, size_t len)
 /********************************************************************
 ** Wrapping into lib
 ********************************************************************/
-// typedef int (*bntvfunc)(bvm*); /* native function pointer */
-int free_bytes_buf(bvm* vm)
-{
-    int argc = be_top(vm);
-    if (argc > 0) {
-        buf_impl * buf = (buf_impl*) be_tocomptr(vm, 1);
-        if (buf != NULL) {
-            be_os_free(buf);
-        }
-    }
-    be_return_nil(vm);
-}
 
-buf_impl * bytes_alloc(int32_t size)
+buf_impl * bytes_realloc(bvm *vm, buf_impl *oldbuf, int32_t size)
 {
     if (size < 4) { size = 4; }
     if (size > BYTES_MAX_SIZE) { size = BYTES_MAX_SIZE; }
-    buf_impl * next = (buf_impl*) be_os_malloc(size + BYTES_OVERHEAD);
+    size_t oldsize = oldbuf ? oldbuf->size + BYTES_OVERHEAD : 0;
+    buf_impl * next = (buf_impl*) be_realloc(vm, oldbuf, oldsize, size + BYTES_OVERHEAD);  /* malloc */
     next->size = size;
-    next->len = 0;
+    if (!oldbuf) {
+        next->len = 0; /* allocate a new buffer */
+    }
     return next;
 }
 
@@ -467,10 +458,10 @@ static int m_init(bvm *vm)
     } else if (argc > 1 && be_isstring(vm, 2)) {
         hex_in = be_tostring(vm, 2);
         if (hex_in) {
-            size = strlen(hex_in) / 2 + BYTES_HEADROOM;        // allocate headroom
+            size = strlen(hex_in) / 2 + BYTES_HEADROOM;        /* allocate headroom */
         }
     }
-    buf_impl * buf = bytes_alloc(size);
+    buf_impl * buf = bytes_realloc(vm, NULL, size); /* allocate new buffer */
     if (!buf) {
         be_throw(vm, BE_MALLOC_FAIL);
     }
@@ -478,22 +469,35 @@ static int m_init(bvm *vm)
     if (hex_in) {
         buf_add_hex(buf, hex_in, strlen(hex_in));
     } 
-    be_newcomobj(vm, buf, &free_bytes_buf);
+    be_pushcomptr(vm, buf);
     be_setmember(vm, 1, ".p");
     be_return_nil(vm);
+}
+
+/* deallocate buffer */
+static int m_deinit(bvm *vm) {
+{
+    be_getmember(vm, 1, ".p");
+    buf_impl * buf = be_tocomptr(vm, -1);
+    be_pop(vm, 1);
+    if (buf != NULL) {
+        be_realloc(vm, buf, buf->size + BYTES_OVERHEAD, 0);
+    }
+    be_pushcomptr(vm, NULL);  /* push NULL pointer instead, just in case */
+    be_setmember(vm, 1, ".p");
+    be_return_nil(vm);
+}
 }
 
 /* grow or shrink to the exact value */
 /* stack item 1 must contain the instance */
 static buf_impl * _bytes_resize(bvm *vm, buf_impl * buf, size_t new_size) {
-    buf_impl * new_buf = bytes_alloc(new_size);
+    buf_impl *new_buf = bytes_realloc(vm, buf, new_size);
     if (!new_buf) {
         be_throw(vm, BE_MALLOC_FAIL);
     }
-    memmove(buf_get_buf(new_buf), buf_get_buf(buf), buf->len);
-    new_buf->len = buf->len;
-    /* replace the .p attribute */
-    be_newcomobj(vm, new_buf, &free_bytes_buf);
+    /* replace the .p attribute since address may have changed */
+    be_pushcomptr(vm, new_buf);
     be_setmember(vm, 1, ".p");
     be_pop(vm, 1); /* remove comobj from stack */
     /* the old buffer will be garbage collected later */
@@ -504,7 +508,13 @@ static buf_impl * _bytes_resize(bvm *vm, buf_impl * buf, size_t new_size) {
 /* if grow, then add some headroom */
 /* stack item 1 must contain the instance */
 static buf_impl * bytes_resize(bvm *vm, buf_impl * buf, size_t new_size) {
-    if (buf->size >= new_size) { return buf; }  /* no resize needed */
+    /* when resized to smaller, we introduce a new heurstic */
+    /* If the buffer is 64 bytes or smaller, don't shrink */
+    /* Shrink buffer only if target size is smaller than half the original size */
+    if (buf->size >= new_size) {  /* enough room, consider if need to shrink */
+        if (buf->size <= 64) { return buf; }  /* don't shrink if below 64 bytes */
+        if (buf->size < new_size * 2) { return buf; }
+    }
     return _bytes_resize(vm, buf, new_size + BYTES_HEADROOM);
 }
 
@@ -1224,6 +1234,7 @@ void be_load_byteslib(bvm *vm)
         { ".p", NULL },
         { "_buffer", m_buffer },
         { "init", m_init },
+        { "deinit", m_deinit },
         { "tostring", m_tostring },
         { "asstring", m_asstring },
         { "fromstring", m_fromstring },
@@ -1259,6 +1270,7 @@ class be_class_bytes (scope: global, name: bytes) {
     .p, var
     _buffer, func(m_buffer)
     init, func(m_init)
+    deinit, func(m_deinit)
     tostring, func(m_tostring)
     asstring, func(m_asstring)
     fromstring, func(m_fromstring)

--- a/src/be_class.c
+++ b/src/be_class.c
@@ -14,6 +14,7 @@
 #include "be_vm.h"
 #include "be_func.h"
 #include "be_var.h"
+#include <string.h>
 
 #define check_members(vm, c)            \
     if (!(c)->members) {                \
@@ -235,6 +236,20 @@ bbool be_class_newobj(bvm *vm, bclass *c, bvalue *reg, int argc, int mode)
         return btrue;
     }
     return bfalse;
+}
+
+/* Find instance member by name and copy value to `dst` */
+/* Do not look into virtual members */
+int be_instance_member_simple(bvm *vm, binstance *instance, bstring *name, bvalue *dst)
+{
+    int type;
+    be_assert(name != NULL);
+    binstance * obj = instance_member(vm, instance, name, dst);
+    type = var_type(dst);
+    if (obj && type == MT_VARIABLE) {
+        *dst = obj->members[dst->v.i];
+    }
+    return type;
 }
 
 /* Find instance member by name and copy value to `dst` */

--- a/src/be_class.h
+++ b/src/be_class.h
@@ -59,6 +59,7 @@ void be_closure_method_bind(bvm *vm, bclass *c, bstring *name, bclosure *cl);
 int be_class_closure_count(bclass *c);
 void be_class_upvalue_init(bvm *vm, bclass *c);
 bbool be_class_newobj(bvm *vm, bclass *c, bvalue *argv, int argc, int mode);
+int be_instance_member_simple(bvm *vm, binstance *obj, bstring *name, bvalue *dst);
 int be_instance_member(bvm *vm, binstance *obj, bstring *name, bvalue *dst);
 int be_class_member(bvm *vm, bclass *obj, bstring *name, bvalue *dst);
 bbool be_instance_setmember(bvm *vm, binstance *obj, bstring *name, bvalue *src);

--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -458,7 +458,7 @@ static void destruct_object(bvm *vm, bgcobject *obj)
         int type;
         binstance *ins = cast_instance(obj);
         /* does not GC when creating the string "deinit". */
-        type = be_instance_member(vm, ins, str_literal(vm, "deinit"), vm->top);
+        type = be_instance_member_simple(vm, ins, str_literal(vm, "deinit"), vm->top);
         be_incrtop(vm);
         if (basetype(type) == BE_FUNCTION) {
             var_setinstance(vm->top, ins);  /* push instance on stack as arg 1 */

--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -461,7 +461,10 @@ static void destruct_object(bvm *vm, bgcobject *obj)
         type = be_instance_member(vm, ins, str_literal(vm, "deinit"), vm->top);
         be_incrtop(vm);
         if (basetype(type) == BE_FUNCTION) {
-            be_dofunc(vm, vm->top - 1, 1);
+            var_setinstance(vm->top, ins);  /* push instance on stack as arg 1 */
+            be_incrtop(vm);
+            be_dofunc(vm, vm->top - 2, 1);  /* warning, there shoudln't be any exception raised here, or the gc stops */
+            be_stackpop(vm, 1);
         }
         be_stackpop(vm, 1);
     }

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -267,7 +267,7 @@ bbool be_value2bool(bvm *vm, bvalue *v)
 static void obj_method(bvm *vm, bvalue *o, bstring *attr, bvalue *dst)
 {
     binstance *obj = var_toobj(o);
-    int type = be_instance_member(vm, obj, attr, dst);
+    int type = be_instance_member_simple(vm, obj, attr, dst);
     if (basetype(type) != BE_FUNCTION) {
         vm_error(vm, "attribute_error",
             "the '%s' object has no method '%s'",


### PR DESCRIPTION
## Description:

Now `bytes()` allocated are taken into account in the gc memory usage.

Also fixed gc's call to `deinit()` that wouldn't pass the instance as argument.

Before:
```
> import gc
> def mem() gc.collect() return gc.allocated() end
> mem()
2510

> b=bytes().resize(2000)

> mem()
2672           # the 2KB are not taken into account

> b=nil
> mem()
2640
```

After
```
> import gc
> def mem() gc.collect() return gc.allocated() end
> mem()
2510

> b=bytes().resize(2000)
> mem()
4652           # increase Berry of heap size

> b=nil
> mem()
2576           # `b` is garbage collected and buffer freed
```
