### PR TITLE
Fix unary not compiler bug

### DIFF
--- a/src/be_code.c
+++ b/src/be_code.c
@@ -569,7 +569,7 @@ static void unaryexp(bfuncinfo *finfo, bopcode op, bexpdesc *e)
 /* Apply not to conditional expression */
 /* If literal compute the value */
 /* Or invert t/f subexpressions */
-static void code_not(bexpdesc *e)
+static void code_not(bfuncinfo *finfo, bexpdesc *e)
 {
     switch (e->type) {
     case ETINT: e->v.i = e->v.i == 0; break;
@@ -578,6 +578,7 @@ static void code_not(bexpdesc *e)
     case ETBOOL: e->v.i = !e->v.i; break;
     case ETSTRING: e->v.i = 0; break;
     default: {
+        unaryexp(finfo, OP_MOVE, e);
         int temp = e->t;
         e->t = e->f;
         e->f = temp;
@@ -620,7 +621,7 @@ int be_code_unop(bfuncinfo *finfo, int op, bexpdesc *e)
 {
     switch (op) {
     case OptNot:
-        code_not(e); break;
+        code_not(finfo, e); break;
     case OptFlip: /* do nothing */
         return code_flip(finfo, e);
     case OptSub:

--- a/tests/bool.be
+++ b/tests/bool.be
@@ -16,3 +16,10 @@ def test(a, b)
     end
 end
 test(true, true)
+
+# bug in unary 
+def f(i)
+    var j = !i       # bug if i is erroneously modified
+    return i
+end
+assert(f(1) == 1)


### PR DESCRIPTION
The unary not `!` can change the register value in place in certain circumstances:
```
def f(i)
    var j = !i       # bug if i is erroneously modified
    return i
end
```

When calling:
```
> f(1)
false      # should be `1`
```

The bytecode generated is wrong:
```
debug.codedump(f)
source 'stdin', function 'f':
; line 2
  0000  JMPF	R0	#0002
  0001  LDBOOL	R0	0	1     <- R0 is erroneously modified in place
  0002  LDBOOL	R0	1	0
  0003  MOVE	R1	R0
; line 3
  0004  RET	1	R0
```

This fix forces the allocation of a new register when needed, like other unary operators. The new generated code is:
```
> debug.codedump(f)
source 'stdin', function 'f':
; line 2
  0000  MOVE	R1	R0
  0001  JMPF	R1	#0003
  0002  LDBOOL	R1	0	1
  0003  LDBOOL	R1	1	0
; line 3
  0004  RET	1	R0
```

Also added a testcase.

-----------
Note: the code is not optimal since it could avoid a `MOVE`. Unfortunately I didn't find an quick way for `exp2reg()` to have use 2 separate registers, one for the evaluation of the condition in `appendjump` and one register for the result by `codebool()`

Optimally the code could be:

```
  0001  JMPF	R0	#0003
  0002  LDBOOL	R1	0	1
  0003  LDBOOL	R1	1	0
  0004  RET	1	R0
```