### PR TITLE
Fix gc type for static closure

### DIFF
--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -172,7 +172,7 @@ static void mark_map(bvm *vm, bgcobject *obj)
         while ((node = be_map_next(map, &iter)) != NULL) {
             bmapkey *key = &node->key;
             bvalue *val = &node->value;
-            if (be_isgctype((signed char)key->type)) {
+            if (be_isgcobj(key)) {
                 mark_gray(vm, var_togc(key));
             }
             mark_gray_var(vm, val);

--- a/src/be_gc.h
+++ b/src/be_gc.h
@@ -47,8 +47,7 @@ if (!gc_isconst(o)) { \
 #define gc_exmark(o)        (((o)->marked >> 4) & 0x0F)
 #define gc_setexmark(o, k)  ((o)->marked |= (k) << 4)
 
-#define be_isgctype(t)      ((t) >= BE_GCOBJECT)
-#define be_isgcobj(o)       be_isgctype(var_type(o))
+#define be_isgcobj(o)       (var_primetype(o) >= BE_GCOBJECT)
 #define be_gcnew(v, t, s)   be_newgcobj((v), (t), sizeof(s))
 
 #define set_fixed(s)        bbool _was_fixed = be_gc_fix_set(vm, cast(bgcobject*, (s)), 1)


### PR DESCRIPTION
Fix a potential mis-detection of gc type for a static native function.

A static native function would have type `BE_FUNCTION | BE_STATIC` or `0x86` which is higher than `BE_GCOBJECT` or `0x10`. In such case, the native function would be marked as gc object and it would lead to a crash.

The macro `be_isgcobj()` needs to use `var_primetype` and not `var_type`. I also removed `be_isgctype()` which is error-prone and left only `be_isgcobj()`. `be_isgctype()` was only used once and would anyways be better served with `be_isgcobj()`