### PR TITLE
Pycoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,18 @@ INCPATH   = src default
 SRCPATH   = src default
 GENERATE  = generate
 CONFIG    = default/berry_conf.h
-COC		  = tools/coc/coc
+# COC		  = tools/coc/coc
+PY3       = python3
+PYCOC     = tools/pycoc/main.py
 CONST_TAB = $(GENERATE)/be_const_strtab.h
-MAKE_COC  = $(MAKE) -C tools/coc
+# MAKE_COC  = $(MAKE) -C tools/coc
 
 ifeq ($(OS), Windows_NT) # Windows
     CFLAGS    += -Wno-format # for "%I64d" warning
     LFLAGS    += -Wl,--out-implib,berry.lib # export symbols lib for dll linked
     TARGET    := $(TARGET).exe
-    COC       := $(COC).exe
+    # COC       := $(COC).exe
+    PY3       := $(PY3).exe
 else
     CFLAGS    += -DUSE_READLINE_LIB
     LIBS      += -lreadline -ldl
@@ -30,7 +33,7 @@ endif
 ifneq ($(V), 1)
     Q=@
     MSG=@echo
-    MAKE_COC += -s Q=$(Q)
+    # MAKE_COC += -s Q=$(Q)
 else
     MSG=@true
 endif
@@ -73,16 +76,16 @@ sinclude $(DEPS)
 
 $(OBJS): $(CONST_TAB)
 
-$(CONST_TAB): $(COC) $(GENERATE) $(SRCS) $(CONFIG)
+$(CONST_TAB): $(GENERATE) $(SRCS) $(CONFIG)
 	$(MSG) [Prebuild] generate resources
-	$(Q) $(COC) -i $(SRCPATH) -c $(CONFIG) -o $(GENERATE)
+	$(Q) $(PY3) $(PYCOC)  -o $(GENERATE) $(SRCPATH) -c $(CONFIG)
 
 $(GENERATE):
 	$(Q) $(MKDIR) $(GENERATE)
 
-$(COC):
-	$(MSG) [Make] coc
-	$(Q) $(MAKE_COC)
+# $(COC):
+# 	$(MSG) [Make] coc
+# 	$(Q) $(MAKE_COC)
 
 install:
 	cp $(TARGET) /usr/local/bin
@@ -90,13 +93,12 @@ install:
 uninstall:
 	$(RM) /usr/local/bin/$(TARGET)
 
-prebuild: $(COC) $(GENERATE)
+prebuild: $(GENERATE)
 	$(MSG) [Prebuild] generate resources
-	$(Q) $(COC) -o $(GENERATE) $(SRCPATH) -c $(CONFIG)
+	$(Q) $(PY3) $(PYCOC) -o $(GENERATE) $(SRCPATH) -c $(CONFIG)
 	$(MSG) done
 
 clean:
 	$(MSG) [Clean...]
 	$(Q) $(RM) $(OBJS) $(DEPS) $(GENERATE)/* berry.lib
-	$(Q) $(MAKE_COC) clean
 	$(MSG) done

--- a/tools/pycoc/block_builder.py
+++ b/tools/pycoc/block_builder.py
@@ -1,0 +1,152 @@
+import copy
+from hash_map import *
+
+class block:
+    def __init__(self):
+        self.type = ""
+        self.name = ""
+        self.attr = {}
+        self.data = {}
+        self.data_ordered = []
+
+def depend(obj, macro):
+    if "depend" in obj.attr:
+        return macro.query(obj.attr["depend"])
+    else:
+        return True
+
+class block_builder:
+    """Output an object"""
+
+    def __init__(self, obj, macro):
+        self.block = block()
+        self.strtab = []
+
+        self.block.name = obj.name
+        if depend(obj, macro):
+            self.block.type = obj.type
+            self.block.attr = obj.attr
+            
+            if "name" in obj.attr:
+                self.strtab.append(obj.attr["name"])
+            
+            for key in obj.data_ordered:
+                second = obj.data[key]
+                if second.depend == None or macro.query(second.depend):
+                    self.block.data[key] = second.value
+                    self.strtab.append(key)
+                    self.block.data_ordered.append(key)
+    
+    def block_tostring(self, block):
+        ostr = ""
+        if block.type == "map":
+            ostr += self.map_tostring(block, block.name)
+        elif block.type == "class":
+            ostr += self.class_tostring(block)
+        elif block.type == "vartab":
+            ostr += self.vartab_tostring(block)
+        elif block.type == "module":
+            ostr += self.module_tostring(block)
+        return ostr
+
+    def class_tostring(self, block):
+        ostr = ""
+        hmap = hash_map(block.data)
+        map_name = block.name + "_map"
+        if len(block.data) > 0:
+            ostr += self.map_tostring(block, map_name, True) + "\n"
+        
+        ostr += self.scope(block) + " be_define_const_class(\n    "
+        ostr += block.name + ",\n    "
+        ostr += str(hmap.var_count()) + ",\n    "
+        ostr += self.get_super(block) + ",\n    "
+        ostr += self.name(block) + "\n);\n"
+        return ostr
+    
+    def map_tostring(self, block, name, local):
+        hmap = hash_map(block.data)
+        entlist = hmap.entry_list()
+        ostr = "static be_define_const_map_slots(" + name + ") {\n"
+        for ent in entlist:
+            ostr += "    { be_const_key(" + ent.key + ", "
+            ostr += str(ent.next) + "), " + ent.value + " },\n"
+        ostr += "};\n\n"
+
+        if local:
+            ostr += "static"
+        else:
+            ostr += self.scope(block)
+        ostr += " be_define_const_map(\n    "
+        ostr += name + ",\n    "
+        ostr += str(len(entlist)) + "\n);\n"
+        return ostr
+    
+    def vartab_tostring(self, block):
+        ostr = ""
+        varvec = []
+        idxblk = copy.deepcopy(block)
+        index = 0
+        idxblk.data = {}
+        for key in block.data_ordered:
+            varvec.append(block.data[key])
+            idxblk.data[key] = "int(" + str(index) + ")"
+            index += 1
+        
+        ostr += self.map_tostring(idxblk, block.name + "_map", True) + "\n"
+        ostr += "static const bvalue __vlist_array[] = {\n";
+        for it in varvec:
+            ostr += "    be_const_" + it + ",\n"
+        ostr += "};\n\n"
+
+        ostr += "static be_define_const_vector(\n    "
+        ostr += block.name + "_vector,\n    __vlist_array,\n    "
+        ostr += str(len(varvec)) + "\n);\n"
+        return ostr
+    
+    def module_tostring(self, block):
+        ostr = ""
+        name = "m_lib" + block.name
+        map_name = name + "_map"
+
+        ostr += self.map_tostring(block, map_name, True) + "\n"
+        ostr += "static be_define_const_module(\n    "
+        ostr += name + ",\n    "
+        ostr += "\"" + block.name + "\"\n);\n"
+        scp = self.scope(block)
+        if scp != "static":
+            ostr += "\n" + scp
+            ostr += " be_define_const_native_module("
+            ostr += block.name + ");\n"
+        return ostr
+
+    def scope(self, block):
+        if "local" in block.attr:
+            return "static"
+        else:
+            return "BE_EXPORT_VARIABLE"
+
+    def get_super(self, block):
+        if "super" in block.attr:
+            return "(bclass *)&" + block.attr["super"]
+        else:
+            return "NULL"
+    
+    def name(self, block):
+        if "name" in block.attr:
+            return block.attr["name"]
+        else:
+            return block.name
+    
+    def writefile(self, filename, text):
+        otext = "#include \"be_constobj.h\"\n\n" + text
+        with open(filename, "w") as f:
+            f.write(otext)
+
+    def dumpfile(self, path):
+        s = self.block_tostring(self.block)
+        if "file" in self.block.attr:
+            name = self.block.attr["file"]
+        else:
+            name = self.block.name
+        self.writefile(path + "/be_fixed_" + name + ".h", s)
+        

--- a/tools/pycoc/coc_parser.py
+++ b/tools/pycoc/coc_parser.py
@@ -1,0 +1,146 @@
+import re
+from coc_string import unescape_operator
+
+class data_value:
+    def __init__(self):
+        self.value = None
+        self.depend = None
+
+class object_block:
+    def __init__(self):
+        self.type = None
+        self.name = None
+        self.attr = {}
+        self.data = {}
+        self.data_ordered = []
+
+class coc_parser:
+    """Parser for Berry"""
+
+    def __init__(self, text):
+        """Parse text file"""
+        self.objects = []
+        self.strtab = set()
+        self.text = text
+        self.parsers = {
+            "@const_object_info_begin": self.parse_object,
+            "be_const_str_": self.parse_string,
+            "be_const_key(": self.parse_string,
+            "be_nested_str(": self.parse_string,
+        }
+
+        while len(self.text) > 0:
+            pattern = "|".join(self.parsers.keys())
+            pattern = re.sub("\\(", "\\(", pattern)
+            r = re.search(pattern, self.text)
+            if not r: break
+
+            self.text = self.text[r.end(0):]        # keep only after pattern
+            func = self.parsers[r[0]]                # retrieve function for matched
+            func()                                  # call function
+    
+    # def scan_const_string(self):
+    #     r = re.match(r"\w*", self.text)
+    #     if r:
+    #         self.text = self.text[r.end(0)]
+    #         self.strtab.append(r[0])
+    
+    def skip_space(self):
+        r = re.match(r"\s+", self.text)
+        if r:
+            self.text = self.text[r.end(0):]
+    
+    def parse_char_base(self, c, necessary):
+        res = self.text[0] == c
+        if not res and necessary:   print(self.text); raise "error"
+        if res: self.text = self.text[1:]
+        return res
+    
+    def parse_char(self, c, necessary = False):
+        self.skip_space()
+        return self.parse_char_base(c, necessary)
+    
+    def skip_char(self, c):
+        self.parse_char(c, True)
+
+    def parse_char_continue(self, c, necessary = False):
+        ch = self.text[0]
+        while ch == ' ' or ch == "\t":  self.text = self.text[1:]
+        return self.parse_char_base(c, necessary)
+
+    def parse_word(self):
+        self.skip_space()
+        r = re.match(r"\w+", self.text)
+        self.text = self.text[r.end(0):]
+        return r[0]
+
+    def parse_tocomma(self):
+        self.skip_space()
+        r = re.match(r"[^,\s]*", self.text)
+        self.text = self.text[r.end(0):]
+        return r[0]
+
+    def parse_tonewline(self):
+        self.skip_space()
+        r = re.match(r"[^\r\n]*", self.text)
+        self.text = self.text[r.end(0):]
+        return r[0]
+
+    def parse_object(self):
+        while True:
+            obj = self.parse_block()
+            self.objects.append(obj)
+            if self.parse_char("@"): break
+        
+        end_text = "const_object_info_end"
+        if not str.startswith(self.text, end_text): raise "error"
+        self.text = self.text[len(end_text):]
+        # print("END: @const_object_info_end test={self.text}")
+
+    def parse_string(self):
+        if not self.text[0].isalnum() and self.text[0] != '_': return      # do not proceed, maybe false positive in solidify
+        ident = self.parse_word()
+        literal = unescape_operator(ident)
+        if not literal in self.strtab:
+            self.strtab.add(literal)
+            # print(f"str '{ident}' -> {literal}")
+
+    def parse_block(self):
+        obj = object_block()
+        obj.type = self.parse_word()
+        obj.name = self.parse_word()
+        # print(f"parse_block: type={obj.type} name={obj.name}")
+        self.parse_attr(obj)
+        self.parse_body(obj)
+        return obj
+
+    def parse_attr(self, obj):
+        self.skip_char("(")
+        self.parse_attr_pair(obj)
+        while self.parse_char(","):
+            self.parse_attr_pair(obj)
+        self.skip_char(")")
+
+    def parse_attr_pair(self, obj):
+        key = self.parse_word()
+        self.skip_char(":")
+        value = self.parse_word()
+        obj.attr[key] = value
+    
+    def parse_body(self, obj):
+        self.skip_char("{")
+        if not self.parse_char("}"):
+            while True:
+                self.parse_body_item(obj)
+                if self.parse_char("}"): break
+    
+    def parse_body_item(self, obj):
+        value = data_value()
+        key = self.parse_tocomma()
+        # print(f"Key={key}")
+        self.parse_char_continue(",", True)
+        value.value = self.parse_tocomma()
+        if self.parse_char_continue(","):
+            value.depend = self.parse_tonewline()
+        obj.data[key] = value
+        obj.data_ordered.append(key)

--- a/tools/pycoc/coc_string.py
+++ b/tools/pycoc/coc_string.py
@@ -1,0 +1,40 @@
+import re
+
+def hashcode(s):
+    """Compute hash for a string, in uint32_t"""
+    hash = 2166136261
+    for c in s.encode('utf8'):
+        hash = ((hash ^ c) * 16777619) & 0xFFFFFFFF
+    return hash
+
+def escape_operator_v1(s):
+    tab = {
+        # "void": "",
+        "..": "opt_connect",
+        "+": "opt_add",        "-": "opt_sub",
+        "*": "opt_mul",        "/": "opt_div",
+        "%": "opt_mod",        "&": "opt_and",
+        "^": "opt_xor",        "|": "opt_or",
+        "<": "opt_lt",         ">": "opt_gt",
+        "<=": "opt_le",        ">=": "opt_ge",
+        "==": "opt_eq",        "!=": "opt_neq",
+        "<<": "opt_shl",       ">>": "opt_shr",
+        "-*": "opt_neg",       "~": "opt_flip",
+        "()": "opt_call",
+    }
+    if s in tab: return tab[s]
+    s2 = ""
+    for c in s:
+        if c == '.':     s2 += 'dot_'
+        else:            s2 += c
+    return s2
+
+def escape_operator(s):
+    s = re.sub('_X', '_X_', s)                  # replace any esape sequence '_X' with '_XX'
+    s = re.sub('[^a-zA-Z0-9_]', lambda m: "_X{0:02X}".format(ord(m.group())), s)
+    return s
+
+def unescape_operator(s):
+    s = re.sub('_X[0-9A-F][0-9A-F]', lambda m: chr(int(m.group()[2:], 16)), s)
+    s = re.sub('_X_', '_X', s)
+    return s

--- a/tools/pycoc/coc_string_test.py
+++ b/tools/pycoc/coc_string_test.py
@@ -1,0 +1,18 @@
+import unittest
+from coc_string import *
+
+class Test_coc_string(unittest.TestCase):
+
+    def test_hash(self):
+        self.assertEqual(hashcode("add"), 993596020)
+        self.assertEqual(hashcode("real"), 3604983901)
+
+    def test_escape(self):
+        self.assertEqual(escape_operator("foo"), "foo")
+        self.assertEqual(escape_operator(".."), "_opt_connect")
+        self.assertEqual(escape_operator("foo.bar"), "foo_dot_bar")
+        self.assertEqual(escape_operator("foo._bar"), "foo_dot___bar")
+        self.assertEqual(escape_operator("foo. bar"), "foo_dot__20bar")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/pycoc/hash_map.py
+++ b/tools/pycoc/hash_map.py
@@ -1,0 +1,162 @@
+import copy
+from coc_string import *
+
+# resize a list, from https://stackoverflow.com/a/8850956
+def list_resize_entry(l, newsize, filling=None):                                                                                  
+    if newsize > len(l):                                                                                 
+        l.extend([entry() for x in range(len(l), newsize)])                                                 
+    else:                                                                                                
+        del l[newsize:]
+
+class entry:
+    def __init__(self):
+        self.key = ""
+        self.value = ""
+        self.next = hash_map.NODE_EMPTY
+    
+    def __repr__(self):
+        return f"<entry object; key='{self.key}', value='{self.value}', next={self.next}>"
+
+class hash_map:
+    NODE_EMPTY = -2
+    NODE_NULL = -1
+
+    def __init__(self, map):
+        self.count = 0
+        self.lastfree = 0
+        self.bucket = []
+
+        self.resize(2)
+        for key in sorted(map.keys()):
+            self.insert(key, map[key])
+    
+    def __repr__(self):
+        return f"<hash_map object; count={self.count}, bucket={self.bucket}, lastfree={self.lastfree}>"
+
+    def is_empty(self, ent):
+        return ent.next == hash_map.NODE_EMPTY
+    
+    def resize(self, size):
+        bucket = copy.deepcopy(self.bucket)
+        list_resize_entry(self.bucket, size)
+        # set all slot to empty
+        for i in range(size):
+            self.bucket[i].next = hash_map.NODE_EMPTY
+        self.lastfree = size - 1
+        for slot in bucket:
+            if slot.next != hash_map.NODE_EMPTY:
+                self.insert_p(slot.key, slot.value)
+
+    def findprev(self, prev, slot):
+        #print(f"findprev: prev={prev} slot={slot}")
+        while True:
+            next = prev.next
+            if next == hash_map.NODE_NULL or self.bucket[next] == slot: break
+            prev = self.bucket[next]
+        if next == hash_map.NODE_NULL: return None
+        return prev
+    
+    def nextfree(self):
+        while self.lastfree >= 0:
+            if self.bucket[self.lastfree].next == hash_map.NODE_EMPTY:
+                return self.lastfree
+            self.lastfree -= 1
+        return -1
+    
+    def find(self, key):
+        hash = hashcode(key)
+        null = entry()
+        slot = self.bucket[hash % len(self.bucket)]
+        if slot.next == hash_map.NODE_EMPTY:
+            return null
+        while slot.key != key:
+            if slot.next == hash_map.NODE_NULL: return null
+            slot = self.bucket[slot.next]
+        return slot
+    
+    def insert_p(self, key, value):
+        slot = self.bucket[hashcode(key) % len(self.bucket)]
+        #print(f"slot={slot}, index={hashcode(key) % len(self.bucket)}")
+        if slot.next == hash_map.NODE_EMPTY:
+            slot.next = hash_map.NODE_NULL
+        else:
+            newidx = self.nextfree()
+            #print(f"newidx={newidx}")
+            # get the main-slot index
+            mainslot = self.bucket[hashcode(slot.key) % len(self.bucket)]
+            newslot = self.bucket[newidx]
+            #print(f"self={self}\nslot={hashcode(key) % len(self.bucket)} idx_main={hashcode(slot.key) % len(self.bucket)} newidx={newidx}")
+            #print(f"insert_p: 1={mainslot} 2={newslot}")
+            if mainslot == slot:
+                newslot.next = mainslot.next
+                mainslot.next = newidx
+                slot = newslot
+            else:   # link to list
+                #print(f"insert_p: 1={mainslot} 2={slot}")
+                prev = self.findprev(mainslot, slot)
+                prev.next = newidx      # link the previous node
+                # copy to new slot
+                newslot.key = slot.key
+                newslot.value = slot.value
+                newslot.next = slot.next
+                slot.next = hash_map.NODE_NULL
+        slot.key = key
+        slot.value = value
+
+    def insert(self, key, value):
+        slot = self.find(key)
+        if slot.next == hash_map.NODE_EMPTY:
+            if self.count >= len(self.bucket):
+                self.resize(len(self.bucket) * 2)
+            self.insert_p(key, value)
+            self.count += 1
+    
+    # return a list (entiry, var_count)
+    def entry_modify(self, ent, var_count):
+        ent.key = escape_operator(ent.key)
+        if ent.value == "var":
+            ent.value = "be_const_var(" + str(var_count) + ")"
+            var_count += 1
+        else:
+            ent.value = "be_const_" + ent.value
+        return (ent, var_count)
+    
+    def entry_list(self):
+        l = []
+        var_count = 0
+        
+        self.resize(self.count)
+        for it in self.bucket:
+            (ent, var_count) = self.entry_modify(it, var_count)
+            l.append(ent)
+        return l
+    
+    def var_count(self):
+        count = 0
+
+        self.resize(self.count)
+        for it in self.bucket:
+            if it.value == "var": count += 1
+        return count
+
+if __name__ == '__main__':
+    # from hash_map import *
+    m = hash_map({})
+    print(m)
+    m.insert("foo","bar")
+    print(m)
+    m.insert("foo2","bar")
+    print(m)
+    m.insert(".","3")
+    print(m)
+    m.insert("foo","bar2")
+    print(m)
+    m.insert("+","bar2")
+    print(m)
+    m.insert("a","var")
+    m.insert("b","var")
+    m.insert("c","var")
+    print()
+    print(m)
+    print(f"var_count={m.var_count()}")
+    print(f"entry_list={m.entry_list()}")

--- a/tools/pycoc/macro_table.py
+++ b/tools/pycoc/macro_table.py
@@ -1,0 +1,50 @@
+import re
+
+def int_safe(v):
+    try:     return int(v, 0)
+    except:  return 0
+
+class macro_table:
+    pat = re.compile("(?:\\n|$)\\s*#define\\s+(\\w+)[ \\t]+(\\w*)", re.MULTILINE)
+    pat_query = re.compile("(!?)(\\w+)")
+
+    def __init__(self):
+        self.map = {}
+    
+    # def readfile(self, filename):
+    #     with open(filename) as f:
+    #         return f.read()
+
+    def parse_value(self, s):
+        if len(s) == 0:             return 1    # defined a macro name but no content, considered true
+        if not s[0].isnumeric():    return 1
+        return int_safe(s)
+    
+    def scan_file(self, filename):
+        str = ""
+        with open(filename) as f:
+           str = f.read()
+        r = macro_table.pat.findall(str)
+        for it in r:
+            # print(f"> it0:{it[0]} it1:{it[1]}")
+            self.map[it[0]] = self.parse_value(it[1])
+    
+    def query(self, s):
+        r = macro_table.pat_query.search(s)
+        value = False
+        if r:
+            bang = r[1]
+            name = r[2]
+            # print(f">query: bang={bang} name={name} value={self.map.get(name)}")
+            if name in self.map:
+                value = int(self.map[name]) != 0
+            if bang == "!":
+                value = not value
+        # print(f">query: {s}:{value}")
+        return value
+
+if __name__ == '__main__':
+    # from hash_map import *
+    pat = re.compile("(?:\\n|$)\\s*#define\\s+(\\w+)[ \\t]+(\\w+)", re.MULTILINE)
+    s = "aaa\n#define A 1  // a \n  #define B 2\n#define C \n#define D 0 \n  #define E     11 \na"
+    

--- a/tools/pycoc/main.py
+++ b/tools/pycoc/main.py
@@ -1,0 +1,64 @@
+# python3 main.py -o out in
+# coc 
+
+import re
+import os
+from coc_parser import *
+from str_build import *
+from block_builder import *
+from macro_table import *
+
+class builder:
+    Input = 0
+    Output = 1
+    Config = 2
+
+    def __init__(self, input_folders, output_folder, macro_files):
+        self.output = output_folder
+        self.input = input_folders
+        self.config = macro_files
+        self.macro = None
+        self.strmap = {}
+
+        self.macro = macro_table()
+        for path in self.config:
+            self.macro.scan_file(path)                
+
+        for d in self.input:
+            self.scandir(d)
+        
+        sb = str_build(self.strmap)
+        sb.build(self.output)
+    
+    def parse_file(self, filename):
+        if re.search(r"\.(c|cc|cpp)$", filename):
+            # print(f"> parse {filename}")
+            text = ""
+            with open(filename) as f:
+                text = f.read()
+            # print(f"> len(text)={len(text)}")
+            parser = coc_parser(text)
+            for s in parser.strtab:
+                self.strmap[s] = 0
+            for obj in parser.objects:
+                builder = block_builder(obj, self.macro)
+                for s in builder.strtab:
+                    self.strmap[s] = 0
+                builder.dumpfile(self.output)
+
+    def scandir(self, srcpath):
+        for item in os.listdir(srcpath):
+            path = os.path.join(srcpath, item)
+            if os.path.isfile(path): self.parse_file(path)
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_folder", nargs='+', help='folders containing the C/C++ files to be parsed')
+    parser.add_argument("-o", help='output folder', required=True)
+    parser.add_argument("-c", nargs='+', help='configuration folders for preprocessor')
+
+    args = vars(parser.parse_args())
+    # print(args)
+    b = builder(args["input_folder"], args["o"], args["c"])

--- a/tools/pycoc/str_build.py
+++ b/tools/pycoc/str_build.py
@@ -1,0 +1,123 @@
+import json
+from coc_string import *
+
+class str_info:
+    def __init__(self):
+        self.hash = 0
+        self.str = ""
+        self.extra = 0
+
+class str_build:
+    def __init__(self, map):
+        size = int(len(map) / 2)         # voluntarily reduce hash size to half
+        if size < 4: size = 4
+        self.buckets = []
+        for i in range(size):
+            self.buckets.append([])
+        
+        self.make_ceil("", 0)   # add empty string as it is always useful
+        self.count = len(map) + 1       # TODO it is not actually accurate since keywords are not counted
+        for k in sorted(map.keys()):
+            self.make_ceil(k, map[k])
+        self.keywords()
+    
+    def build(self, path):
+        prefix = path + "/be_const_strtab"
+        self.writefile(prefix + "_def.h", self.build_table_def())
+        self.writefile(prefix + ".h", self.build_table_ext())
+    
+    def get_count(self):            # compute the total size by adding sizes of each bucket
+        size = 0
+        for bucket in self.buckets:
+            size += len(bucket)
+        return size
+    
+    def keywords(self):
+        opif = 50
+        tab = {
+            "if": opif,             "elif": opif + 1 ,
+            "else": opif + 2 ,      "while": opif + 3 ,
+            "for": opif + 4 ,       "def": opif + 5 ,
+            "end": opif + 6 ,       "class": opif + 7 ,
+            "break": opif + 8 ,     "continue": opif + 9 ,
+            "return": opif + 10 ,   "true": opif + 11 ,
+            "false": opif + 12 ,    "nil": opif + 13 ,
+            "var": opif + 14 ,      "do": opif + 15 ,
+            "import": opif + 16 ,   "as": opif + 17 ,
+            "try": opif + 18 ,      "except": opif + 19 ,
+            "raise": opif + 20 ,    "static": opif + 21,
+        }
+        for key in sorted(tab.keys()):
+            self.make_ceil(key, tab[key])
+    
+    def make_ceil(self, name, extra):
+        info = str_info()
+        info.hash = hashcode(name)
+        info.str = name
+        info.extra = extra
+        self.buckets[info.hash % len(self.buckets)].append(info)
+
+    def writefile(self, filename, text):
+        buf = ""
+        try:
+            with open(filename) as f:
+                buf = f.read()
+        except FileNotFoundError:
+            pass
+        if buf != text:
+            with open(filename, "w") as f:
+                f.write(text)
+    
+    def build_table_def(self):
+        strings = {}
+        for bucket in self.buckets:
+            # print(f"> Bucket= {[x.str for x in bucket]}")
+            size = len(bucket)
+            for i in range(size):
+                info = bucket[i]
+                node = escape_operator(info.str)
+                istr = ""
+                if i < size - 1:
+                    next = "&be_const_str_" + escape_operator(bucket[i + 1].str)
+                else:
+                    next = "NULL"
+                istr += "be_define_const_str("
+                istr += node + ", " + json.dumps(info.str) + ", "
+                istr += str(info.hash) + "u, " + str(info.extra) + ", "
+                istr += str(len(info.str)) + ", " + next + ");\n"
+                strings[info.str] = istr
+        
+        ostr = ""
+        for s in sorted(strings.keys()):
+            ostr += strings[s]
+        ostr += "\n"
+        ostr += "static const bstring* const m_string_table[] = {\n"
+
+
+        size = len(self.buckets)
+        for i in range(size):
+            bucket = self.buckets[i]
+            if len(bucket) > 0:
+                ostr += "    (const bstring *)&be_const_str_" + escape_operator(bucket[0].str)
+            else:
+                ostr += "    NULL"
+            if i < size - 1: ostr += ","
+            ostr += "\n"
+        ostr += "};\n\n"
+        ostr += "static const struct bconststrtab m_const_string_table = {\n"
+        ostr += "    .size = " + str(size) + ",\n"
+        ostr += "    .count = " + str(self.get_count()) + ",\n"
+        ostr += "    .table = m_string_table\n"
+        ostr += "};\n"
+        return ostr
+
+    def build_table_ext(self):
+        ostr = ""
+        # put all in a sorted sed
+        all = set()
+        for bucket in self.buckets:
+            for info in bucket:
+                all.add(escape_operator(info.str))
+        for s in sorted(all):
+            ostr += "extern const bcstring be_const_str_" + s + ";\n"
+        return ostr


### PR DESCRIPTION
This is a big one. Last week I ported `coc` compiler to Python3 which will make it easier to do it in CI within Tasmota. I checked the `pycoc` compiler that outputs exactly the same bytes as `coc` compiler.

Then I changed the string encoding to make it easier to onboard solidified strings. Now `be_const_str_<XXX>` is now encoded in a bijection system, so that the pycoc parser can recreate the original string from the indetifier.

Encoding:
- `_X` is used as a marker for espace
- `A-Za-z0-9` are unchanged
- `_X` is replaced with `_X_`, any other occurence of `_` is unchangedd
- any other char is replaced with `_XHH` where `HH` is the hex of the character

Example:
- `"_upper_"` becomes `be_const_str___upper__`
- `".."` becomes `be_const_str__X3D_X3D`
- `".p"` becomes `be_const_str__X2Ep`