### PR TITLE
Remove conversion from comptr to int

### DIFF
--- a/src/be_baselib.c
+++ b/src/be_baselib.c
@@ -233,8 +233,6 @@ static int l_int(bvm *vm)
             be_pushvalue(vm, 1);
         } else if (be_isbool(vm, 1)) {
             be_pushint(vm, be_tobool(vm, 1) ? 1 : 0);
-        } else if (be_iscomptr(vm, 1)) {
-            be_pushint(vm, (int) be_tocomptr(vm, 1));
         } else {
             be_return_nil(vm);
         }


### PR DESCRIPTION
Fix #189 

There is no more conversion from `comptr` to `int` since they might have different sizes.