### PR TITLE
Add more perf counters

### DIFF
--- a/src/be_debuglib.c
+++ b/src/be_debuglib.c
@@ -169,6 +169,7 @@ static int m_counters(bvm *vm)
     map_insert(vm, "set", vm->counter_set);
     map_insert(vm, "try", vm->counter_try);
     map_insert(vm, "raise", vm->counter_exc);
+    map_insert(vm, "objects", vm->counter_gc_kept);
     be_pop(vm, 1);
     be_return(vm);
 }

--- a/src/be_exec.c
+++ b/src/be_exec.c
@@ -74,6 +74,9 @@ struct filebuf {
 
 void be_throw(bvm *vm, int errorcode)
 {
+#if BE_USE_PERF_COUNTERS
+    vm->counter_exc++;
+#endif
     if (vm->errjmp) {
         vm->errjmp->status = errorcode;
         exec_throw(vm->errjmp);

--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -497,6 +497,9 @@ static void delete_white(bvm *vm)
                 prev->next = next;
             }
             free_object(vm, node);
+#if BE_USE_PERF_COUNTERS
+            vm->counter_gc_freed++;
+#endif
         } else {
             gc_setwhite(node);
             prev = node;
@@ -537,6 +540,10 @@ void be_gc_collect(bvm *vm)
     if (vm->gc.status & GC_HALT) {
         return; /* the GC cannot run for some reason */
     }
+#if BE_USE_PERF_COUNTERS
+    vm->counter_gc_kept = 0;
+    vm->counter_gc_freed = 0;
+#endif
 #if BE_USE_OBSERVABILITY_HOOK
     if (vm->obshook != NULL)
         (*vm->obshook)(vm, BE_OBS_GC_START, vm->gc.usage);
@@ -559,6 +566,6 @@ void be_gc_collect(bvm *vm)
     vm->gc.threshold = next_threshold(vm->gc);
 #if BE_USE_OBSERVABILITY_HOOK
     if (vm->obshook != NULL)
-        (*vm->obshook)(vm, BE_OBS_GC_END, vm->gc.usage);
+        (*vm->obshook)(vm, BE_OBS_GC_END, vm->gc.usage, vm->counter_gc_kept, vm->counter_gc_freed);
 #endif
 }

--- a/src/be_gc.h
+++ b/src/be_gc.h
@@ -37,7 +37,11 @@ if (!gc_isconst(o)) { \
 
 #define gc_setwhite(o)      gc_setmark((o), GC_WHITE)
 #define gc_setgray(o)       gc_setmark((o), GC_GRAY)
-#define gc_setdark(o)       gc_setmark((o), GC_DARK)
+#if BE_USE_PERF_COUNTERS
+    #define gc_setdark(o)       { vm->counter_gc_kept++; gc_setmark((o), GC_DARK); }
+#else
+    #define gc_setdark(o)       gc_setmark((o), GC_DARK)
+#endif
 #define gc_isfixed(o)       (((o)->marked & GC_FIXED) != 0)
 #define gc_setfixed(o)      ((o)->marked |= GC_FIXED)
 #define gc_clearfixed(o)    ((o)->marked &= ~GC_FIXED)

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -20,6 +20,7 @@
 #include "be_decoder.h"
 #include "be_debug.h"
 #include "be_exec.h"
+#include <limits.h>
 
 #define OP_NOT_BINARY           TokenNone
 #define OP_NOT_UNARY            TokenNone
@@ -29,6 +30,17 @@
 
 #define FUNC_METHOD             1
 #define FUNC_ANONYMOUS          2
+
+#if BE_INTGER_TYPE == 0 /* int */
+  #define M_IMAX    INT_MAX
+  #define M_IMIN    INT_MIN
+#elif BE_INTGER_TYPE == 1 /* long */
+  #define M_IMAX    LONG_MAX
+  #define M_IMIN    LONG_MIN
+#else /* int64_t (long long) */
+  #define M_IMAX    LLONG_MAX
+  #define M_IMIN    LLONG_MIN
+#endif
 
 /* get binary operator priority */
 #define binary_op_prio(op)      (binary_op_prio_tab[cast_int(op) - OptAdd])
@@ -602,12 +614,12 @@ static bproto* funcbody(bparser *parser, bstring *name, int type)
     return finfo.proto; /* return fully constructed `bproto` */
 }
 
-/* anonymous function, build `bproto` object with name `<anonymous>` */
+/* anonymous function, build `bproto` object with name `_anonymous_` */
 /* and build a expdesc for the bproto */
 static void anon_func(bparser *parser, bexpdesc *e)
 {
     bproto *proto;
-    bstring *name = parser_newstr(parser, "<anonymous>");
+    bstring *name = parser_newstr(parser, "_anonymous_");
     /* 'def' ID '(' varlist ')' block 'end' */
     scan_next_token(parser); /* skip 'def' */
     proto = funcbody(parser, name, FUNC_ANONYMOUS);

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -20,7 +20,6 @@
 #include "be_decoder.h"
 #include "be_debug.h"
 #include "be_exec.h"
-#include <limits.h>
 
 #define OP_NOT_BINARY           TokenNone
 #define OP_NOT_UNARY            TokenNone
@@ -30,17 +29,6 @@
 
 #define FUNC_METHOD             1
 #define FUNC_ANONYMOUS          2
-
-#if BE_INTGER_TYPE == 0 /* int */
-  #define M_IMAX    INT_MAX
-  #define M_IMIN    INT_MIN
-#elif BE_INTGER_TYPE == 1 /* long */
-  #define M_IMAX    LONG_MAX
-  #define M_IMIN    LONG_MIN
-#else /* int64_t (long long) */
-  #define M_IMAX    LLONG_MAX
-  #define M_IMIN    LLONG_MIN
-#endif
 
 /* get binary operator priority */
 #define binary_op_prio(op)      (binary_op_prio_tab[cast_int(op) - OptAdd])

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -472,6 +472,8 @@ BERRY_API bvm* be_vm_new(void)
     vm->counter_set = 0;
     vm->counter_try = 0;
     vm->counter_exc = 0;
+    vm->counter_gc_kept = 0;
+    vm->counter_gc_freed = 0;
 #endif
     return vm;
 }

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -112,6 +112,8 @@ struct bvm {
     uint32_t counter_set; /* counter for SETMBR */
     uint32_t counter_try; /* counter for `try` statement */
     uint32_t counter_exc; /* counter for raised exceptions */
+    uint32_t counter_gc_kept; /* counter for objects scanned by last gc */
+    uint32_t counter_gc_freed; /* counter for objects freed by last gc */
 #endif
 #if BE_USE_DEBUG_HOOK
     bvalue hook;


### PR DESCRIPTION
Changes to performance counters:
- fixed the counter for exceptions raised
- add 2 new counters at each gc: `counter_gc_kept` counts the number of objects that survived the GC, `counter_gc_freed` the number of objects that were freed
- For solidification, renamed anonymous functions from `<anonymous>` to `_anonymous_` to make names easier to escape
- Added `objects` metrics to `debug.counters()`