### PR TITLE
Add ctype

### DIFF
--- a/src/be_object.c
+++ b/src/be_object.c
@@ -20,7 +20,7 @@ const char* be_vtype2str(bvalue *v)
     case BE_INT: return "int";
     case BE_REAL: return "real";
     case BE_BOOL: return "bool";
-    case BE_CLOSURE: case BE_NTVCLOS:
+    case BE_CLOSURE: case BE_NTVCLOS: case BE_CTYPE_FUNC:
     case BE_NTVFUNC: return "function";
     case BE_PROTO: return "proto";
     case BE_CLASS: return "class";

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -34,6 +34,7 @@
 #define BE_NTVFUNC      ((0 << 5) | BE_FUNCTION)
 #define BE_CLOSURE      ((1 << 5) | BE_FUNCTION)
 #define BE_NTVCLOS      ((2 << 5) | BE_FUNCTION)
+#define BE_CTYPE_FUNC   ((3 << 5) | BE_FUNCTION)
 #define BE_STATIC       (1 << 7)
 
 #define array_count(a)   (sizeof(a) / sizeof((a)[0]))

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -464,6 +464,7 @@ BERRY_API bvm* be_vm_new(void)
     be_loadlibs(vm);
     vm->compopt = 0;
     vm->obshook = NULL;
+    vm->ctypefunc = NULL;
 #if BE_USE_PERF_COUNTERS
     vm->counter_ins = 0;
     vm->counter_enter = 0;
@@ -1125,6 +1126,17 @@ newframe: /* a new call frame */
                 ret_native(vm);
                 break;
             }
+            case BE_CTYPE_FUNC: {
+                if (vm->ctypefunc) {
+                    push_native(vm, var, argc, mode);
+                    const void* args = var_toobj(var);
+                    vm->ctypefunc(vm, args);
+                    ret_native(vm);
+                } else {
+                    vm_error(vm, "internal_error", "missing ctype_func handler");
+                }
+                break;
+            }
             case BE_MODULE: {
                 bvalue attr;
                 var_setstr(&attr, str_literal(vm, "()"));
@@ -1254,4 +1266,14 @@ BERRY_API void be_set_obs_hook(bvm *vm, bobshook hook)
     (void)hook;     /* avoid comiler warning */
 
     vm->obshook = hook;
+}
+
+BERRY_API void be_set_ctype_func_hanlder(bvm *vm, bctypefunc handler)
+{
+    vm->ctypefunc = handler;
+}
+
+BERRY_API bctypefunc be_get_ctype_func_hanlder(bvm *vm)
+{
+    return vm->ctypefunc;
 }

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -100,6 +100,7 @@ struct bvm {
     bmap *ntvclass; /* native class table */
     blist *registry; /* registry list */
     struct bgc gc;
+    bctypefunc ctypefunc; /* handler to ctype_func */
     bbyte compopt; /* compilation options */
     bobshook obshook;
 #if BE_USE_PERF_COUNTERS

--- a/src/berry.h
+++ b/src/berry.h
@@ -409,6 +409,8 @@ enum beobshookevents {
   BE_OBS_STACK_RESIZE_START,    /* Berry stack resized */
 };
 
+typedef int (*bctypefunc)(bvm*, const void*);
+
 /* FFI functions */
 #define be_writestring(s)       be_writebuffer((s), strlen(s))
 #define be_writenewline()       be_writebuffer("\n", 1)


### PR DESCRIPTION
This PR adds a new native function type, used to ease mapping from C function to Berry. The proposal is to register a callback in the VM so that the mapping can be externalized to another module. This is currently used in `berry_mapping` to make mapping of C functions easy.