### PR TITLE
performance counters

### DIFF
--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -66,6 +66,21 @@
  **/
 #define BE_USE_OBSERVABILITY_HOOK       0
 
+/* Macro: BE_USE_OBSERVABILITY_HOOK
+ * Use the obshook function to report low-level actions.
+ * Default: 0
+ **/
+#define BE_USE_PERF_COUNTERS            1
+
+/* Macro: BE_VM_OBSERVABILITY_SAMPLING
+ * If BE_USE_OBSERVABILITY_HOOK == 1 and BE_USE_PERF_COUNTERS == 1
+ * then the observability hook is called regularly in the VM loop
+ * allowing to stop infinite loops or too-long running code.
+ * The value is a power of 2.
+ * Default: 20 - which translates to 2^20 or ~1 million instructions
+ **/
+#define BE_VM_OBSERVABILITY_SAMPLING    20
+
 /* Macro: BE_STACK_TOTAL_MAX
  * Set the maximum total stack size.
  * Default: 20000

--- a/src/be_debuglib.c
+++ b/src/be_debuglib.c
@@ -149,6 +149,31 @@ static int m_upvname(bvm *vm)
 }
 #endif
 
+
+#if BE_USE_PERF_COUNTERS
+static void map_insert(bvm *vm, const char *key, int value)
+{
+    be_pushstring(vm, key);
+    be_pushint(vm, value);
+    be_data_insert(vm, -3);
+    be_pop(vm, 2);
+}
+
+static int m_counters(bvm *vm)
+{
+    be_newobject(vm, "map");
+    map_insert(vm, "instruction", vm->counter_ins);
+    map_insert(vm, "vmenter", vm->counter_enter);
+    map_insert(vm, "call", vm->counter_call);
+    map_insert(vm, "get", vm->counter_get);
+    map_insert(vm, "set", vm->counter_set);
+    map_insert(vm, "try", vm->counter_try);
+    map_insert(vm, "raise", vm->counter_exc);
+    be_pop(vm, 1);
+    be_return(vm);
+}
+#endif
+
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(debug) {
     be_native_module_function("attrdump", m_attrdump),
@@ -156,6 +181,9 @@ be_native_module_attr_table(debug) {
     be_native_module_function("traceback", m_traceback),
 #if BE_USE_DEBUG_HOOK
     be_native_module_function("sethook", m_sethook),
+#endif
+#if BE_USE_PERF_COUNTERS
+    be_native_module_function("counters", m_counters),
 #endif
     be_native_module_function("calldepth", m_calldepth),
     be_native_module_function("top", m_top),
@@ -173,6 +201,7 @@ module debug (scope: global, depend: BE_USE_DEBUG_MODULE) {
     codedump, func(m_codedump)
     traceback, func(m_traceback)
     sethook, func(m_sethook), BE_USE_DEBUG_HOOK
+    counters, func(m_counters), BE_USE_PERF_COUNTERS
     calldepth, func(m_calldepth)
     top, func(m_top)
     varname, func(m_varname), BE_DEBUG_VAR_INFO

--- a/src/be_exec.c
+++ b/src/be_exec.c
@@ -390,6 +390,10 @@ void be_stack_expansion(bvm *vm, int n)
         stack_resize(vm, size + 1);
         be_raise(vm, "runtime_error", STACK_OVER_MSG(BE_STACK_TOTAL_MAX));
     }
+#if BE_USE_OBSERVABILITY_HOOK
+    if (vm->obshook != NULL)
+        (*vm->obshook)(vm, BE_OBS_STACK_RESIZE_START, size * sizeof(bvalue), (size + n) * sizeof(bvalue));
+#endif
     stack_resize(vm, size + n);
 }
 

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -48,9 +48,28 @@
   #define DEBUG_HOOK()
 #endif
 
+#if BE_USE_PERF_COUNTERS
+  #define COUNTER_HOOK() \
+    vm->counter_ins++;
+#else
+  #define COUNTER_HOOK()
+#endif
+
+#if BE_USE_PERF_COUNTERS && BE_USE_OBSERVABILITY_HOOK
+  #define VM_HEARTBEAT() \
+    if ((vm->counter_ins & ((1<<(BE_VM_OBSERVABILITY_SAMPLING - 1))-1) ) == 0) { /* call every 2^BE_VM_OBSERVABILITY_SAMPLING instructions */    \
+        if (vm->obshook != NULL)                                                    \
+            (*vm->obshook)(vm, BE_OBS_VM_HEARTBEAT, vm->counter_ins);               \
+    }
+#else
+  #define VM_HEARTBEAT()
+#endif
+
 #define vm_exec_loop() \
     loop: \
         DEBUG_HOOK(); \
+        COUNTER_HOOK(); \
+        VM_HEARTBEAT(); \
         switch (IGET_OP(ins = *vm->ip++))
 
 #if BE_USE_SINGLE_FLOAT
@@ -68,7 +87,7 @@
         res = ibinop(op, a, b); \
     } else if (var_isnumber(a) && var_isnumber(b)) { \
         res = var2real(a) op var2real(b); \
-    } else if (var_isinstance(a)) { \
+    } else if (var_isinstance(a) && !var_isnil(b)) { \
         res = object_eqop(vm, #op, iseq, a, b); \
     } else if (var_type(a) == var_type(b)) { /* same types */ \
         if (var_isnil(a)) { /* nil op nil */ \
@@ -445,6 +464,15 @@ BERRY_API bvm* be_vm_new(void)
 #if BE_USE_OBSERVABILITY_HOOK
     vm->obshook = NULL;
 #endif
+#if BE_USE_PERF_COUNTERS
+    vm->counter_ins = 0;
+    vm->counter_enter = 0;
+    vm->counter_call = 0;
+    vm->counter_get = 0;
+    vm->counter_set = 0;
+    vm->counter_try = 0;
+    vm->counter_exc = 0;
+#endif
     return vm;
 }
 
@@ -478,6 +506,9 @@ newframe: /* a new call frame */
     clos = var_toobj(vm->cf->func);  /* `clos` is the current function/closure */
     ktab = clos->proto->ktab;  /* `ktab` is the current constant table */
     reg = vm->reg;  /* `reg` is the current stack base for the callframe */
+#if BE_USE_PERF_COUNTERS
+    vm->counter_enter++;
+#endif
     vm_exec_loop() {
         opcase(LDNIL): {
             var_setnil(RA());
@@ -786,6 +817,9 @@ newframe: /* a new call frame */
             dispatch();
         }
         opcase(GETMBR): {
+#if BE_USE_PERF_COUNTERS
+            vm->counter_get++;
+#endif
             bvalue a_temp;  /* copy result to a temp variable because the stack may be relocated in virtual member calls */
             bvalue *b = RKB(), *c = RKC();
             if (var_isinstance(b) && var_isstr(c)) {
@@ -806,6 +840,9 @@ newframe: /* a new call frame */
             dispatch();
         }
         opcase(GETMET): {
+#if BE_USE_PERF_COUNTERS
+            vm->counter_get++;
+#endif
             bvalue a_temp;  /* copy result to a temp variable because the stack may be relocated in virtual member calls */
             bvalue *b = RKB(), *c = RKC();
             if (var_isinstance(b) && var_isstr(c)) {
@@ -837,6 +874,9 @@ newframe: /* a new call frame */
             dispatch();
         }
         opcase(SETMBR): {
+#if BE_USE_PERF_COUNTERS
+            vm->counter_set++;
+#endif
             bvalue *a = RA(), *b = RKB(), *c = RKC();
             if (var_isinstance(a) && var_isstr(b)) {
                 binstance *obj = var_toobj(a);
@@ -971,6 +1011,9 @@ newframe: /* a new call frame */
             dispatch();
         }
         opcase(RAISE): {
+#if BE_USE_PERF_COUNTERS
+            vm->counter_exc++;
+#endif
             if (IGET_RA(ins) < 2) {  /* A==2 means no arguments are passed to RAISE, i.e. rethrow with current exception */
                 bvalue *top = vm->top;
                 top[0] = *RKB(); /* push the exception value to top */
@@ -985,6 +1028,9 @@ newframe: /* a new call frame */
             dispatch();
         }
         opcase(EXBLK): {
+#if BE_USE_PERF_COUNTERS
+            vm->counter_try++;
+#endif
             if (!IGET_RA(ins)) {
                 be_except_block_setup(vm);
                 if (be_setjmp(vm->errjmp->b)) {
@@ -998,6 +1044,9 @@ newframe: /* a new call frame */
             dispatch();
         }
         opcase(CALL): {
+#if BE_USE_PERF_COUNTERS
+            vm->counter_call++;
+#endif
             bvalue *var = RA();  /* `var` is the register for the call followed by arguments */
             int mode = 0, argc = IGET_RKB(ins);  /* B contains number of arguments pushed on stack */
         recall: /* goto: instantiation class and call constructor */

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -104,6 +104,15 @@ struct bvm {
 #if BE_USE_OBSERVABILITY_HOOK
     bobshook obshook;
 #endif
+#if BE_USE_PERF_COUNTERS
+    uint32_t counter_ins; /* instructions counter */
+    uint32_t counter_enter; /* counter for times the VM was entered */
+    uint32_t counter_call; /* counter for calls, VM or native */
+    uint32_t counter_get; /* counter for GETMBR or GETMET */
+    uint32_t counter_set; /* counter for SETMBR */
+    uint32_t counter_try; /* counter for `try` statement */
+    uint32_t counter_exc; /* counter for raised exceptions */
+#endif
 #if BE_USE_DEBUG_HOOK
     bvalue hook;
     bbyte hookmask;

--- a/src/berry.h
+++ b/src/berry.h
@@ -402,8 +402,10 @@ typedef void(*bntvhook)(bvm *vm, bhookinfo *info);
 
 typedef void(*bobshook)(bvm *vm, int event, ...);
 enum beobshookevents {
-  BE_OBS_GC_START,        // start of GC, arg = allocated size
-  BE_OBS_GC_END,          // end of GC, arg = allocated size
+  BE_OBS_GC_START,        /* start of GC, arg = allocated size */
+  BE_OBS_GC_END,          /* end of GC, arg = allocated size */
+  BE_OBS_VM_HEARTBEAT,    /* VM heartbeat called every million instructions */
+  BE_OBS_STACK_RESIZE_START,    /* Berry stack resized */
 };
 
 /* FFI functions */


### PR DESCRIPTION
Add performance counters to Berry.

``` python
> import debug
> debug.counters()
{'call': 1, 'vmenter': 4, 'set': 0, 'raise': 0, 'get': 1, 'try': 0, 'instruction': 8}
```

In details:
- `call`: number of function calls made by berry VM (including native and berry)
- `vmenter`: number of times the Berry VM was called
- `set`: number of times `SETMBR` was called
- `get`: number of times `GETMBR` or `GETMET` was called
- `try`: number of `try` statements
- `raise`: number of exception raised
- `instruction`: number of VM instruction executed

In addition the observability hook is called every 2^BE_VM_OBSERVABILITY_SAMPLING instructions. Default value is 2^20 which is every million instructions. The hook is called with `BE_OBS_VM_HEARTBEAT` event type with the number of instructions executed as parameter. This allows to implement a watchdog and raise an exception if some code takes too long (like infinite loop).