### PR TITLE
String range and negative index

### DIFF
--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -327,7 +327,6 @@ static bstring* string_range(bvm *vm, bstring *str, binstance *range)
 {
     bint lower, upper;
     bint size = str_len(str);   /* size of source string */
-    // bint size = be_data_size(vm, -1); /* get source list size */
     /* get index range */
     bvalue temp;
     be_instance_member(vm, range, be_newstr(vm, "__lower__"), &temp);

--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -323,15 +323,47 @@ BERRY_API const char *be_str2num(bvm *vm, const char *str)
     return sout;
 }
 
+static bstring* string_range(bvm *vm, bstring *str, binstance *range)
+{
+    bint lower, upper;
+    bint size = str_len(str);   /* size of source string */
+    // bint size = be_data_size(vm, -1); /* get source list size */
+    /* get index range */
+    bvalue temp;
+    be_instance_member(vm, range, be_newstr(vm, "__lower__"), &temp);
+    lower = var_toint(&temp);
+    be_instance_member(vm, range, be_newstr(vm, "__upper__"), &temp);
+    upper = var_toint(&temp);
+    /* protection scope */
+    if (upper < 0) { upper = size + upper; }
+    if (lower < 0) { lower = size + lower; }
+    upper = upper < size ? upper : size - 1;
+    lower = lower < 0 ? 0 : lower;
+    if (lower > upper) {
+        return be_newstrn(vm, "", 0);   /* empty string */
+    }
+    return be_newstrn(vm, str(str) + lower, upper - lower + 1);
+
+}
+
 /* string subscript operation */
 bstring* be_strindex(bvm *vm, bstring *str, bvalue *idx)
 {
     if (var_isint(idx)) {
         int pos = var_toidx(idx);
-        if (pos < str_len(str)) {
+        int size = str_len(str);
+        if (pos < 0) { pos = size + pos; }
+        if ((pos < size) && (pos >= 0)) {
             return be_newstrn(vm, str(str) + pos, 1);
         }
         be_raise(vm, "index_error", "string index out of range");
+    } else if (var_isinstance(idx)) {
+        binstance * ins = var_toobj(idx);
+        const char *cname = str(be_instance_name(ins));
+        if (!strcmp(cname, "range")) {
+            return string_range(vm, str, ins);
+        }
+        // str(be_instance_name(i))
     }
     be_raise(vm, "index_error", "string indices must be integers");
     return NULL;

--- a/tests/string.be
+++ b/tests/string.be
@@ -34,3 +34,21 @@ assert(s.format("%i%%", 12) == "12%")
 assert(s.format("%i%%%i", 12, 13) == "12%13")
 assert(s.format("%s%%", "foo") == "foo%")
 assert(s.format("%.1f%%", 3.5) == "3.5%")
+
+#- string ranges -#
+s="azertyuiop"
+assert(s[0] == "a")
+assert(s[0..1] == "az")
+assert(s[0..2] == "aze")
+assert(s[0..10] == s)
+assert(s[0..size(s)] == s)
+assert(s[0..50] == s)       #- upper limit is allowed to be out of range -#
+
+#- negative indices start from the end -#
+s="azertyuiop"
+assert(s[-1] == "p")
+assert(s[-2] == "o")
+assert(s[0..-2] == "azertyuio")
+assert(s[-4..-2] == "uio")
+assert(s[-2..-4] == "")  #- if range is in wrong order, returns empty string -#
+assert(s[-40..-2] == "azertyuio")  #- borders are allowed to be out of range -#


### PR DESCRIPTION
Allow use of ranges in string:
- `s[a..b]` returns all characters between indices `a` and `b`. It contains `b-a+1` characters or less if limits are out of bound. Limits out of bound don't cause an exception
- negative indices are counted from the end of the string

```
> s="foobar"
> s[1..3]
'oob'
> s[3..3]
'b'
> s[4..2]  # reverse limits return an empty string
''
> s[10]
index_error: string index out of range
stack traceback:
	stdin:1: in function `main`
> s[10..10]  # never fails
''

> s[-1]  # last character
'f'
> s[4..-2]  # from character 4 to just before last
'a'
```