### PR TITLE
Unary not, avoid unnecessary move

### DIFF
--- a/src/be_code.c
+++ b/src/be_code.c
@@ -561,7 +561,10 @@ static void unaryexp(bfuncinfo *finfo, bopcode op, bexpdesc *e)
 {
     int src = exp2anyreg(finfo, e);
     int dst = e->type == ETREG ? src : be_code_allocregs(finfo, 1);
-    codeABC(finfo, op, dst, src, 0);
+    if (!(op == OP_MOVE && src == dst)) {
+        /* skip if MOVE from same src / dst */
+        codeABC(finfo, op, dst, src, 0);
+    }
     e->type = ETREG;
     e->v.idx = dst;
 }


### PR DESCRIPTION
#166 was a little too aggressive and caused some useless register moves:

```
> import string
> def f() return !string.find("a","a") end
> import debug
> debug.codedump(f)
source 'stdin', function 'f':
; line 1
  0000  GETNGBL	R0	K0
  0001  GETMET	R0	R0	K1
  0002  LDCONST	R2	K2
  0003  LDCONST	R3	K2
  0004  CALL	R0	3
  0005  MOVE	R0	R0               <- unnecessary move from a register to itself
  0006  JMPF	R0	#0008
  0007  LDBOOL	R0	0	1
  0008  LDBOOL	R0	1	0
  0009  RET	1	R0
```

There is now a simple test that skips an instruction if it's a move to the same register.

After:

```
> import string
> def f() return !string.find("a","a") end
> import debug
> debug.codedump(f)
source 'stdin', function 'f':
; line 1
  0000  GETNGBL R0  K0
  0001  GETMET  R0  R0  K1
  0002  LDCONST R2  K2
  0003  LDCONST R3  K2
  0004  CALL  R0  3
  0005  JMPF  R0  #0007
  0006  LDBOOL  R0  0 1
  0007  LDBOOL  R0  1 0
  0008  RET 1 R0
```

