### PR TITLE
Allow json.dump on subclasses

### DIFF
--- a/src/be_jsonlib.c
+++ b/src/be_jsonlib.c
@@ -41,6 +41,7 @@ static const char* match_char(const char *json, int ch)
     }
     return NULL;
 }
+
 static int is_object(bvm *vm, const char *class, int idx)
 {
     if (be_isinstance(vm, idx)) {

--- a/src/be_jsonlib.c
+++ b/src/be_jsonlib.c
@@ -41,12 +41,22 @@ static const char* match_char(const char *json, int ch)
     }
     return NULL;
 }
-
 static int is_object(bvm *vm, const char *class, int idx)
 {
     if (be_isinstance(vm, idx)) {
-        const char *name = be_classname(vm, idx);
-        return !strcmp(name, class);
+        be_pushvalue(vm, idx);
+        while (1) {
+            be_getsuper(vm, -1);
+            if (be_isnil(vm, -1)) {
+                be_pop(vm, 1);
+                break;
+            }
+            be_remove(vm, -2);
+        }
+        const char *name = be_classname(vm, -1);
+        bbool ret = !strcmp(name, class);
+        be_pop(vm, 1);
+        return ret;
     }
     return  0;
 }

--- a/tests/json.be
+++ b/tests/json.be
@@ -51,3 +51,8 @@ assert_dump({1: 'x'}, '{"1":"x"}');
 assert_dump([1, 'x'], '[\n  1,\n  "x"\n]', 'format');
 assert_dump({1: 'x'}, '{\n  "1": "x"\n}', 'format');
 assert_dump({1: 'x', 'k': 'v'}, '{"k":"v","1":"x"}');
+
+class map2 : map def init() super(self).init() end end
+var m = map2()
+m['key'] = 1
+assert_dump(m, '{"key":1}')


### PR DESCRIPTION
Allows `json.dump()` to work on subclasses of `map` and `list. Added test case.