### PR TITLE
Fix exception

### DIFF
--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -1065,7 +1065,13 @@ newframe: /* a new call frame */
             if (!IGET_RA(ins)) {
                 be_except_block_setup(vm);
                 if (be_setjmp(vm->errjmp->b)) {
+                    bvalue *top = vm->top;
+                    bvalue e1 = top[0];
+                    bvalue e2 = top[1];
                     be_except_block_resume(vm);
+                    top = vm->top;
+                    top[0] = e1;
+                    top[1] = e2;
                     goto newframe;
                 }
                 reg = vm->reg;

--- a/tests/exceptions.be
+++ b/tests/exceptions.be
@@ -1,0 +1,7 @@
+
+try
+    for k: 0..1 assert({'a':1}.contains('b'), 'failure') end
+except .. as e,m
+    assert(e == "assert_failed")
+    assert(m == "failure")
+end


### PR DESCRIPTION
Fix for #177

Exceptions are stored in the 2 registers above the stack. However when calling an exception, the top of the stack might move after calling `be_except_block_resume()` and exception information is no more above the stack.
This fix takes a temporary copy of the two elements above the stack top and puts them back after `be_except_block_resume()`

Test case added