### PR TITLE
Fix static initializer for subclass

### DIFF
--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -1420,11 +1420,12 @@ static void classdef_stmt(bparser *parser, bclass *c)
 static void class_inherit(bparser *parser, bexpdesc *e)
 {
     if (next_type(parser) == OptColon) { /* ':' */
+        bexpdesc ec = *e;    /* work on a copy because we preserve original class */
         bexpdesc e1;
         scan_next_token(parser); /* skip ':' */
         expr(parser, &e1);
         check_var(parser, &e1);
-        be_code_setsuper(parser->finfo, e, &e1);
+        be_code_setsuper(parser->finfo, &ec, &e1);
     }
 }
 

--- a/tests/class_const.be
+++ b/tests/class_const.be
@@ -91,3 +91,11 @@ assert(a.f == [1])
 assert(a.g == A.g)
 assert(a.aa == nil)
 assert(a.ab == nil)
+
+#- used to fail for subclasses -#
+class A static a=1 end
+class B:A static a=A def f() end static b=1 static c=A end
+assert(A.a == 1)
+assert(B.a == A)
+assert(B.b == 1)
+assert(B.c == A)


### PR DESCRIPTION
Fix a compiler bug with static initializer in sub-class.

Add test case for it.

The following would fail (now works):

```
class A static a=1 end
class B:A static a=A def f() end static b=1 static c=A end
```