### PR TITLE
Fix compiler bug in compound assignement

### DIFF
--- a/src/be_code.c
+++ b/src/be_code.c
@@ -335,12 +335,15 @@ static void free_suffix(bfuncinfo *finfo, bexpdesc *e)
     }
 }
 
-static int suffix_destreg(bfuncinfo *finfo, bexpdesc *e1, int dst)
+static int suffix_destreg(bfuncinfo *finfo, bexpdesc *e1, int dst, bbool no_reg_reuse)
 {
     int cand_dst = dst;  /* candidate for new dst */
     int nlocal = be_list_count(finfo->local);
     int reg1 = (e1->v.ss.tt == ETREG) ? e1->v.ss.obj : -1;  /* check if obj is ETREG or -1 */
     int reg2 = (!isK(e1->v.ss.idx) && e1->v.ss.idx >= nlocal) ? e1->v.ss.idx : -1;  /* check if idx is ETREG or -1 */
+    if (no_reg_reuse) {  /* if no_reg_reuse flag, then don't reuse any register, this is useful for compound assignments */
+        reg1 = reg2 = -1;
+    }
 
     if (reg1 >= 0 && reg2 >= 0) {
         /* both are ETREG, we keep the lowest and discard the other */
@@ -364,9 +367,9 @@ static int suffix_destreg(bfuncinfo *finfo, bexpdesc *e1, int dst)
     return dst;
 }
 
-static int code_suffix(bfuncinfo *finfo, bopcode op, bexpdesc *e, int dst)
+static int code_suffix(bfuncinfo *finfo, bopcode op, bexpdesc *e, int dst, bbool no_reg_reuse)
 {
-    dst = suffix_destreg(finfo, e, dst);
+    dst = suffix_destreg(finfo, e, dst, no_reg_reuse);
     if (dst > finfo->freereg) {
         dst = finfo->freereg;
     }
@@ -400,6 +403,7 @@ static bbool constint(bfuncinfo *finfo, bint i)
 /* At exit, If dst is `freereg`, the register is allocated */
 static int var2reg(bfuncinfo *finfo, bexpdesc *e, int dst)
 {
+    bbool no_reg_reuse = (dst >= 0);  /* if dst reg is explicitly specified, do not optimize register allocation */
     if (dst < 0) {  /* if unspecified, allocate a new register if needed */
         dst = finfo->freereg;
     }
@@ -434,10 +438,10 @@ static int var2reg(bfuncinfo *finfo, bexpdesc *e, int dst)
         codeABx(finfo, OP_GETUPV, dst, e->v.idx);
         break;
     case ETMEMBER:
-        dst = code_suffix(finfo, OP_GETMBR, e, dst);
+        dst = code_suffix(finfo, OP_GETMBR, e, dst, no_reg_reuse);
         break;
     case ETINDEX:
-        dst = code_suffix(finfo, OP_GETIDX, e, dst);
+        dst = code_suffix(finfo, OP_GETIDX, e, dst, no_reg_reuse);
         break;
     case ETLOCAL: case ETREG: case ETCONST:
         return e->v.idx;
@@ -479,6 +483,7 @@ static int exp2reg(bfuncinfo *finfo, bexpdesc *e, int dst)
 /* Returns the destination register, guaranteed to be ETREG */
 static int codedestreg(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, int dst)
 {
+    if (dst < 0) { dst = finfo->freereg; }
     int cand_dst = dst;
     int con1 = e1->type == ETREG, con2 = e2->type == ETREG;
 
@@ -506,7 +511,6 @@ static int codedestreg(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, int dst)
 /* On exit, e1 is guaranteed to be ETREG, which may have been allocated */
 static void binaryexp(bfuncinfo *finfo, bopcode op, bexpdesc *e1, bexpdesc *e2, int dst)
 {
-    if (dst < 0) { dst = finfo->freereg; }
     int src1 = exp2reg(finfo, e1, dst);  /* potentially force the target for src1 reg */
     int src2 = exp2anyreg(finfo, e2);
     dst = codedestreg(finfo, e1, e2, dst);
@@ -720,7 +724,7 @@ int be_code_getmethod(bfuncinfo *finfo, bexpdesc *e)
 {
     int dst = finfo->freereg;
     be_assert(e->type == ETMEMBER);
-    dst = code_suffix(finfo, OP_GETMET, e, dst);
+    dst = code_suffix(finfo, OP_GETMET, e, dst, bfalse);
     /* method [object] args */
     be_code_allocregs(finfo, dst == finfo->freereg ? 2 : 1);
     return dst;

--- a/tests/compound.be
+++ b/tests/compound.be
@@ -17,3 +17,12 @@ b=A()
 assert(b.a == 1)
 b.g(10)
 assert(b.a == 6)
+
+# bug in compound assignments
+class A var a,b end
+c=A()
+c.a = {"x": 1, "y": 2}
+c.b = "x"
+assert(c.a[c.b] == 1)
+c.a[c.b] += 2   # this is where the bug happens
+assert(c.a[c.b] == 3)


### PR DESCRIPTION
Fix compiler bug in compound assignments.

In the example below, `GETIDX` has both arguments as `ETREG` and the registers are optimized (one of them is released and the other reused). This is fine when reading but wrong in a compound assignement where we need to keep arguments for the future `SETIDX`.

```
class A var a,b end
c=A()
c.a = {"x": 1, "y": 2}
c.b = "x"

c.a[c.b] += 2   # this is where the bug happens

type_error: value 'int' does not support index assignment
stack traceback:
	stdin:1: in function `main`
```

```
> f = compile("c.a[c.b] += 2")
> import debug
> debug.codedump(f)

source 'string', function 'main':
; line 1
  0000  GETNGBL	R0	K0
  0001  GETNGBL	R1	K0
  0002  GETMBR	R1	R1	K2
  0003  GETMBR	R0	R0	K1
  0004  GETIDX	R0	R0	R1    <- wrong, a new register should be allocated
  0005  ADD	R0	R0	K3
  0006  SETIDX	R0	R1	R0
  0007  RET	0
```

I introduced a new parameter to avoid register optimization in the case of a compound assignement. More precisely, this happens when `dst` is explicitly set, instead of `-1` to indicate any register.

Now:

```
> f = compile("c.a[c.b] += 2")
> import debug
> debug.codedump(f)
source 'string', function 'main':
; line 1
  0000  GETNGBL	R0	K0
  0001  GETNGBL	R1	K0
  0002  GETMBR	R1	R1	K2
  0003  GETMBR	R0	R0	K1
  0004  GETIDX	R2	R0	R1    <- R2 is allocated for the value
  0005  ADD	R2	R2	K3
  0006  SETIDX	R0	R1	R2
  0007  RET	0
```

Test case added as well.
