### PR TITLE
Improved module init

### DIFF
--- a/src/berry.h
+++ b/src/berry.h
@@ -514,6 +514,7 @@ BERRY_API bbool be_refcontains(bvm *vm, int index);
 BERRY_API void be_refpush(bvm *vm, int index);
 BERRY_API void be_refpop(bvm *vm);
 BERRY_API void be_stack_require(bvm *vm, int count);
+BERRY_API bbool be_getmodule(bvm *vm, const char *k);
 
 /* relop operation APIs */
 BERRY_API bbool be_iseq(bvm *vm);


### PR DESCRIPTION
Improvement of module (especially solidified modules) initialization.

Previous sequence:
- `import feature`
- Check if the import is not already in cache, if true return the cached value
- If not in cache, get the return value `<m>`of the code called by import
- Cache the value `<m>` for entry `feature` in the module table
- If result `<m>` is of type `module` and it has a `init()` function, call it with the module as parameter: `feature.init(feature)`
- Set the global variable `feature` with the value `<m>`

New initialization sequence:
- `import feature`
- Check if the import is not already in cache, if true return the cached value
- If not in cache, get the return value `<m>`of the code called by import
- ~~Cache the value `<m>` for entry `feature` in the module table~~
- If result `<m>` is of type `module` and it has a `init()` function, call it with the module as parameter: `feature.init(feature)` and **take the result `<m2>` of this function**
- Cache the value **`<m2>`** for entry `feature` in the module table
- Set the global variable `feature` with the value **`<m2>`**

This feature is very useful since it gives the opportunity to modify the result of the imported module before it is passed back to calling code. Especially for solidified modules (read-only) for which the module attributes can't be changed.

For example this solves elegantly the Singleton pattern (class with a single instance), preventing developers from instantiating twice, and without polluting the global namespace with the class name.

To do this, we embed the class as an inner class to the `init()` function:

File `singleton.be`:
```python
var m = module("singleton")

m.init = def (_module)
    class A
        var a,b
        def init()
            self.a = 1
            self.b = "foo"
        end
        def hello()
            print("Hello")
        end
    end

    return A()  #- return an instance of A -#
end

return m
```

Usage

```python
> import singleton
> singleton
<instance: A()>
> A            #- class A is not in global namespace -#
syntax_error: stdin:1: 'A' undeclared (first use in this function)
> singleton.a
1
> singleton.hello()
Hello
> x = singleton
> import singleton
> x == singleton        #- if we import again we get the same instance -#
true
```

For Tasmota I created a simple `persist` module to automatically persist values as JSON in the file-system:
```python
#-  persistance module for Berry -#
var persist_module = module("persist")

persist_module.init = def (m)

  class Persist
    var _filename
    var _p
    var _dirty

    #- persist can be initialized with pre-existing values. The map is not copied so any change will be reflected -#
    def init(m)
      self._filename = '_persist.json'
      if isinstance(m,map)
        self._p = m.copy()   # need to copy instead?
      else
        self._p = {}
      end
      self.load(self._p, self._filename)
      self._dirty = false
    end

    #- virtual member getter, if a key does not exists return `nil`-#
    def member(key)
      return self._p.find(key)
    end

    #- virtual member setter -#
    def setmember(key, value)
      self._p[key] = value
      self._dirty = true
    end

    #- clear all entries -#
    def zero()
      self._p = {}
      self._dirty = true
    end
    
    def remove(k)
        self._p.remove(k)
        self._dirty = true
    end

    def   contains(k)
        return self._p.  contains(k)
    end

    def find(k, d)
        return self._p.find(k, d)
    end

    def load()
      import os
      import json
      var f           # file object
      var val         # values loaded from json

      if os.path.exists(self._filename)
        try
          f = open(self._filename, "r")
          val = json.load(f.read())
          f.close()
        except .. as e, m
          if f != nil f.close() end
          raise e, m
        end
        self._p = val
        self._dirty = false
      end
    end

    def save()
      import json
  
      var f       # file object
      try
        f = open(self._filename, "w")
        f.write(json.dump(self._p))
        f.close()
      except .. as e, m
        if f != nil f.close() end
        raise e, m
      end
      self._dirty = false
    end
  end

  return Persist()    # return an instance of this class
end

return persist_module
```

Usage is simple:
```python
> import persist
> persist.a
attribute_error: the 'Persist' object has no attribute 'a'
stack traceback:
	stdin:1: in function `main`
> persist.a = "foo"
> persist.a
'foo'
> persist.save()

[...] restart Berry

> import persist
> persist.a
'foo'
```

Also included: bug fix that would prevent a Berry function to be run as init()