### PR TITLE
Avoid crashes with solidified code

### DIFF
--- a/src/be_api.c
+++ b/src/be_api.c
@@ -51,7 +51,7 @@ static void class_init(bvm *vm, bclass *c, const bnfuncinfo *lib)
                 ++slib;
             }
         }
-        be_map_release(vm, c->members); /* clear space */
+        be_map_compact(vm, c->members); /* clear space */
     }
 }
 

--- a/src/be_class.c
+++ b/src/be_class.c
@@ -40,7 +40,7 @@ bclass* be_newclass(bvm *vm, bstring *name, bclass *super)
 void be_class_compress(bvm *vm, bclass *c)
 {
     if (!gc_isconst(c) && c->members) {
-        be_map_release(vm, c->members); /* clear space */
+        be_map_compact(vm, c->members); /* clear space */
     }
 }
 

--- a/src/be_map.c
+++ b/src/be_map.c
@@ -343,8 +343,10 @@ bmapnode* be_map_val2node(bvalue *value)
     return (bmapnode *)((size_t)value - sizeof(bmapkey));
 }
 
-void be_map_release(bvm *vm, bmap *map)
+void be_map_compact(bvm *vm, bmap *map)
 {
     (void)vm;
-    resize(vm, map, map->count ? map->count : 1);
+    if (!gc_isconst(map)) {
+        resize(vm, map, map->count ? map->count : 1);
+    }
 }

--- a/src/be_map.h
+++ b/src/be_map.h
@@ -56,6 +56,6 @@ bvalue* be_map_insertstr(bvm *vm, bmap *map, bstring *key, bvalue *value);
 void be_map_removestr(bvm *vm, bmap *map, bstring *key);
 bmapnode* be_map_next(bmap *map, bmapiter *iter);
 bmapnode* be_map_val2node(bvalue *value);
-void be_map_release(bvm *vm, bmap *map);
+void be_map_compact(bvm *vm, bmap *map);
 
 #endif

--- a/src/be_module.c
+++ b/src/be_module.c
@@ -99,7 +99,7 @@ static bmodule* new_module(bvm *vm, const bntvmodule *nm)
         obj->table = NULL; /* gc protection */
         obj->table = be_map_new(vm);
         insert_attrs(vm, obj->table, nm);
-        be_map_release(vm, obj->table); /* clear space */
+        be_map_compact(vm, obj->table); /* clear space */
         be_stackpop(vm, 1);
     }
     return obj;

--- a/src/be_var.c
+++ b/src/be_var.c
@@ -87,7 +87,7 @@ bvalue* be_global_var(bvm *vm, int index)
 
 void be_global_release_space(bvm *vm)
 {
-    be_map_release(vm, global(vm).vtab);
+    be_map_compact(vm, global(vm).vtab);
     be_vector_release(vm, &global(vm).vlist);
 }
 
@@ -130,7 +130,7 @@ int be_builtin_new(bvm *vm, bstring *name)
 
 void be_bulitin_release_space(bvm *vm)
 {
-    be_map_release(vm, builtin(vm).vtab);
+    be_map_compact(vm, builtin(vm).vtab);
     be_vector_release(vm, &builtin(vm).vlist);
 }
 #else

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -964,7 +964,12 @@ newframe: /* a new call frame */
             bvalue *a = RA(), *b = RKB();
             if (var_isclass(a) && var_isclass(b)) {
                 bclass *obj = var_toobj(a);
-                be_class_setsuper(obj, var_toobj(b));
+                if (!gc_isconst(obj))  {
+                   be_class_setsuper(obj, var_toobj(b));
+                } else {
+                    vm_error(vm, "internal_error",
+                    "cannot change superclass of a read-only class");
+                }
             } else {
                 vm_error(vm, "type_error",
                     "value '%s' does not support set super",


### PR DESCRIPTION
When code is solidified, prevent compaction and `SETSUPER` to happen on solidified code, avoiding a crash.

I propose also to rename `be_map_release()` to `be_map_compact()` which seems to me less misleading.