### PR TITLE
introspect.vcall()

### DIFF
--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -76,12 +76,62 @@ static int m_setmember(bvm *vm)
     be_return_nil(vm);
 }
 
+/* call a function with variable number of arguments */
+/* first argument is a callable object (function, closure, native function, native closure) */
+/* then all subsequent arguments are pushed except the last one */
+/* If the last argument is a 'list', then all elements are pushed as arguments */
+/* otherwise the last argument is pushed as well */
+static int m_vcall(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1 && be_isfunction(vm, 1)) {
+        size_t arg_count = top - 1;  /* we have at least 'top - 1' arguments */
+        /* test if last argument is a list */
+
+        if (top > 1 && be_isinstance(vm, top) && be_getmember(vm, top, ".p") && be_islist(vm, top + 1)) {
+            int32_t list_size = be_data_size(vm, top + 1);
+
+            if (list_size > 0) {
+                be_stack_require(vm, list_size + 3);   /* make sure we don't overflow the stack */
+                for (int i = 0; i < list_size; i++) {
+                    be_pushnil(vm);
+                }
+                be_moveto(vm, top + 1, top + 1 + list_size);
+                be_moveto(vm, top, top + list_size);
+
+                be_refpush(vm, -2);
+                be_pushiter(vm, -1);
+                while (be_iter_hasnext(vm, -2)) {
+                    be_iter_next(vm, -2);
+                    be_moveto(vm, -1, top);
+                    top++;
+                    be_pop(vm, 1);
+                }
+                be_pop(vm, 1);  /* remove iterator */
+                be_refpop(vm);
+            }
+            be_pop(vm, 2);
+            arg_count = arg_count - 1 + list_size;
+        }
+        /* actual call */
+        be_call(vm, arg_count);
+        /* remove args */
+        be_pop(vm, arg_count);
+        /* return value */
+
+        be_return(vm);
+    }
+    be_raise(vm, "value_error", "first argument must be a function");
+    be_return_nil(vm);
+}
+
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(introspect) {
     be_native_module_function("members", m_attrlist),
 
     be_native_module_function("get", m_findmember),
     be_native_module_function("set", m_setmember),
+    be_native_module_function("vcall", m_vcall),
 };
 
 be_define_native_module(introspect, NULL);
@@ -92,6 +142,7 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     get, func(m_findmember)
     set, func(m_setmember)
+    vcall, func(m_vcall)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_introspect.h"

--- a/tests/introspect.be
+++ b/tests/introspect.be
@@ -1,4 +1,4 @@
-#- base64 encode -#
+#- introspect -#
 import introspect
 
 #- test for modules -#

--- a/tests/introspect_vcall.be
+++ b/tests/introspect_vcall.be
@@ -1,0 +1,105 @@
+#- introspect vcall -#
+import introspect
+
+#- -#
+#- witness function dumping first 3 args -#
+#- -#
+def f(a,b,c) return [a,b,c] end
+
+#- simple calls with fixed args -#
+assert(introspect.vcall(f) == [nil, nil, nil])
+assert(introspect.vcall(f, 1) == [1, nil, nil])
+assert(introspect.vcall(f, 1, 2) == [1, 2, nil])
+assert(introspect.vcall(f, 1, 2, 3, 4) == [1, 2, 3])
+
+#- call with var args -#
+assert(introspect.vcall(f, []) == [nil, nil, nil])
+assert(introspect.vcall(f, [1]) == [1, nil, nil])
+assert(introspect.vcall(f, [1, 2]) == [1, 2, nil])
+assert(introspect.vcall(f, [1, 2, 3, 4]) == [1, 2, 3])
+
+#- mixed args -#
+assert(introspect.vcall(f, 1, []) == [1, nil, nil])
+assert(introspect.vcall(f, 1, [2]) == [1, 2, nil])
+assert(introspect.vcall(f, 1, [2, "foo", 4]) == [1, 2, "foo"])
+
+#- non terminal list -#
+assert(introspect.vcall(f, 1, [2, 3, 4], "foo") == [1, [2, 3, 4], "foo"])
+
+#- -#
+#- same tests with vararg function -#
+#- -#
+def g(a, *b)
+    if   size(b) == 0 return [a, nil, nil]
+    elif size(b) == 1 return [a, b[0], nil]
+    elif size(b) > 1  return [a, b[0], b[1]]
+    end
+end
+
+#- simple calls with fixed args -#
+assert(introspect.vcall(g) == [nil, nil, nil])
+assert(introspect.vcall(g, 1) == [1, nil, nil])
+assert(introspect.vcall(g, 1, 2) == [1, 2, nil])
+assert(introspect.vcall(g, 1, 2, 3, 4) == [1, 2, 3])
+
+#- call with var args -#
+assert(introspect.vcall(g, []) == [nil, nil, nil])
+assert(introspect.vcall(g, [1]) == [1, nil, nil])
+assert(introspect.vcall(g, [1, 2]) == [1, 2, nil])
+assert(introspect.vcall(g, [1, 2, 3, 4]) == [1, 2, 3])
+
+#- mixed args -#
+assert(introspect.vcall(g, 1, []) == [1, nil, nil])
+assert(introspect.vcall(g, 1, [2]) == [1, 2, nil])
+assert(introspect.vcall(g, 1, [2, "foo", 4]) == [1, 2, "foo"])
+
+#- non terminal list -#
+assert(introspect.vcall(g, 1, [2, 3, 4], "foo") == [1, [2, 3, 4], "foo"])
+
+#- -#
+#- test with vararg only -#
+#- -#
+def c(*a) return size(a) end
+
+#- simple calls with fixed args -#
+assert(introspect.vcall(c) == 0)
+assert(introspect.vcall(c, 1) == 1)
+assert(introspect.vcall(c, 1, 2) == 2)
+assert(introspect.vcall(c, 1, 2, 3, 4) == 4)
+
+#- call with var args -#
+assert(introspect.vcall(c, []) == 0)
+assert(introspect.vcall(c, [1]) == 1)
+assert(introspect.vcall(c, [1, 2]) == 2)
+assert(introspect.vcall(c, [1, 2, 3, 4]) == 4)
+
+#- mixed args -#
+assert(introspect.vcall(c, 1, []) == 1)
+assert(introspect.vcall(c, 1, [2]) == 2)
+assert(introspect.vcall(c, 1, [2, "foo", 4]) == 4)
+
+#- non terminal list -#
+assert(introspect.vcall(c, 1, [2, 3, 4], "foo") == 3)
+
+#- -#
+#- test with native function -#
+#- -#
+import string
+
+assert(introspect.vcall(string.format, "a") == "a")
+assert(introspect.vcall(string.format, "%i", 1) == "1")
+assert(introspect.vcall(string.format, "%i - %i", 1, 2) == "1 - 2")
+
+assert(introspect.vcall(string.format, "%i - %i", [1, 2]) == "1 - 2")
+assert(introspect.vcall(string.format, "%i - %i", [1, 2, 3]) == "1 - 2")
+
+assert(introspect.vcall(string.format, "%i - %i", 1, [1, 2, 3]) == "1 - 1")
+
+#- -#
+#- try with an insanely high number of arguments to check that we don't blow up the stack -#
+#- -#
+l50 = []
+for i:1..50 l50.push(i) end
+
+assert(introspect.vcall(g, l50) == [1, 2, 3])
+assert(introspect.vcall(c, l50) == 50)


### PR DESCRIPTION
Better handling of vararg calls, that now work when called from native call with `be_call()`. Previously it would work only in VM with CALL opcode.

Added `introspect.vcall()` as the reverse of vararg. It allows to call a function with a dynamic number of arguments:

```
import introspect
introspect.vcall(<function> [,<statis_arg>]* [, <list<args>>]?) 
```

The first argument needs to be a callable object (function, closure, native function). All subsequent arguments are pushed as static arguments. If the last argument is a `list`, all elements are pushed as elementary arguments.

Example:
```
introspect.vcall(f)                # equivalent to f()
introspect.vcall(f, 1, 2)          # equivalent to f(1,2)
introspect.vcall(f, 1, [2, 3, 4])  # equivalent to f(1, 2, 3, 4)
introspect.vcall(f, [])            # equivalent to f()
```

Example, inserting a prefix to `string.format`:
```
def format2(fmt, *args)
  import string
  import introspect
  fmt = ">>> "..fmt   #- add prefix -#
  return introspect.vcall(string.format, fmt, args)
end

print(format2("a=%i b=%i", 1, 2))    # prints '>>> a=1 b=2'
```