### PR TITLE
Add toint() converter

### DIFF
--- a/tests/int.be
+++ b/tests/int.be
@@ -1,0 +1,8 @@
+#- toint() converts any instance to int -#
+class Test_int
+    def toint()
+        return 42
+    end
+end
+t=Test_int()
+assert(int(t) == 42)


### PR DESCRIPTION
Add support for `toint()` method so that any instance can be converted to integer with `int()` function. This is equivalent to `tobool()`.

Unit test added accordingly