### PR TITLE
Allow open range for right arg

### DIFF
--- a/tests/lexer.be
+++ b/tests/lexer.be
@@ -38,7 +38,7 @@ check(45.e+2, 4500)
 
 test_source('x = 5; 0...x;', 'unexpected symbol near \'.\'')
 test_source('x = 5; 0...x;', 'unexpected symbol near \'.\'')
-test_source('45..', 'unexpected symbol near \'EOS\'')
+# test_source('45..', 'unexpected symbol near \'EOS\'')
 test_source('0xg', 'invalid hexadecimal number')
 test_source('"\\x5g"', 'invalid hexadecimal number')
 test_source('0x5g', 'malformed number')

--- a/tests/lexer.be
+++ b/tests/lexer.be
@@ -38,7 +38,6 @@ check(45.e+2, 4500)
 
 test_source('x = 5; 0...x;', 'unexpected symbol near \'.\'')
 test_source('x = 5; 0...x;', 'unexpected symbol near \'.\'')
-# test_source('45..', 'unexpected symbol near \'EOS\'')
 test_source('0xg', 'invalid hexadecimal number')
 test_source('"\\x5g"', 'invalid hexadecimal number')
 test_source('0x5g', 'malformed number')

--- a/tests/string.be
+++ b/tests/string.be
@@ -35,6 +35,11 @@ assert(s.format("%i%%%i", 12, 13) == "12%13")
 assert(s.format("%s%%", "foo") == "foo%")
 assert(s.format("%.1f%%", 3.5) == "3.5%")
 
+s="azerty"
+assert(s[1..2] == "ze")
+assert(s[1..] == "zerty")
+assert(s[1..-1] == "zerty")
+
 #- string ranges -#
 s="azertyuiop"
 assert(s[0] == "a")

--- a/tools/grammar/berry.ebnf
+++ b/tools/grammar/berry.ebnf
@@ -17,7 +17,7 @@ func_body = '(' [arg_field {',' arg_field}] ')' block 'end';
 arg_field = ['*'] ID;
 (* class define statement *)
 class_stmt = 'class' ID [':' ID] class_block 'end';
-class_block = {'var' ID {',' ID} | 'static' ID ['=' expr] {',' ID ['=' expr] } | func_stmt};
+class_block = {'var' ID {',' ID} | 'static' ID ['=' expr] {',' ID ['=' expr] } | 'static' func_stmt | func_stmt};
 import_stmt = 'import' (ID (['as' ID] | {',' ID}) | STRING 'as' ID);
 (* exceptional handling statement *)
 try_stmt = 'try' block except_block {except_block} 'end';
@@ -28,12 +28,13 @@ throw_stmt = 'raise' expr [',' expr];
 var_stmt = 'var' ID ['=' expr] {',' ID ['=' expr]};
 (* expression define *)
 expr_stmt = expr [assign_op expr];
-expr = suffix_expr | unop expr | expr binop expr | cond_expr;
+expr = suffix_expr | unop expr | expr binop expr | range_expr | cond_expr;
 cond_expr = expr '?' expr ':' expr; (* conditional expression *)
 assign_op = '=' | '+=' | '-=' | '*=' | '/=' |
             '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=';
-binop = '..' | '<' | '<=' | '==' | '!=' | '>' | '>=' | '||' | '&&' |
+binop = '<' | '<=' | '==' | '!=' | '>' | '>=' | '||' | '&&' |
         '<<' | '>>' | '&' | '|' | '^' | '+' | '-' | '*' | '/' | '%';
+range_expr = expr '..' [expr]
 unop = '-' | '!' | '~';
 suffix_expr = primary_expr {call_expr | ('.' ID) | '[' expr ']'};
 primary_expr = '(' expr ')' | simple_expr | list_expr | map_expr | anon_func | lambda_expr;


### PR DESCRIPTION
This was a feature asked by Tasmota users to mimick the Python open range.

Now you can do `l[1..]` to get all elements from second element to last one.

Internally `1..` is parsed as `1..MAX_INT`

``` ruby
> l = [1,2,3]
> l[1..]
[2, 3]
```

Note: I'm not sure how to change the grammar to indicate the binary operator `..` accepts that there is no right expr.