### PR TITLE
Fix bytecode for class static members

### DIFF
--- a/tools/grammar/berry.bytecode
+++ b/tools/grammar/berry.bytecode
@@ -80,7 +80,7 @@ class:
     method_count: 4   -- number of method
     method_table: [
             string    -- method name
-            function  -- method function body
+            function | nil  -- method function body or nil (static member) if the first byte is null (which would be an empty func name)
         ](method_count)
     member_index_table -> [
             string    -- member name


### PR DESCRIPTION
I forgot to change bytecode to handle class static members. The change is backwards compatible with already compiled code.

In the list of methods, if the first byte is zero (which would indicate an invalid empty function name), the member is `nil` and considered a class static member.