### PR TITLE
Fix potential crash when stack is resized

### DIFF
--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -787,7 +787,6 @@ newframe: /* a new call frame */
         }
         opcase(GETMBR): {
             bvalue a_temp;  /* copy result to a temp variable because the stack may be relocated in virtual member calls */
-            // bvalue *a = RA(), *b = RKB(), *c = RKC();
             bvalue *b = RKB(), *c = RKC();
             if (var_isinstance(b) && var_isstr(c)) {
                 obj_attribute(vm, b, var_tostr(c), &a_temp);
@@ -800,6 +799,7 @@ newframe: /* a new call frame */
                 reg = vm->reg;
             } else {
                 attribute_error(vm, "attribute", b, c);
+                a_temp = *RA();     /* avoid gcc warning for uninitialized variable a_temp, this code is never reached */
             }
             bvalue *a = RA();
             *a = a_temp;    /* assign the resul to the specified register on the updated stack */


### PR DESCRIPTION
Fix a rare bug discovered in Tasmota.

When calling a virtual method or virtual member, `GETMBR` and `GETMET` indirectly call a function (native or Berry). This calls checks the stack size and may in rare circumstances resize the stack; hence relocates the stack at a different address.

Unfortunately in such case, `RA()` address is no more valid and still points to the old stack location. This patch stores the result to a temporary location on the C stack, and defers the computation of `RA()` until after the call to the function was made.