### PR TITLE
Update doc link to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ Berry has the following advantages:
 
 ## Documents
 
-LaTeX documents repository: [https://github.com/Skiars/berry_doc](https://github.com/Skiars/berry_doc)
+Reference Manual: [Wiki](https://github.com/berry-lang/berry/wiki/Reference)
 
-Short Manual: [berry_short_manual.pdf](https://github.com/Skiars/berry_doc/releases/download/latest/berry_short_manual.pdf).
-
-Reference Manual: [berry_rm_en_us.pdf](https://github.com/Skiars/berry_doc/releases/download/latest/berry_rm_en_us.pdf), [berry_rm_zh_cn.pdf](https://github.com/Skiars/berry_doc/releases/download/latest/berry_rm_zh_cn.pdf).
+Short Manual (slightly outdated): [berry_short_manual.pdf](https://github.com/Skiars/berry_doc/releases/download/latest/berry_short_manual.pdf).
 
 Berry's EBNF grammar definition: [tools/grammar/berry.ebnf](./tools/grammar/berry.ebnf)
 


### PR DESCRIPTION
Update link to point to wiki for up to date Reference Manual. I have seen people not finding the new doc.