### PR TITLE
Fix compound assignment

### DIFF
--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -900,10 +900,12 @@ static void suffix_expr(bparser *parser, bexpdesc *e)
 static void suffix_alloc_reg(bparser *parser, bexpdesc *l)
 {
     bfuncinfo *finfo = parser->finfo;
-    bbool suffix = l->type == ETINDEX || l->type == ETMEMBER;
+    bbool is_suffix = l->type == ETINDEX || l->type == ETMEMBER;   /* is suffix */
+    bbool is_suffix_reg = l->v.ss.tt == ETREG || l->v.ss.tt == ETLOCAL || l->v.ss.tt == ETGLOBAL || l->v.ss.tt == ETNGLOBAL;   /* if suffix, does it need a register */
+    bbool is_global = l->type == ETGLOBAL || l->type == ETNGLOBAL;
     /* in the suffix expression, if the object is a temporary
      * variable (l->v.ss.tt == ETREG), it needs to be cached. */
-    if (suffix && l->v.ss.tt == ETREG) {
+    if (is_global || (is_suffix && is_suffix_reg)) {
         be_code_allocregs(finfo, 1);
     }
 }

--- a/tests/compound.be
+++ b/tests/compound.be
@@ -1,0 +1,19 @@
+# test bug in compound statements
+
+a = 0
+assert(a == 0)
+a += 1
+assert(a == 1)
+a += 10/2
+assert(a == 6)
+
+class A var a def init() self.a = 1 end def f(x) self.a+=x/2 end def g(x) self.a = self.a + x/2 end end
+
+a = A()
+assert(a.a == 1)
+a.f(10)
+assert(a.a == 6)
+b=A()
+assert(b.a == 1)
+b.g(10)
+assert(b.a == 6)


### PR DESCRIPTION
Fix compiler error in compound assignment when right side is computed.

```
> a = 0
> code = compile("a += 10/2")
> import debug
> debug.codedump(code)
source 'string', function 'main':
; line 1
  0000  LDINT	R0	10
  0001  DIV	R0	R0	K0
  0002  GETGBL	R0	G24
  0003  ADD	R0	R0	R0
  0004  SETGBL	R0	G24
  0005  RET	0
```

As we can see, both the `a` and the result of the division are stored in `R0` which creates a wrong result. This is due to missing criterias in `suffix_alloc_reg()`

After the fix:

```
> a = 0
> code = compile("a += 10/2")
> import debug
> debug.codedump(code)
source 'string', function 'main':
; line 1
  0000  LDINT	R1	10
  0001  DIV	R1	R1	K0
  0002  GETGBL	R0	G24
  0003  ADD	R0	R0	R1
  0004  SETGBL	R0	G24
  0005  RET	0
```

Now the intermediate register is correctly allocated.

Also added test case.