### PR TITLE
Ability to manipulate comptr

### DIFF
--- a/src/be_baselib.c
+++ b/src/be_baselib.c
@@ -231,6 +231,10 @@ static int l_int(bvm *vm)
             be_pushint(vm, (bint)be_toreal(vm, 1));
         } else if (be_isint(vm, 1)) {
             be_pushvalue(vm, 1);
+        } else if (be_isbool(vm, 1)) {
+            be_pushint(vm, be_tobool(vm, 1) ? 1 : 0);
+        } else if (be_iscomptr(vm, 1)) {
+            be_pushint(vm, (int) be_tocomptr(vm, 1));
         } else {
             be_return_nil(vm);
         }

--- a/src/be_constobj.h
+++ b/src/be_constobj.h
@@ -72,6 +72,11 @@ extern "C" {
     .type = BE_STRING                                           \
 }
 
+#define be_const_comptr(_val) {                                 \
+    .v.c = (const void*)(_val),                                       \
+    .type = BE_COMPTR                                           \
+}
+
 #define be_const_class(_class) {                                \
     .v.c = &(_class),                                           \
     .type = BE_CLASS                                            \
@@ -152,6 +157,14 @@ const bntvmodule be_native_module(_module) = {                  \
     .name = _cname                                              \
 }
 
+/* defines needed for solidified modules */
+#define be_local_module(_c_name, _module_name, _map)            \
+  static const bmodule m_lib##_c_name = {                       \
+    be_const_header(BE_MODULE),                                 \
+    .table = (bmap*)_map,                                       \
+    .info.name = _module_name                                   \
+}
+
 #define be_nested_map(_size, _slots)                            \
   & (const bmap) {                                              \
     be_const_header(BE_MAP),                                    \
@@ -216,6 +229,11 @@ const bntvmodule be_native_module(_module) = {                  \
 #define be_const_real_hex(_val) {                               \
     bvaldata((void*)(_val)),                                    \
     BE_REAL                                                     \
+}
+
+#define be_const_comptr(_val) {                                 \
+    bvaldata((void*)(_val)),                                    \
+    BE_COMPTR                                                   \
 }
 
 #define be_const_str(_string) {                                 \

--- a/src/be_debug.c
+++ b/src/be_debug.c
@@ -178,11 +178,11 @@ static void sourceinfo(bproto *proto, binstruction *ip)
         be_writestring(str(proto->source));
         be_writestring(buf);
     } else {
-        be_writestring("<unknow source>:");
+        be_writestring("<unknown source>:");
     }
 #else
     (void)proto; (void)ip;
-    be_writestring("<unknow source>:");
+    be_writestring("<unknown source>:");
 #endif
 }
 

--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -13,6 +13,8 @@
 #include "be_debug.h"
 #include "be_map.h"
 #include "be_vm.h"
+#include "be_exec.h"
+#include "be_gc.h"
 #include <string.h>
 
 #if BE_USE_INTROSPECT_MODULE
@@ -56,12 +58,20 @@ static int m_attrlist(bvm *vm)
     be_return(vm);
 }
 
+static void m_findmember_protected(bvm *vm, void* data)
+{
+    be_getmember(vm, 1, (const char*) data);
+}
+
 static int m_findmember(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 2 && (be_isinstance(vm, 1) || be_ismodule(vm, 1) || be_isclass(vm, 1)) && be_isstring(vm, 2)) {
-        be_getmember(vm, 1, be_tostring(vm, 2));
-        be_return(vm);
+        int ret = be_execprotected(vm, &m_findmember_protected, (void*) be_tostring(vm, 2));
+        if (ret == BE_OK) {
+            // be_getmember(vm, 1, be_tostring(vm, 2));
+            be_return(vm);
+        }
     }
     be_return_nil(vm);
 }
@@ -76,12 +86,57 @@ static int m_setmember(bvm *vm)
     be_return_nil(vm);
 }
 
+static int m_toptr(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        if (var_basetype(v) >= BE_FUNCTION || var_type(v) == BE_COMPTR) {
+            be_pushcomptr(vm, var_toobj(v));
+            be_return(vm);
+        } else if (var_type(v) == BE_INT) {
+            be_pushcomptr(vm, (void*) var_toint(v));
+            be_return(vm);
+        } else {
+            be_raise(vm, "value_error", "unsupported for this type");
+        }
+    }
+    be_return_nil(vm);
+}
+
+static int m_fromptr(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1) {
+        void* v;
+        if (be_iscomptr(vm, 1)) {
+            v = be_tocomptr(vm, 1);
+        } else {
+            v = (void*) be_toint(vm, 1);
+        }
+        if (v) {
+            bgcobject * ptr = (bgcobject*) v;
+            if (var_basetype(ptr) >= BE_GCOBJECT) {
+                bvalue *top = be_incrtop(vm);
+                var_setobj(top, ptr->type, ptr);
+            } else {
+                be_raise(vm, "value_error", "unsupported for this type");
+            }
+            be_return(vm);
+        }
+    }
+    be_return_nil(vm);
+}
+
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(introspect) {
     be_native_module_function("members", m_attrlist),
 
     be_native_module_function("get", m_findmember),
     be_native_module_function("set", m_setmember),
+
+    be_native_module_function("toptr", m_toptr),
+    be_native_module_function("fromptr", m_fromptr),
 };
 
 be_define_native_module(introspect, NULL);
@@ -92,6 +147,9 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     get, func(m_findmember)
     set, func(m_setmember)
+
+    toptr, func(m_toptr)
+    fromptr, func(m_fromptr)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_introspect.h"

--- a/src/be_object.c
+++ b/src/be_object.c
@@ -30,6 +30,7 @@ const char* be_vtype2str(bvalue *v)
     case BE_INSTANCE: return "instance";
     case BE_MODULE: return "module";
     case BE_INDEX: return "var";
+    case BE_COMPTR: return "ptr";
     default: return "invalid type";
     }
 }

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -11,7 +11,7 @@
 #include "berry.h"
 
 /* basic types, do not change value */
-#define BE_NONE         (-1)    /* unknow type */
+#define BE_NONE         (-1)    /* unknown type */
 #define BE_COMPTR       (-2)    /* common pointer */
 #define BE_INDEX        (-3)    /* index for instance variable, previously BE_INT */
 #define BE_NIL          0
@@ -209,6 +209,7 @@ typedef const char* (*breader)(void*, size_t*);
 #define var_ismap(_v)           var_istype(_v, BE_MAP)
 #define var_ismodule(_v)        var_istype(_v, BE_MODULE)
 #define var_isindex(_v)         var_istype(_v, BE_INDEX)
+#define var_iscomptr(_v)        var_istype(_v, BE_COMPTR)
 #define var_isnumber(_v)        (var_isint(_v) || var_isreal(_v))
 
 #define var_setnil(_v)          var_settype(_v, BE_NIL)

--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -97,8 +97,11 @@ static bstring* sim2str(bvm *vm, bvalue *v)
     case BE_MODULE:
         module2str(sbuf, v);
         break;
+    case BE_COMPTR:
+        sprintf(sbuf, "<ptr: %p>", var_toobj(v));
+        break;
     default:
-        strcpy(sbuf, "(unknow value)");
+        strcpy(sbuf, "(unknown value)");
         break;
     }
     return be_newstr(vm, sbuf);
@@ -218,7 +221,7 @@ const char* be_pushvfstr(bvm *vm, const char *format, va_list arg)
             break;
         }
         default:
-            pushstr(vm, "(unknow)", 8);
+            pushstr(vm, "(unknown)", 8);
             break;
         }
         concat2(vm);

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -77,7 +77,7 @@
             res = var_tobool(a) op var_tobool(b); \
         } else if (var_isstr(a)) { /* string op string */ \
             res = 1 op be_eqstr(a->v.s, b->v.s); \
-        } else if (var_isclass(a) || var_isfunction(a)) { \
+        } else if (var_isclass(a) || var_isfunction(a) || var_iscomptr(a)) { \
             res = var_toobj(a) op var_toobj(b); \
         } else { \
             binop_error(vm, #op, a, b); \


### PR DESCRIPTION
These are features that I have been needing for better Berry - C mapping and encapsulation. It provides easier ways to create and read `comptr` values.
- `introspect.toptr(i)` converts an int or a type to a `comptr` pointer. This is used to pass a Berry object as pointer
- `introspect.fromptr(i)` converts a `comptr` to a native Berry value. To use with caution, the object may have been gced, so a reference to it needs to be kept.

Extra features:
- `int(b)` where `b` is bool returns `0` or `1` instead of an exception
- `int(p)` where `p` is a `comptr` converts the pointer to an int (to use with caution is int and pointers are not the same size)
- access to virtual members are protected from exceptions