### PR TITLE
Added string.tr() and string.escape()

### DIFF
--- a/src/be_string.c
+++ b/src/be_string.c
@@ -57,12 +57,18 @@ int be_eqstr(bstring *s1, bstring *s2)
     }
     /* const short strings */
     if (gc_isconst(s1) || gc_isconst(s2)) { /* one of the two string is short const */
-        if (cast(bcstring*, s1)->hash && cast(bcstring*, s2)->hash) {
-            return 0; /* if they both have a hash, then we know they are different */
+        uint32_t hash1 = cast(bcstring*, s1)->hash;
+        uint32_t hash2 = cast(bcstring*, s2)->hash;
+        if (hash1 && hash2 && hash1 != hash2) {
+            return 0; /* if hash differ, since we know both are non-null */
         }
+        /* if hash are equals, there might be a chance that they are different */
+        /* This can happen with solidified code that a same string is present more than once */
+        /* so just considering that two strings with the same hash must be same pointer, this is no more true */
         return !strcmp(str(s1), str(s2));
     }
 
+    /* if both strings are in-memory, they can't be equal without having the same pointer */
     return 0;
 }
 

--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -787,6 +787,53 @@ static int str_toupper(bvm *vm) {
     return str_touplower(vm, btrue);
 }
 
+static int str_tr(bvm *vm)
+{
+    if (be_top(vm) == 3 && be_isstring(vm, 1) && be_isstring(vm, 2) && be_isstring(vm, 3)) {
+        const char *p, *s = be_tostring(vm, 1);
+        const char *t1 = be_tostring(vm, 2);
+        const char *t2 = be_tostring(vm, 3);
+        if (strlen(t2) < strlen(t1)) {
+            be_raise(vm, "value_error", "invalid translation pattern");
+        }
+        size_t len = (size_t)be_strlen(vm, 1);
+        char *buf, *q;
+        buf = be_pushbuffer(vm, len);
+        /* convert each char */
+        for (p = s, q = buf; *p != '\0'; ++p, ++q) {
+            const char *p1, *p2;
+            *q = *p;  /* default to no change */
+            for (p1=t1, p2=t2; *p1 != '\0'; ++p1, ++p2) {
+                if (*p == *p1) {
+                    *q = *p2;
+                    break;
+                }
+            }
+        }
+        be_pushnstring(vm, buf, len); /* make escape string from buffer */
+        be_remove(vm, 2); /* remove buffer */
+        be_return(vm);
+    }
+    be_return_nil(vm);
+}
+
+static int str_escape(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1 && be_isstring(vm, 1)) {
+        int quote = 'u';
+        if (top >= 2 && be_isbool(vm, 2)) {
+            if (be_tobool(vm, 1)) {
+                quote = 'x';
+            }
+        }
+        be_tostring(vm, 1);
+        be_toescape(vm, 1, quote);
+        be_pushvalue(vm, 1);
+        be_return(vm);
+    }
+    be_return_nil(vm);
+}
 
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(string) {
@@ -799,6 +846,8 @@ be_native_module_attr_table(string) {
     be_native_module_function("char", str_char),
     be_native_module_function("tolower", str_tolower),
     be_native_module_function("toupper", str_toupper),
+    be_native_module_function("tr", str_tr),
+    be_native_module_function("escape", str_escape),
 };
 
 be_define_native_module(string, NULL);
@@ -814,6 +863,8 @@ module string (scope: global, depend: BE_USE_STRING_MODULE) {
     char, func(str_char)
     tolower, func(str_tolower)
     toupper, func(str_toupper)
+    tr, func(str_tr)
+    escape, func(str_escape)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_string.h"

--- a/tests/string.be
+++ b/tests/string.be
@@ -52,3 +52,20 @@ assert(s[0..-2] == "azertyuio")
 assert(s[-4..-2] == "uio")
 assert(s[-2..-4] == "")  #- if range is in wrong order, returns empty string -#
 assert(s[-40..-2] == "azertyuio")  #- borders are allowed to be out of range -#
+
+# escape
+import string
+assert(string.escape("A") == '"A"')
+assert(string.escape("A", true) == "'A'")
+assert(string.escape("\"") == '"\\""')
+assert(string.escape("\"", true) == '\'"\'')
+
+var s ='"a\'b"\''
+assert(string.escape(s) == '"\\"a\'b\\"\'"')
+assert(string.escape(s, true) == '\'"a\\\'b"\\\'\'')
+
+# tr
+assert(string.tr("azer", "abcde", "ABCDE") == 'AzEr')
+assert(string.tr("azer", "", "") == 'azer')
+assert(string.tr("azer", "aaa", "ABC") == 'Azer')  # only first match works
+assert(string.tr("A_b", "_", " ") == 'A b')


### PR DESCRIPTION
Add two new funtions to `string` module

`string.tr(source:string, pattern_from:string, pattern_to:strin) -> string``

Takes the input string and converts any character in `pattern_from` to the corresponding character in `pattern_to``

```
> import string
> string.tr("Hello_world.", "_.", " !")
'Hello world!'
```

`string.escape(source:string [, single_quote:bool]) -> string`

Escapes a string into double quotes suitable for C and Berry code. When passing a second attribute as `true`, escapes to single quotes suitable for Berry (not C).

```
> import string
> print(string.escape('{"A":1}'))
"{\"A\":1}"
```