### PR TITLE
Customize constant search size

### DIFF
--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -80,6 +80,16 @@
  **/
 #define BE_STACK_FREE_MIN               10
 
+/* Macro: BE_CONST_SEARCH_SIZE
+ * Constants in function are limited to 255. However the compiler
+ * will look for a maximum of pre-existing constants to avoid
+ * performance degradation. This may cause the number of constants
+ * to be higher than required.
+ * Increase is you need to solidify functions.
+ * Default: 50
+ **/
+#define BE_CONST_SEARCH_SIZE            50
+
 /* Macro: BE_STACK_FREE_MIN
  * The short string will hold the hash value when the value is
  * true. It may be faster but requires more RAM.

--- a/src/be_code.c
+++ b/src/be_code.c
@@ -251,7 +251,7 @@ static int newconst(bfuncinfo *finfo, bvalue *k)
 }
 
 /* Find constant by value and return constant number, or -1 if constant does not exist */
-/* The search is linear and lilited to 50 elements for performance reasons */
+/* The search is linear and limited to BE_CONST_SEARCH_SIZE elements for performance reasons */
 static int findconst(bfuncinfo *finfo, bexpdesc *e)
 {
     int i, count = be_vector_count(&finfo->kvec);
@@ -260,7 +260,7 @@ static int findconst(bfuncinfo *finfo, bexpdesc *e)
      * so only search the constant table for the
      * previous value.
      **/
-    count = count < 50 ? count : 50;
+    count = count < BE_CONST_SEARCH_SIZE ? count : BE_CONST_SEARCH_SIZE;
     for (i = 0; i < count; ++i) {
         bvalue *k = be_vector_at(&finfo->kvec, i);
         switch (e->type) {


### PR DESCRIPTION
I needed to increase the constant search size when solidifying functions to avoid constant duplicates. Instead of patching the code I propose to make it a compile option.