### PR TITLE
Stabilize setmember

### DIFF
--- a/src/be_class.c
+++ b/src/be_class.c
@@ -336,7 +336,7 @@ bbool be_instance_setmember(bvm *vm, binstance *o, bstring *name, bvalue *src)
             vm->top += 4;   /* prevent collection results */
             be_dofunc(vm, top, 3); /* call method 'member' */
             vm->top -= 4;
-            return var_tobool(top);
+            return btrue;
         }
     }
     return bfalse;


### PR DESCRIPTION
Make `setmember()` for virtual members less error-prone (it bit me twice already).

Before: `setmember()` needed to return true to indicate a success and false for a failure.

Now the return value of `setmember()` is ignored, a failure to store the value should raise an exception.