### PR TITLE
Fix flip

### DIFF
--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -743,7 +743,7 @@ newframe: /* a new call frame */
         opcase(FLIP): {
             bvalue *dst = RA(), *a = RKB();
             if (var_isint(a)) {
-                var_setint(dst, -a->v.i);
+                var_setint(dst, ~a->v.i);
             } else if (var_isinstance(a)) {
                 ins_unop(vm, "~", *RKB());
                 reg = vm->reg;

--- a/tests/bitwise.be
+++ b/tests/bitwise.be
@@ -1,0 +1,14 @@
+# and, or, xor
+a = 11
+assert(a & 0xFE == 10)
+assert(a | 32 == 43)
+assert(a ^ 33 == 42)
+
+# same with literal
+assert(11 & 0xFE == 10)
+assert(11 | 32 == 43)
+assert(11 ^ 33 == 42)
+
+# flip
+assert(~a == -12)
+assert(~11 == -12)


### PR DESCRIPTION
There was a typo in `be_vm.c` and flip was a negate instead of bit flip. It used to work for literal since the bit-flip is done at compile time.

I also added a test case.