### PR TITLE
Always enable observability and allow minimum stack

### DIFF
--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -60,20 +60,14 @@
  **/
 #define BE_DEBUG_VAR_INFO               1
 
-/* Macro: BE_USE_OBSERVABILITY_HOOK
+/* Macro: BE_USE_PERF_COUNTERS
  * Use the obshook function to report low-level actions.
- * Default: 0
- **/
-#define BE_USE_OBSERVABILITY_HOOK       0
-
-/* Macro: BE_USE_OBSERVABILITY_HOOK
- * Use the obshook function to report low-level actions.
- * Default: 0
+ * Default: 1
  **/
 #define BE_USE_PERF_COUNTERS            1
 
 /* Macro: BE_VM_OBSERVABILITY_SAMPLING
- * If BE_USE_OBSERVABILITY_HOOK == 1 and BE_USE_PERF_COUNTERS == 1
+ * If BE_USE_PERF_COUNTERS == 1
  * then the observability hook is called regularly in the VM loop
  * allowing to stop infinite loops or too-long running code.
  * The value is a power of 2.
@@ -94,6 +88,12 @@
  * Default: 10
  **/
 #define BE_STACK_FREE_MIN               10
+
+/* Macro: BE_STACK_START
+ * Set the starting size of the stack at VM creation.
+ * Default: 50
+ **/
+#define BE_STACK_START                  50
 
 /* Macro: BE_CONST_SEARCH_SIZE
  * Constants in function are limited to 255. However the compiler

--- a/src/be_exec.c
+++ b/src/be_exec.c
@@ -393,10 +393,7 @@ void be_stack_expansion(bvm *vm, int n)
         stack_resize(vm, size + 1);
         be_raise(vm, "runtime_error", STACK_OVER_MSG(BE_STACK_TOTAL_MAX));
     }
-#if BE_USE_OBSERVABILITY_HOOK
-    if (vm->obshook != NULL)
-        (*vm->obshook)(vm, BE_OBS_STACK_RESIZE_START, size * sizeof(bvalue), (size + n) * sizeof(bvalue));
-#endif
+    if (vm->obshook != NULL) (*vm->obshook)(vm, BE_OBS_STACK_RESIZE_START, size * sizeof(bvalue), (size + n) * sizeof(bvalue));
     stack_resize(vm, size + n);
 }
 

--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -544,10 +544,7 @@ void be_gc_collect(bvm *vm)
     vm->counter_gc_kept = 0;
     vm->counter_gc_freed = 0;
 #endif
-#if BE_USE_OBSERVABILITY_HOOK
-    if (vm->obshook != NULL)
-        (*vm->obshook)(vm, BE_OBS_GC_START, vm->gc.usage);
-#endif
+    if (vm->obshook != NULL) (*vm->obshook)(vm, BE_OBS_GC_START, vm->gc.usage);
     /* step 1: set root-set reference objects to unscanned */
     premark_internal(vm); /* object internal the VM */
     premark_global(vm); /* global objects */
@@ -564,8 +561,5 @@ void be_gc_collect(bvm *vm)
     reset_fixedlist(vm);
     /* step 5: calculate the next GC threshold */
     vm->gc.threshold = next_threshold(vm->gc);
-#if BE_USE_OBSERVABILITY_HOOK
-    if (vm->obshook != NULL)
-        (*vm->obshook)(vm, BE_OBS_GC_END, vm->gc.usage, vm->counter_gc_kept, vm->counter_gc_freed);
-#endif
+    if (vm->obshook != NULL) (*vm->obshook)(vm, BE_OBS_GC_END, vm->gc.usage, vm->counter_gc_kept, vm->counter_gc_freed);
 }

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -101,9 +101,7 @@ struct bvm {
     blist *registry; /* registry list */
     struct bgc gc;
     bbyte compopt; /* compilation options */
-#if BE_USE_OBSERVABILITY_HOOK
     bobshook obshook;
-#endif
 #if BE_USE_PERF_COUNTERS
     uint32_t counter_ins; /* instructions counter */
     uint32_t counter_enter; /* counter for times the VM was entered */

--- a/src/berry.h
+++ b/src/berry.h
@@ -402,6 +402,7 @@ typedef void(*bntvhook)(bvm *vm, bhookinfo *info);
 
 typedef void(*bobshook)(bvm *vm, int event, ...);
 enum beobshookevents {
+  BE_OBS_PCALL_ERROR,     /* called when be_callp() returned an error, most likely an exception */
   BE_OBS_GC_START,        /* start of GC, arg = allocated size */
   BE_OBS_GC_END,          /* end of GC, arg = allocated size */
   BE_OBS_VM_HEARTBEAT,    /* VM heartbeat called every million instructions */


### PR DESCRIPTION
Add `BE_STACK_START` macro to define the starting size for the Berry register stack. This avoids multiple resizes (and potentially bugs) when starting the MCU when you know in advance that the stack will reach a certain size.

Also removed `BE_USE_OBSERVABILITY_HOOK` to make observability always enabled. The check for a hook is only done in rare occasions (stack resize, gc, heartbeat) so there is anyways no impact on performance.