### PR TITLE
Remove unused native initializer for modules

### DIFF
--- a/src/be_constobj.h
+++ b/src/be_constobj.h
@@ -138,13 +138,12 @@ const bvector _name = {                                         \
     .end = (void*)(_data + (_size) - 1)                         \
 }
 
-#define be_define_const_native_module(_module, _init)           \
+#define be_define_const_native_module(_module)                  \
 const bntvmodule be_native_module(_module) = {                  \
     .name = #_module,                                           \
     .attrs = NULL,                                              \
     .size = 0,                                                  \
-    .module = (bmodule*)&(m_lib##_module),                      \
-    .init = _init                                               \
+    .module = (bmodule*)&(m_lib##_module)                       \
 }
 
 /* defines needed for solidified classes */

--- a/src/berry.h
+++ b/src/berry.h
@@ -172,7 +172,6 @@ typedef struct bntvmodule {
     const bntvmodobj *attrs; /* native module attributes */
     size_t size; /* native module attribute count */
     const struct bmodule *module; /* const module object */
-    bntvfunc init; /* initialization function */
 } bntvmodule;
 
 /* native module node definition macro */

--- a/tools/coc/block_builder.cpp
+++ b/tools/coc/block_builder.cpp
@@ -143,8 +143,7 @@ std::string block_builder::module_tostring(const block &block)
     if (scp != "static") { /* extern */
         ostr << "\n" << scp
              << " be_define_const_native_module("
-             << block.name << ", "
-             << init(block) << ");" << std::endl;
+             << block.name << ");" << std::endl;
     }
     return ostr.str();
 }
@@ -166,12 +165,6 @@ std::string block_builder::name(const block &block)
 {
     auto it = block.attr.find("name");
     return it == block.attr.end() ? block.name : it->second;
-}
-
-std::string block_builder::init(const block &block)
-{
-    auto it = block.attr.find("init");
-    return it == block.attr.end() ? "NULL" : it->second;
 }
 
 void block_builder::writefile(const std::string &filename, const std::string &text)

--- a/tools/coc/block_builder.h
+++ b/tools/coc/block_builder.h
@@ -39,7 +39,6 @@ private:
     std::string scope(const block &block);
     std::string super(const block &block);
     std::string name(const block &block);
-    std::string init(const block &block);
     void writefile(const std::string &filename, const std::string &text);
 
 private:


### PR DESCRIPTION
Remove an unused and superseeded feature.

A special option `init` allowed to specify an initialize native function for native modules. This is not currently used by built-in module. It is not necessary anymore now that a generalized solution exists: just create a member called `init` in the module.