### PR TITLE
Add `map.has()`

### DIFF
--- a/src/be_maplib.c
+++ b/src/be_maplib.c
@@ -121,6 +121,15 @@ static int m_find(bvm *vm)
     be_return(vm);
 }
 
+static int m_has(bvm *vm)
+{
+    be_getmember(vm, 1, ".p");
+    map_check_data(vm, 2);
+    be_pushvalue(vm, 2);
+    be_pushbool(vm, be_getindex(vm, -2));
+    be_return(vm);
+}
+
 static int m_insert(bvm *vm)
 {
     bbool res;
@@ -232,6 +241,7 @@ class be_class_map (scope: global, name: map) {
     item, func(m_item)
     setitem, func(m_setitem)
     find, func(m_find)
+    has, func(m_has)
     size, func(m_size)
     insert, func(m_insert)
     iter, func(m_iter)

--- a/tests/mab.be
+++ b/tests/mab.be
@@ -1,0 +1,25 @@
+m = { 'a':1, 'b':3.5, 'c': "foo", 0:1}
+
+assert(type(m) == 'instance')
+assert(classname(m) == 'map')
+
+# accessor
+assert(m['a'] == 1)
+assert(m['b'] == 3.5)
+assert(m['c'] == 'foo')
+assert(m[0] == 1)
+
+# find
+assert(m.find('a') == 1)
+assert(m.find('z') == nil)
+assert(m.find('z', 4) == 4)
+
+# has
+assert(m.has('a'))
+assert(m.has(0))
+assert(!m.has('z'))
+assert(!m.has())
+
+# set
+m['y'] = -1
+assert(m['y'] == -1)


### PR DESCRIPTION
Adding `map.has()` to test if a key exists in a map. Previously it was not possible to distinguish between a key containing `nil` and an absent key.

```
> m = {'a':1, 'b':2}
> m.has('a')
true
> m.has('z')
false
```