### PR TITLE
Improved solidify

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -1105,6 +1105,7 @@ be_local_closure(getbits,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
+    0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
@@ -1164,6 +1165,7 @@ be_local_closure(setbits,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     4,                          /* argc */
+    0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */

--- a/src/be_constobj.h
+++ b/src/be_constobj.h
@@ -37,12 +37,17 @@ extern "C" {
     .type = BE_FUNCTION                                         \
 }
 
+#define be_const_nil() {                                        \
+    .v.i = 0,                                                   \
+    .type = BE_NIL                                              \
+}
+
 #define be_const_int(_val) {                                    \
     .v.i = (bint)(_val),                                        \
     .type = BE_INT                                              \
 }
 
-#define be_const_var(_val) {                                    \
+#define be_const_var(_val) {                                  \
     .v.i = (bint)(_val),                                        \
     .type = BE_INDEX                                            \
 }
@@ -50,6 +55,16 @@ extern "C" {
 #define be_const_real(_val) {                                   \
     .v.r = (breal)(_val),                                       \
     .type = BE_REAL                                             \
+}
+
+#define be_const_real_hex(_val) {                               \
+    .v.p = (void*)(_val),                                       \
+    .type = BE_REAL                                             \
+}
+
+#define be_const_bool(_val) {                                   \
+    .v.b = (bbool)(_val),                                       \
+    .type = BE_BOOL                                             \
 }
 
 #define be_const_str(_str) {                                    \
@@ -93,6 +108,15 @@ const bclass _name = {                                          \
     .name = (bstring*)&be_const_str_##_name_                    \
 }
 
+#define be_define_const_empty_class(_name, _super, _name_)      \
+const bclass _name = {                                          \
+    be_const_header(BE_CLASS),                                  \
+    .nvar = 0,                                                  \
+    .super = (bclass*)_super,                                   \
+    .members = NULL,                                            \
+    .name = (bstring*)&be_const_str_##_name_                    \
+}
+
 #define be_define_const_module(_name, _name_)                   \
 const bmodule _name = {                                         \
     be_const_header(BE_MODULE),                                 \
@@ -118,6 +142,39 @@ const bntvmodule be_native_module(_module) = {                  \
     .init = _init                                               \
 }
 
+/* defines needed for solidified classes */
+#define be_local_class(_name, _nvar, _super, _map, _cname)      \
+  const bclass be_class_##_name = {                             \
+    be_const_header(BE_CLASS),                                  \
+    .nvar = _nvar,                                              \
+    .super = (bclass*)_super,                                   \
+    .members = (bmap*)_map,                                     \
+    .name = _cname                                              \
+}
+
+#define be_nested_map(_size, _slots)                            \
+  & (const bmap) {                                              \
+    be_const_header(BE_MAP),                                    \
+    .slots = _slots,                                            \
+    .lastfree = NULL,                                           \
+    .size = _size,                                              \
+    .count = _size                                              \
+  }
+
+#define be_nested_string(_str, _hash, _len)                     \
+  {                                                             \
+    { .s=(be_nested_const_str(_str, _hash, _len ))              \
+    },                                                          \
+    BE_STRING                                                   \
+  }
+
+#define be_nested_key(_str, _hash, _len, _next)                 \
+  {                                                             \
+    { .s=(be_nested_const_str(_str, _hash, _len )) },           \
+    BE_STRING,                                                  \
+    (uint32_t)(_next) & 0xFFFFFF                                \
+  }
+
 #else
 
 #define be_const_key(_str, _next) {                             \
@@ -131,18 +188,33 @@ const bntvmodule be_native_module(_module) = {                  \
     BE_FUNCTION                                                 \
 }
 
+#define be_const_nil() {                                        \
+    bvaldata(0),                                                \
+    BE_NIL                                                      \
+}
+
 #define be_const_int(_val) {                                    \
     bvaldata(bint(_val)),                                       \
     BE_INT                                                      \
 }
 
-#define be_const_var(_val) {                                    \
+#define be_const_bool(_val) {                                   \
+    bvaldata(bbool(_val)),                                      \
+    BE_BOOL                                                     \
+}
+
+#define be_const_var(_val) {                                  \
     bvaldata(bint(_val)),                                       \
     BE_INDEX                                                    \
 }
 
 #define be_const_real(_val) {                                   \
     bvaldata(breal(_val)),                                      \
+    BE_REAL                                                     \
+}
+
+#define be_const_real_hex(_val) {                               \
+    bvaldata((void*)(_val)),                                    \
     BE_REAL                                                     \
 }
 
@@ -176,7 +248,13 @@ const bmap _name(                                               \
 
 #define be_define_const_class(_name, _nvar, _super, _name_)     \
 const bclass _name(                                             \
-    _nvar, _super, (bmap*)&_name##_map,                         \
+    _nvar, (bclass*)_super, (bmap*)&_name##_map,                         \
+    (bstring*)&be_const_str_##_name_                            \
+)
+
+#define be_define_const_empty_class(_name, _super, _name_)      \
+const bclass _name(                                             \
+    0, (bclass*)_super, NULL,                                            \
     (bstring*)&be_const_str_##_name_                            \
 )
 

--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -32,17 +32,57 @@
         be_writestring(__lbuf);         \
     } while (0)
 
-/* output only valid types for ktab, or NULL */
-static const char * m_type_ktab(int type)
+static void m_solidify_bvalue(bvm *vm, bvalue * value)
 {
-    switch (type){
-        case BE_NIL:    return "BE_NIL";
-        case BE_INT:    return "BE_INT";
-        case BE_INDEX:  return "BE_INDEX";
-        case BE_REAL:   return "BE_REAL";
-        case BE_BOOL:   return "BE_BOOL";
-        case BE_STRING: return "BE_STRING";
-        default:        return NULL;
+    int type = var_type(value);
+    switch (type) {
+    case BE_NIL:
+        logfmt("be_const_nil()");
+        break;
+    case BE_BOOL:
+        logfmt("be_const_bool(%i)", var_tobool(value));
+        break;
+    case BE_INT:
+#if BE_INTGER_TYPE == 2
+        logfmt("be_const_int(%lli)", var_toint(value));
+#else
+        logfmt("be_const_int(%i)", var_toint(value));
+#endif
+        break;
+    case BE_INDEX:
+#if BE_INTGER_TYPE == 2
+        logfmt("be_const_var(%lli)", var_toint(value));
+#else
+        logfmt("be_const_var(%i)", var_toint(value));
+#endif
+        break;
+    case BE_REAL:
+#if BE_USE_SINGLE_FLOAT
+        logfmt("be_const_real_hex(0x%08X)", (uint32_t) var_toobj(value));
+#else
+        logfmt("be_const_real_hex(0x%016llX)", (uint64_t) var_toobj(value));
+#endif
+        break;
+    case BE_STRING:
+        {
+            logfmt("be_nested_string(\"");
+            be_writestring(str(var_tostr(value)));
+            size_t len = strlen(str(var_tostr(value)));
+            if (len >= 255) {
+                be_raise(vm, "internal_error", "Strings greater than 255 chars not supported yet");
+            }
+            logfmt("\", %i, %zu)", be_strhash(var_tostr(value)), len >= 255 ? 255 : len);
+        }
+        break;
+    case BE_CLOSURE:
+        logfmt("be_const_closure(%s_closure)", str(((bclosure*) var_toobj(value))->proto->name));
+        break;
+    default:
+        {
+            char error[64];
+            snprintf(error, sizeof(error), "Unsupported type in function constants: %i", type);
+            be_raise(vm, "internal_error", error);
+        }
     }
 }
 
@@ -56,6 +96,7 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
 
     logfmt("%*s%d,                          /* nstack */\n", indent, "", pr->nstack);
     logfmt("%*s%d,                          /* argc */\n", indent, "", pr->argc);
+    logfmt("%*s%d,                          /* varg */\n", indent, "", pr->varg);
     logfmt("%*s%d,                          /* has upvals */\n", indent, "", (pr->nupvals > 0) ? 1 : 0);
 
     if (pr->nupvals > 0) {
@@ -70,13 +111,15 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
 
     logfmt("%*s%d,                          /* has sup protos */\n", indent, "", (pr->nproto > 0) ? 1 : 0);
     if (pr->nproto > 0) {
+        logfmt("%*s( &(const struct bproto*[%2d]) {\n", indent, "", pr->nproto);
         for (int32_t i = 0; i < pr->nproto; i++) {
             size_t sub_len = strlen(func_name) + 10;
             char sub_name[sub_len];
             snprintf(sub_name, sizeof(sub_name), "%s_%d", func_name, i);
-            m_solidify_proto(vm, pr->ptab[i], sub_name, builtins, indent);
+            m_solidify_proto(vm, pr->ptab[i], sub_name, builtins, indent+2);
             logfmt(",\n");
         }
+        logfmt("%*s}),\n", indent, "");
     } else {
         logfmt("%*sNULL,                       /* no sub protos */\n", indent, "");
     }
@@ -85,32 +128,9 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
     if (pr->nconst > 0) {
         logfmt("%*s( &(const bvalue[%2d]) {     /* constants */\n", indent, "", pr->nconst);
         for (int k = 0; k < pr->nconst; k++) {
-            int type = pr->ktab[k].type;
-            const char *type_name = m_type_ktab(type);
-            if (type_name == NULL) {
-                char error[64];
-                snprintf(error, sizeof(error), "Unsupported type in function constants: %i", type);
-                be_raise(vm, "internal_error", error);
-            }
-            if (type == BE_STRING) {
-                logfmt("%*s  { { .s=be_nested_const_str(\"", indent, "");
-                be_writestring(str(pr->ktab[k].v.s));
-                size_t len = strlen(str(pr->ktab[k].v.s));
-                if (len >= 255) {
-                    be_raise(vm, "internal_error", "Strings greater than 255 chars not supported yet");
-                }
-                logfmt("\", %i, %zu) }, %s},\n", be_strhash(pr->ktab[k].v.s), len >= 255 ? 255 : len, type_name);
-            } else if (type == BE_INT || type == BE_INDEX) {
-                logfmt("%*s  { { .i=%" BE_INT_FMTLEN "i }, %s},\n", indent, "", pr->ktab[k].v.i, type_name);
-            } else if (type == BE_REAL) {
-    #if BE_USE_SINGLE_FLOAT
-                logfmt("%*s  { { .p=(void*)0x%08X }, %s},\n", indent, "", (uint32_t) pr->ktab[k].v.p, type_name);
-    #else
-                logfmt("%*s  { { .p=(void*)0x%016llX }, %s},\n", indent, "", (uint64_t) pr->ktab[k].v.p, type_name);
-    #endif
-            } else if (type == BE_BOOL) {
-                logfmt("%*s  { { .b=%i }, %s},\n", indent, "", pr->ktab[k].v.b, type_name);
-            }
+            logfmt("%*s/* K%-3d */  ", indent, "", k);
+            m_solidify_bvalue(vm, &pr->ktab[k]);
+            logfmt(",\n");
         }
         logfmt("%*s}),\n", indent, "");
     } else {
@@ -167,6 +187,78 @@ static void m_solidify_closure(bvm *vm, bclosure *cl, int builtins)
     logfmt("/*******************************************************************/\n\n");
 }
 
+
+static void m_solidify_class(bvm *vm, bclass *cl, int builtins)
+{
+    const char * class_name = str(cl->name);
+
+    /* iterate on members to dump closures */
+    if (cl->members) {
+        bmapnode *node;
+        bmapiter iter = be_map_iter();
+        while ((node = be_map_next(cl->members, &iter)) != NULL) {
+            if (var_isstr(&node->key) && var_isclosure(&node->value)) {
+                bclosure *f = var_toobj(&node->value);
+                m_solidify_closure(vm, f, builtins);
+            }
+        }
+    }
+
+
+    logfmt("\n");
+    logfmt("/********************************************************************\n");
+    logfmt("** Solidified class: %s\n", class_name);
+    logfmt("********************************************************************/\n");
+
+    if (cl->super) {
+        logfmt("extern const bclass be_class_%s;\n", str(cl->super->name));
+    }
+
+    logfmt("be_local_class(%s,\n", class_name);
+    logfmt("    %i,\n", cl->nvar);
+    if (cl->super) {
+        logfmt("    &be_class_%s,\n", str(cl->super->name));
+    } else {
+        logfmt("    NULL,\n");
+    }
+
+    if (cl->members) {
+        logfmt("    be_nested_map(%i,\n", cl->members->count);
+
+        logfmt("    ( (struct bmapnode*) &(const bmapnode[]) {\n");
+        for (int i = 0; i < cl->members->count; i++) {
+            bmapnode * node = &cl->members->slots[i];
+            if (node->key.type != BE_STRING) {
+                char error[64];
+                snprintf(error, sizeof(error), "Unsupported type in key: %i", node->key.type);
+                be_raise(vm, "internal_error", error);
+            }
+            int key_next = node->key.next;
+            size_t len = strlen(str(node->key.v.s));
+            if (0xFFFFFF == key_next) {
+                key_next = -1;      /* more readable */
+            }
+            logfmt("        { be_nested_key(\"%s\", %i, %zu, %i), ", str(node->key.v.s), be_strhash(node->key.v.s), len >= 255 ? 255 : len, key_next);
+            m_solidify_bvalue(vm, &node->value);
+
+            logfmt(" },\n");
+        }
+        logfmt("    })),\n");
+    } else {
+        logfmt("    NULL,\n");
+    }
+
+    logfmt("    (be_nested_const_str(\"%s\", %i, %i))\n", class_name, be_strhash(cl->name), str_len(cl->name));
+    logfmt(");\n");
+    logfmt("/*******************************************************************/\n\n");
+
+    logfmt("void be_load_%s_class(bvm *vm) {\n", class_name);
+    logfmt("    be_pushntvclass(vm, &be_class_%s);\n", class_name);
+    logfmt("    be_setglobal(vm, \"%s\");\n", class_name);
+    logfmt("    be_pop(vm, 1);\n");
+    logfmt("}\n");
+}
+
 #define be_builtin_count(vm) \
     be_vector_count(&(vm)->gbldesc.builtin.vlist)
 
@@ -176,6 +268,8 @@ static int m_dump(bvm *vm)
         bvalue *v = be_indexof(vm, 1);
         if (var_isclosure(v)) {
             m_solidify_closure(vm, var_toobj(v), be_builtin_count(vm));
+        } else if (var_isclass(v)) {
+            m_solidify_class(vm, var_toobj(v), be_builtin_count(vm));
         }
     }
     be_return_nil(vm);

--- a/src/berry.h
+++ b/src/berry.h
@@ -329,7 +329,7 @@ typedef struct bntvmodule {
   }
 
 /* new version for more compact literals */
-#define be_nested_proto(_nstack, _argc, _has_upval, _upvals, _has_subproto, _protos, _has_const, _ktab, _fname, _source, _code)     \
+#define be_nested_proto(_nstack, _argc, _varg, _has_upval, _upvals, _has_subproto, _protos, _has_const, _ktab, _fname, _source, _code)     \
   & (const bproto) {                                                              \
     NULL,                       /* bgcobject *next */                             \
     BE_PROTO,                   /* type BE_PROTO */                               \
@@ -337,7 +337,7 @@ typedef struct bntvmodule {
     (_nstack),                  /* nstack */                                      \
     BE_IIF(_has_upval)(sizeof(*_upvals)/sizeof(bupvaldesc),0),  /* nupvals */     \
     (_argc),                    /* argc */                                        \
-    0,                          /* varg */                                        \
+    (_varg),                    /* varg */                                        \
     NULL,                       /* bgcobject *gray */                             \
     (bupvaldesc*) _upvals,      /* bupvaldesc *upvals */                          \
     (bvalue*) _ktab,            /* ktab */                                        \
@@ -365,7 +365,7 @@ typedef struct bntvmodule {
 
 /* new version for more compact literals */
 #define be_local_closure(_name, _proto)       \
-  const bclosure _name##_closure = {          \
+  static const bclosure _name##_closure = {   \
     NULL,           /* bgcobject *next */     \
     BE_CLOSURE,     /* type BE_CLOSURE */     \
     GC_CONST,       /* marked GC_CONST */     \


### PR DESCRIPTION
Improved module `solidify` to be on par with Tasmota's.

Now supports solidification of a complete task in a single step. Example:

```
class A
  var a, b
  static c = "foo"
  static d = / x -> x + 10
  def f(x)
    print(x)
  end
end

import solidify
solidify.dump(A)
```

Result:
```
/********************************************************************
** Solidified function: f
********************************************************************/
be_local_closure(f,   /* name */
  be_nested_proto(
    4,                          /* nstack */
    2,                          /* argc */
    0,                          /* varg */
    0,                          /* has upvals */
    NULL,                       /* no upvals */
    0,                          /* has sup protos */
    NULL,                       /* no sub protos */
    0,                          /* has constants */
    NULL,                       /* no const */
    (be_nested_const_str("f", -485742695, 1)),
    (be_nested_const_str("stdin", -1529146723, 5)),
    ( &(const binstruction[ 4]) {  /* code */
      0x6008000F,  //  0000  GETGBL	R2	G15
      0x5C0C0200,  //  0001  MOVE	R3	R1
      0x7C080200,  //  0002  CALL	R2	1
      0x80000000,  //  0003  RET	0
    })
  )
);
/*******************************************************************/


/********************************************************************
** Solidified function: <lambda>
********************************************************************/
be_local_closure(<lambda>,   /* name */
  be_nested_proto(
    2,                          /* nstack */
    1,                          /* argc */
    0,                          /* varg */
    0,                          /* has upvals */
    NULL,                       /* no upvals */
    0,                          /* has sup protos */
    NULL,                       /* no sub protos */
    0,                          /* has constants */
    NULL,                       /* no const */
    (be_nested_const_str("<lambda>", 607256038, 8)),
    (be_nested_const_str("stdin", -1529146723, 5)),
    ( &(const binstruction[ 3]) {  /* code */
      0x54060009,  //  0000  LDINT	R1	10
      0x00040001,  //  0001  ADD	R1	R0	R1
      0x80040200,  //  0002  RET	1	R1
    })
  )
);
/*******************************************************************/


/********************************************************************
** Solidified class: A
********************************************************************/
be_local_class(A,
    2,
    NULL,
    be_nested_map(5,
    ( (struct bmapnode*) &(const bmapnode[]) {
        { be_nested_key("a", -468965076, 1, -1), be_const_var(0) },
        { be_nested_key("f", -485742695, 1, -1), be_const_closure(f_closure) },
        { be_nested_key("b", -418632219, 1, -1), be_const_var(1) },
        { be_nested_key("c", -435409838, 1, 4), be_nested_string("foo", -1443660073, 3) },
        { be_nested_key("d", -519297933, 1, -1), be_const_closure(<lambda>_closure) },
    })),
    (be_nested_const_str("A", -1005848884, 1))
);
/*******************************************************************/

void be_load_A_class(bvm *vm) {
    be_pushntvclass(vm, &be_class_A);
    be_setglobal(vm, "A");
    be_pop(vm, 1);
}
```
