### PR TITLE
Static methods

### DIFF
--- a/src/be_bytecode.c
+++ b/src/be_bytecode.c
@@ -23,7 +23,7 @@
 #define MAGIC_NUMBER1       0xBE
 #define MAGIC_NUMBER2       0xCD
 #define MAGIC_NUMBER3       0xFE
-#define BYTECODE_VERSION    2
+#define BYTECODE_VERSION    3
 
 #define USE_64BIT_INT       (BE_INTGER_TYPE == 2 \
     || BE_INTGER_TYPE == 1 && LONG_MAX == 9223372036854775807L)
@@ -425,7 +425,7 @@ static void load_class(bvm *vm, void *fp, bvalue *v, int version)
         be_incrtop(vm);
         if (load_proto(vm, fp, (bproto**)&var_toobj(value), -3, version)) {
             /* actual method */
-            be_method_bind(vm, c, name, var_toobj(value));
+            be_method_bind(vm, c, name, var_toobj(value), bfalse);
         } else {
             /* no proto, static member set to nil */
             be_member_bind(vm, c, name, bfalse);

--- a/src/be_class.c
+++ b/src/be_class.c
@@ -75,7 +75,7 @@ void be_member_bind(bvm *vm, bclass *c, bstring *name, bbool var)
     }
 }
 
-void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p)
+void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p, bbool is_static)
 {
     bclosure *cl;
     bvalue *attr;
@@ -87,6 +87,9 @@ void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p)
     cl = be_newclosure(vm, p->nupvals);
     cl->proto = p;
     var_setclosure(attr, cl);
+    if (is_static) {
+        func_setstatic(attr);
+    }
 }
 
 void be_prim_method_bind(bvm *vm, bclass *c, bstring *name, bntvfunc f)

--- a/src/be_class.h
+++ b/src/be_class.h
@@ -53,7 +53,7 @@ bclass* be_newclass(bvm *vm, bstring *name, bclass *super);
 void be_class_compress(bvm *vm, bclass *c);
 int be_class_attribute(bvm *vm, bclass *c, bstring *attr);
 void be_member_bind(bvm *vm, bclass *c, bstring *name, bbool var);
-void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p);
+void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p, bbool is_static);
 void be_prim_method_bind(bvm *vm, bclass *c, bstring *name, bntvfunc f);
 void be_closure_method_bind(bvm *vm, bclass *c, bstring *name, bclosure *cl);
 int be_class_closure_count(bclass *c);

--- a/src/be_constobj.h
+++ b/src/be_constobj.h
@@ -15,6 +15,7 @@ extern "C" {
 #include "be_object.h"
 #include "be_gc.h"
 #include "be_map.h"
+#include "be_list.h"
 #include "be_class.h"
 #include "be_string.h"
 #include "be_module.h"
@@ -35,6 +36,11 @@ extern "C" {
 #define be_const_func(_func) {                                  \
     .v.nf = (_func),                                            \
     .type = BE_FUNCTION                                         \
+}
+
+#define be_const_static_func(_func) {                           \
+    .v.nf = (_func),                                            \
+    .type = BE_FUNCTION | BE_FUNC_STATIC                        \
 }
 
 #define be_const_nil() {                                        \
@@ -85,6 +91,11 @@ extern "C" {
 #define be_const_closure(_closure) {                            \
     .v.c = &(_closure),                                         \
     .type = BE_CLOSURE                                          \
+}
+
+#define be_const_static_closure(_closure) {                     \
+    .v.c = &(_closure),                                         \
+    .type = BE_CLOSURE | BE_FUNC_STATIC                         \
 }
 
 #define be_const_module(_module) {                              \
@@ -200,6 +211,11 @@ const bntvmodule be_native_module(_module) = {                  \
     BE_FUNCTION                                                 \
 }
 
+#define be_const_static_func(_func) {                           \
+    bvaldata(_func),                                            \
+    BE_FUNCTION | BE_FUNC_STATIC                                \
+}
+
 #define be_const_nil() {                                        \
     bvaldata(0),                                                \
     BE_NIL                                                      \
@@ -248,6 +264,11 @@ const bntvmodule be_native_module(_module) = {                  \
 #define be_const_closure(_closure) {                            \
     bvaldata(&(_closure)),                                      \
     BE_CLOSURE                                                  \
+}
+
+#define be_const_static_closure(_closure) {                     \
+    bvaldata(&(_closure)),                                      \
+    BE_CLOSURE | BE_FUNC_STATIC                                 \
 }
 
 #define be_const_module(_module) {                              \

--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -348,7 +348,7 @@ static void free_instance(bvm *vm, bgcobject *obj)
 
 static void free_object(bvm *vm, bgcobject *obj)
 {
-    switch (obj->type) {
+    switch (var_type(obj)) {
     case BE_STRING: free_lstring(vm, obj); break; /* long string */
     case BE_CLASS: be_free(vm, obj, sizeof(bclass)); break;
     case BE_INSTANCE: free_instance(vm, obj); break;

--- a/src/be_gc.h
+++ b/src/be_gc.h
@@ -10,8 +10,6 @@
 
 #include "be_object.h"
 
-#define BE_GCOBJECT         BE_STRING
-
 #define gc_object(o)        cast(bgcobject*, o)
 #define gc_cast(o, t, T)    ((o) && (o)->type == (t) ? (T*)(o) : NULL)
 #define cast_proto(o)       gc_cast(o, BE_PROTO, bproto)

--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -69,7 +69,6 @@ static int m_findmember(bvm *vm)
     if (top >= 2 && (be_isinstance(vm, 1) || be_ismodule(vm, 1) || be_isclass(vm, 1)) && be_isstring(vm, 2)) {
         int ret = be_execprotected(vm, &m_findmember_protected, (void*) be_tostring(vm, 2));
         if (ret == BE_OK) {
-            // be_getmember(vm, 1, be_tostring(vm, 2));
             be_return(vm);
         }
     }

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -11,25 +11,34 @@
 #include "berry.h"
 
 /* basic types, do not change value */
-#define BE_NONE         (-1)    /* unknown type */
-#define BE_COMPTR       (-2)    /* common pointer */
-#define BE_INDEX        (-3)    /* index for instance variable, previously BE_INT */
 #define BE_NIL          0
 #define BE_INT          1
 #define BE_REAL         2
 #define BE_BOOL         3
-#define BE_FUNCTION     4
-#define BE_STRING       5       /* from this type can be gced, see BE_GCOBJECT */
-#define BE_CLASS        6
-#define BE_INSTANCE     7
-#define BE_PROTO        8
-#define BE_LIST         9
-#define BE_MAP          10
-#define BE_MODULE       11
-#define BE_COMOBJ       12      /* common object */
+#define BE_NONE         4       /* unknown type */
+#define BE_COMPTR       5       /* common pointer */
+#define BE_INDEX        6       /* index for instance variable, previously BE_INT */
+#define BE_FUNCTION     7
+
+#define BE_GCOBJECT     16      /* from this type can be gced */
+
+#define BE_STRING       16
+#define BE_CLASS        17
+#define BE_INSTANCE     18
+#define BE_PROTO        19
+#define BE_LIST         20
+#define BE_MAP          21
+#define BE_MODULE       22
+#define BE_COMOBJ       23      /* common object */
+
 #define BE_NTVFUNC      ((0 << 5) | BE_FUNCTION)
 #define BE_CLOSURE      ((1 << 5) | BE_FUNCTION)
 #define BE_NTVCLOS      ((2 << 5) | BE_FUNCTION)
+#define BE_FUNC_STATIC  (1 << 7)
+
+#define func_isstatic(o)       (((o)->type & BE_FUNC_STATIC) != 0)
+#define func_setstatic(o)      ((o)->type |= BE_FUNC_STATIC)
+#define func_clearstatic(o)    ((o)->type &= ~BE_FUNC_STATIC)
 
 #define array_count(a)   (sizeof(a) / sizeof((a)[0]))
 
@@ -187,7 +196,7 @@ typedef const char* (*breader)(void*, size_t*);
 #define cast_bool(_v)           cast(bbool, _v)
 #define basetype(_t)            ((_t) & 0x1F)
 
-#define var_type(_v)            ((_v)->type)
+#define var_type(_v)            ((_v)->type & 0x7F)
 #define var_basetype(_v)        basetype((_v)->type)
 #define var_istype(_v, _t)      (var_type(_v) == _t)
 #define var_settype(_v, _t)     ((_v)->type = _t)

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <math.h>
 
+#include <stdio.h>
 #define NOT_METHOD          BE_NONE
 
 #define vm_error(vm, except, ...) \
@@ -851,9 +852,9 @@ newframe: /* a new call frame */
                 reg = vm->reg;
                 bvalue *a = RA();
                 *a = a_temp;
-                if (basetype(type) == BE_FUNCTION) {
-                    if (func_isstatic(a)) {
-                        /* static method, don't bother with the instance */
+                if (var_basetype(a) == BE_FUNCTION) {
+                    if (func_isstatic(a) || (type == BE_INDEX)) {    /* if instance variable then we consider it's non-method */
+                       /* static method, don't bother with the instance */
                         a[1] = a_temp;
                         var_settype(a, NOT_METHOD);
                     } else {

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -852,16 +852,29 @@ newframe: /* a new call frame */
                 bvalue *a = RA();
                 *a = a_temp;
                 if (basetype(type) == BE_FUNCTION) {
-                    /* check if the object is a superinstance, if so get the lowest possible subclass */
-                    while (obj->sub) {
-                        obj = obj->sub;
+                    if (func_isstatic(a)) {
+                        /* static method, don't bother with the instance */
+                        a[1] = a_temp;
+                        var_settype(a, NOT_METHOD);
+                    } else {
+                        /* this is a real method (i.e. non-static) */
+                        /* check if the object is a superinstance, if so get the lowest possible subclass */
+                        while (obj->sub) {
+                            obj = obj->sub;
+                        }
+                        var_setinstance(&a[1], obj);  /* replace superinstance by lowest subinstance */
                     }
-                    var_setinstance(&a[1], obj);  /* replace superinstance by lowest subinstance */
                 } else {
                     vm_error(vm, "attribute_error",
                         "class '%s' has no method '%s'",
                         str(be_instance_name(obj)), str(var_tostr(c)));
                 }
+            } else if (var_isclass(b) && var_isstr(c)) {
+                class_attribute(vm, b, c, &a_temp);
+                reg = vm->reg;
+                bvalue *a = RA();
+                a[1] = a_temp;
+                var_settype(a, NOT_METHOD);
             } else if (var_ismodule(b) && var_isstr(c)) {
                 module_attribute(vm, b, c, &a_temp);
                 reg = vm->reg;
@@ -891,9 +904,14 @@ newframe: /* a new call frame */
                 dispatch();
             }
             if (var_isclass(a) && var_isstr(b)) {
+                /* if value is a function, we mark it as a static to distinguish from methods */
                 bclass *obj = var_toobj(a);
                 bstring *attr = var_tostr(b);
-                if (!be_class_setmember(vm, obj, attr, c)) {
+                bvalue c_static = *c;
+                if (var_isfunction(&c_static)) {
+                    c_static.type = func_setstatic(&c_static);
+                }
+                if (!be_class_setmember(vm, obj, attr, &c_static)) {
                     reg = vm->reg;
                     vm_error(vm, "attribute_error",
                         "class '%s' cannot assign to static attribute '%s'",

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -24,7 +24,6 @@
 #include <string.h>
 #include <math.h>
 
-#include <stdio.h>
 #define NOT_METHOD          BE_NONE
 
 #define vm_error(vm, except, ...) \

--- a/tests/class_const.be
+++ b/tests/class_const.be
@@ -64,7 +64,7 @@ A.h = def (x, y) return type(x) end
 assert(type(a.g) == 'function')
 assert(type(a.h) == 'function')
 
-assert_attribute_error("a.g(1,2)")
+assert(a.g(1) == 'int')
 assert(a.h(1) == 'int')
 assert(A.h(1) == 'int')
 
@@ -85,6 +85,9 @@ assert(a.g(1,2) == [1,2])
 assert(a.h(1,2) == [1,2])
 assert(A.g(1,2) == [1,2])
 assert(A.h(1,2) == [1,2])
+a.a = def (x,y) return [x,y] end
+assert(a.a(1,2) == [1,2])
+
 
 #- test static initializers -#
 class A

--- a/tests/class_const.be
+++ b/tests/class_const.be
@@ -65,8 +65,26 @@ assert(type(a.g) == 'function')
 assert(type(a.h) == 'function')
 
 assert_attribute_error("a.g(1,2)")
-assert(a.h(1) == 'instance')
-# A.h(1) - error
+assert(a.h(1) == 'int')
+assert(A.h(1) == 'int')
+
+
+class A
+    var a
+    static def g(x, y) return [x,y] end
+    static h = def (x, y) return [x,y] end
+    def init() self.a = 1 end
+    def f(x, y) return type(self) end
+end
+a=A()
+assert(type(a.g) == 'function')
+assert(type(a.h) == 'function')
+assert(type(A.g) == 'function')
+assert(type(A.h) == 'function')
+assert(a.g(1,2) == [1,2])
+assert(a.h(1,2) == [1,2])
+assert(A.g(1,2) == [1,2])
+assert(A.h(1,2) == [1,2])
 
 #- test static initializers -#
 class A


### PR DESCRIPTION
Form the experience of Berry developers in Tasmota, it was confusing that functions declared as instance variables acted like methods and not functions (i.e. got `self` is first argument). I propose to change this behavior and introduce pure static methods in classes.So any call will no longer add an implicit `self` depending on the calling syntax.

Before:
``` python
> class A static f = def(x) return x end end
> a = A()
> a.f(1)
<instance: A()>      # argument x is actually `self`
```

After
``` python
> class A static f = def(x) return x end end
> a = A()
> a.f(1)
1
```

## New syntax

There is now a new simplified syntax for static methods:

``` python
class <class_name>
    static def <name>(<args>)
        <body>
   end
end
```

This syntax is more or less equivalent to:

``` python
class <class_name>
    static <name> = def (<args>)
        <body>
    end
end
```

Example:

``` python
# declaring the following class:
class A
  var g
  static def f(x)
    print(type(x))
  end
end
```

``` python
# calling directly a static method
> A.f(0)
int

# calling from an instance
> a = A()
> a.f(0)
int        # used to be `instance`

# setting an instance variable of an instance and calling it as a method now throws an error to avoid any confusion
> a.g = def (x) print(type(x)) end
> a.g(0)
attribute_error: class 'A' has no method 'g'
stack traceback:
	stdin:1: in function `main`

# instead assign to a variable
> var g = a.g
> g(0)
int
```

## Implementation

I needed to renumber the internal type, to free space for an additional bit (bit 7) to act as a marker for static method.

Now types are in two groups, non-gc and gc-able, to allows for extensions without breaking bytecode:
``` C
/* basic types, do not change value */
#define BE_NIL          0
#define BE_INT          1
#define BE_REAL         2
#define BE_BOOL         3
#define BE_NONE         4       /* unknown type */
#define BE_COMPTR       5       /* common pointer */
#define BE_INDEX        6       /* index for instance variable, previously BE_INT */
#define BE_FUNCTION     7

#define BE_GCOBJECT     16      /* from this type can be gced */

#define BE_STRING       16
#define BE_CLASS        17
#define BE_INSTANCE     18
#define BE_PROTO        19
#define BE_LIST         20
#define BE_MAP          21
#define BE_MODULE       22
#define BE_COMOBJ       23      /* common object */
```

Bytecode `.bec` version is changed and any precompiled bytecode needs to be compiled again. Solidified code does not need any change.

By default the `static` (bit 7) marker is not set. It is set only if a function is assigned to a `class` or an `instance` via `SETMBR`, which happens automatically when creating a class with static member.
