### PR TITLE
Fix warning for pointer overflow arithmetic

### DIFF
--- a/src/be_vector.c
+++ b/src/be_vector.c
@@ -81,7 +81,11 @@ void be_vector_resize(bvm *vm, bvector *vector, int count)
             vector->capacity = newcap;
         }
         vector->count = count;
-        vector->end = (char*)vector->data + size * ((size_t)count - 1);
+        if (count == 0) {
+            vector->end = (char*)vector->data - size;
+        } else {
+            vector->end = (char*)vector->data + size * ((size_t)count - 1);
+        }
     }
 }
 


### PR DESCRIPTION
When running `make test`, it triggered a warning:

```
run testcase: global.be
src/be_vector.c:84:43: runtime error: addition of unsigned offset to 0x613000000040 overflowed to 0x612fffffff88
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/be_vector.c:84:43 in
```

The culprit code is below. When `count == 0` it adds `-1 * size` which triggers a pointer overflow. Although the result is normally correct, it is strictly `undefined-behavior`

``` C
        vector->end = (char*)vector->data + size * ((size_t)count - 1);
```

This patch detects if `count == 0` and substracts the valu instead of adding a big number.