### PR TITLE
string.tr for removing characters

### DIFF
--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -793,9 +793,6 @@ static int str_tr(bvm *vm)
         const char *p, *s = be_tostring(vm, 1);
         const char *t1 = be_tostring(vm, 2);
         const char *t2 = be_tostring(vm, 3);
-        if (strlen(t2) < strlen(t1)) {
-            be_raise(vm, "value_error", "invalid translation pattern");
-        }
         size_t len = (size_t)be_strlen(vm, 1);
         char *buf, *q;
         buf = be_pushbuffer(vm, len);
@@ -803,11 +800,17 @@ static int str_tr(bvm *vm)
         for (p = s, q = buf; *p != '\0'; ++p, ++q) {
             const char *p1, *p2;
             *q = *p;  /* default to no change */
-            for (p1=t1, p2=t2; *p1 != '\0'; ++p1, ++p2) {
+            for (p1=t1, p2=t2; *p1 != '\0'; ++p1) {
                 if (*p == *p1) {
-                    *q = *p2;
+                    if (*p2) {
+                        *q = *p2;
+                    } else {
+                        q--;    /* remove this char */
+                        len--;
+                    }
                     break;
                 }
+                if (*p2) { p2++; }
             }
         }
         be_pushnstring(vm, buf, len); /* make escape string from buffer */

--- a/tests/string.be
+++ b/tests/string.be
@@ -69,3 +69,5 @@ assert(string.tr("azer", "abcde", "ABCDE") == 'AzEr')
 assert(string.tr("azer", "", "") == 'azer')
 assert(string.tr("azer", "aaa", "ABC") == 'Azer')  # only first match works
 assert(string.tr("A_b", "_", " ") == 'A b')
+# tr used to remove characters
+assert(string.tr("qwerty", "qwe", "_") == '_rty')


### PR DESCRIPTION
Extends `string.tr()` to remove characters if they are not in the second pattern, like unix `tr` command.

Example:

``` ruby
> import string
> string.tr("qwerty", "qwe", "_")
_rty
```