### PR TITLE
math.nan

### DIFF
--- a/src/be_mathlib.c
+++ b/src/be_mathlib.c
@@ -34,6 +34,17 @@
   #define mathfunc(func)        func
 #endif
 
+static int m_isnan(bvm *vm)
+{
+    if (be_top(vm) >= 1 && be_isreal(vm, 1)) {
+        breal x = be_toreal(vm, 1);
+        be_pushbool(vm, isnan(x));
+    } else {
+        be_pushbool(vm, bfalse);
+    }
+    be_return(vm);
+}
+
 static int m_abs(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
@@ -272,6 +283,7 @@ static int m_rand(bvm *vm)
 
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(math) {
+    be_native_module_function("isnan", m_isnan),
     be_native_module_function("abs", m_abs),
     be_native_module_function("ceil", m_ceil),
     be_native_module_function("floor", m_floor),
@@ -295,6 +307,7 @@ be_native_module_attr_table(math) {
     be_native_module_function("srand", m_srand),
     be_native_module_function("rand", m_rand),
     be_native_module_real("pi", M_PI),
+    be_native_module_real("nan", NAN),
     be_native_module_int("imax", M_IMAX),
     be_native_module_int("imin", M_IMIN),
 };
@@ -303,6 +316,7 @@ be_define_native_module(math, NULL);
 #else
 /* @const_object_info_begin
 module math (scope: global, depend: BE_USE_MATH_MODULE) {
+    isnan, func(m_isnan)
     abs, func(m_abs)
     ceil, func(m_ceil)
     floor, func(m_floor)
@@ -326,6 +340,7 @@ module math (scope: global, depend: BE_USE_MATH_MODULE) {
     srand, func(m_srand)
     rand, func(m_rand)
     pi, real(M_PI)
+    nan, real(NAN)
     imax, int(M_IMAX)
     imin, int(M_IMIN)
 }

--- a/tests/math.be
+++ b/tests/math.be
@@ -1,0 +1,12 @@
+import math
+
+#- nan -#
+n = math.nan
+assert(str(n) == 'nan')
+assert(math.isnan(n))
+assert(math.isnan(n+n))
+assert(math.isnan(n+1))
+assert(math.isnan(n*0))
+
+assert(!math.isnan(0))
+assert(!math.isnan(1.5))

--- a/tests/math.be
+++ b/tests/math.be
@@ -10,3 +10,5 @@ assert(math.isnan(n*0))
 
 assert(!math.isnan(0))
 assert(!math.isnan(1.5))
+
+assert(n != n)      #- nan is never identical to itself -#


### PR DESCRIPTION
Add `math.nan` and `math.isnan(v)` to support `NaN` (Not a Number).

NaN has special characteristics:
- any operation involving `nan` results in `nan`.
- `nan` is never equal to itself. `nan` != `nan`. So you can't use tests like `if v == math.nan ...` because it always fails. Use `math.isnan()` instead