### PR TITLE
Preserve builtins order

### DIFF
--- a/src/be_baselib.c
+++ b/src/be_baselib.c
@@ -455,6 +455,11 @@ void be_load_baselib(bvm *vm)
     be_regfunc(vm, "issubclass", l_issubclass);
     be_regfunc(vm, "isinstance", l_isinstance);
     be_regfunc(vm, "__iterator__", l_iterator);
+}
+
+/* call must be added later to respect order of builtins */
+void be_load_baselib_call(bvm *vm)
+{
     be_regfunc(vm, "call", l_call);
 }
 #else
@@ -482,12 +487,12 @@ vartab m_builtin (scope: local) {
     issubclass, func(l_issubclass)
     isinstance, func(l_isinstance)
     __iterator__, func(l_iterator)
-    call, func(l_call)
     open, func(be_nfunc_open)
     list, class(be_class_list)
     map, class(be_class_map)
     range, class(be_class_range)
     bytes, class(be_class_bytes)
+    call, func(l_call)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_m_builtin.h"

--- a/src/be_libs.c
+++ b/src/be_libs.c
@@ -8,6 +8,7 @@
 #include "be_libs.h"
 
 extern void be_load_baselib(bvm *vm);
+extern void be_load_baselib_call(bvm *vm);
 extern void be_load_listlib(bvm *vm);
 extern void be_load_maplib(bvm *vm);
 extern void be_load_rangelib(bvm *vm);
@@ -23,5 +24,6 @@ void be_loadlibs(bvm *vm)
     be_load_rangelib(vm);
     be_load_filelib(vm);
     be_load_byteslib(vm);
+    be_load_baselib_call(vm);
 #endif
 }

--- a/tools/coc/block_builder.cpp
+++ b/tools/coc/block_builder.cpp
@@ -33,10 +33,12 @@ block_builder::block_builder(const object_block *object, const macro_table *macr
             m_strtab.push_back(it->second);
         }
         
-        for (auto i : object->data) {
-            if (i.second.depend.empty() || macro->query(i.second.depend)) {
-                m_block.data[i.first] = i.second.value;
-                m_strtab.push_back(i.first);
+        for (auto key : object->data_ordered) {
+            auto second = object->data.at(key);
+            if (second.depend.empty() || macro->query(second.depend)) {
+                m_block.data[key] = second.value;
+                m_strtab.push_back(key);
+                m_block.data_ordered.push_back(key);  /* record insertion order */
             }
         }
     }
@@ -106,10 +108,9 @@ std::string block_builder::vartab_tostring(const block &block)
 
     idxblk = block;
     idxblk.data.clear();
-    for (auto it : block.data) {
-        varvec.push_back(it.second);
-        it.second = "int(" + std::to_string(index++) + ")";
-        idxblk.data.insert(it);
+    for (auto key : block.data_ordered) {
+        varvec.push_back(block.data.at(key));
+        idxblk.data[key] = "int(" + std::to_string(index++) + ")";
     }
 
     ostr << map_tostring(idxblk, block.name + "_map", true) << std::endl;

--- a/tools/coc/block_builder.h
+++ b/tools/coc/block_builder.h
@@ -28,6 +28,7 @@ private:
         std::string name;
         std::map<std::string, std::string> attr;
         std::map<std::string, std::string> data;
+        std::vector<std::string> data_ordered;  /* used to retrieve in insertion order */
     };
 
     std::string block_tostring(const block &block);

--- a/tools/coc/coc_parser.cpp
+++ b/tools/coc/coc_parser.cpp
@@ -186,4 +186,5 @@ void coc_parser::parse_body_item(object_block *object)
     if (parse_char_continue(','))
         value.depend = parse_tonewline();
     object->data[key] = value;
+    object->data_ordered.push_back(key);
 }

--- a/tools/coc/object_block.h
+++ b/tools/coc/object_block.h
@@ -20,6 +20,7 @@ struct object_block {
     std::string name;
     std::map<std::string, std::string> attr;
     std::map<std::string, data_value> data;
+    std::vector<std::string> data_ordered;  /* preserve order of keys */
 };
 
 #endif


### PR DESCRIPTION
Changed COC parser to preserve builtin order (a vector keeps track of insert order, vs alphabetical ordre of C++ map iterator).

When not precompiled, `call` is added after all other builtins.