### PR TITLE
Changed `list.find()` to more intuitive behavior

### DIFF
--- a/src/be_listlib.c
+++ b/src/be_listlib.c
@@ -209,15 +209,31 @@ static int m_item(bvm *vm)
 
 static int m_find(bvm *vm)
 {
+    bbool found = bfalse;
+    int idx;
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 2);
-    if (be_isint(vm, 2)) {
-        be_pushvalue(vm, 2);
-        if (be_getindex(vm, -2)) {
-            be_return(vm);
+    list_check_ref(vm);
+    be_refpush(vm, 1);
+    be_pushiter(vm, -1);
+    for (idx=0; be_iter_hasnext(vm, -2); idx++) {
+        be_iter_next(vm, -2);
+        be_pushvalue(vm, 2);    /* push needle to compare */
+        if (be_iseq(vm)) {
+            found = btrue;
+            be_pop(vm, 2);
+            break;
         }
+        be_pop(vm, 2);
     }
-    be_return_nil(vm);
+    be_pop(vm, 1); /* pop iterator */
+    be_refpop(vm);
+    if (found) {
+        be_pushint(vm, idx);
+        be_return(vm);
+    } else {
+        be_return_nil(vm);
+    }
 }
 
 static int m_setitem(bvm *vm)

--- a/tests/list.be
+++ b/tests/list.be
@@ -72,3 +72,33 @@ assert(l2 == [2, 3])
 assert(l1+[2] == [0, 1, 2])
 assert([-1]+l1 == [-1, 0, 1])
 assert(l1 == [0, 1])
+
+#- find -#
+#- if no argument return nil -#
+assert([].find() == nil)
+assert([1,2].find() == nil)
+assert([1,1,nil,2].find() == nil)
+
+#- nil if not found -#
+assert([1,2].find(3) == nil)
+assert([1,2].find(true) == nil)
+assert([1,2].find('foo') == nil)
+
+#- if found -#
+assert([1,2,3,4].find(1) == 0)
+assert([1,2,3,4].find(2) == 1)
+assert([1,2,3,4].find(3) == 2)
+assert([1,2,3,4].find(4) == 3)
+assert([1,2,"foo",4].find('foo') == 2)
+
+#- if multiple occurrences -#
+assert([1,1,2,2].find(1) == 0)
+assert([1,1,2,2].find(2) == 2)
+
+#- look for nil -#
+assert([1,1,nil,2].find(nil) == 2)
+
+#- sub-structure -#
+assert([1,[1,nil,2],3,[3]].find(3) == 2)
+assert([1,[1,nil,2],3,[3]].find([3]) == 3)
+assert([1,[1,nil,2],3,[3]].find([1,nil,2]) == 1)


### PR DESCRIPTION
I initially added `list.find()` as an equivalent of `map.find()`, i.e. the equivalent of `list.item(i)` that returns `nil` instead of an exception when the index is invalid.

I find now that it is completely unintuitive, and propose to replace with a proper find-in-list function. I.e. find the first element equal to a specific value and return its index.

```
> l = [ 'a', 'b', 'c' ]
> l.find('a')
0
> l.find('b')
1
> l.find('foo')

```