### PR TITLE
introspect.module() to load modules by name

### DIFF
--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -127,6 +127,22 @@ static int m_fromptr(bvm *vm)
     be_return_nil(vm);
 }
 
+/* load module by name, like `import` would do. But don't create a global variable from it. */
+static int m_getmodule(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        if (var_isstr(v)) {
+            int ret = be_module_load(vm, var_tostr(v));
+            if (ret == BE_OK) {
+                be_return(vm);
+            }
+        }
+    }
+    be_return_nil(vm);
+}
+
 /* checks if the function (berry bytecode bproto only) is hinted as a method */
 static int m_ismethod(bvm *vm)
 {
@@ -150,6 +166,8 @@ be_native_module_attr_table(introspect) {
     be_native_module_function("get", m_findmember),
     be_native_module_function("set", m_setmember),
 
+    be_native_module_function("module", m_getmodule),
+
     be_native_module_function("toptr", m_toptr),
     be_native_module_function("fromptr", m_fromptr),
 
@@ -164,6 +182,8 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     get, func(m_findmember)
     set, func(m_setmember)
+
+    module, func(m_getmodule)
 
     toptr, func(m_toptr)
     fromptr, func(m_fromptr)

--- a/tests/introspect.be
+++ b/tests/introspect.be
@@ -26,3 +26,8 @@ assert(introspect.get(a, 'a') == nil)
 
 introspect.set(a, 'a', 3)
 assert(a.a == 3)
+
+#- load module dynamically -#
+import introspect
+m = introspect.module("math") # load module `math`, assign to `m` and don't create a global variable
+assert(type(m.pi) == 'real')


### PR DESCRIPTION
`introspect.module(name:string) -> module` allows to load a module dynamically by name, and does not automatically create a global variable.

This allows more flexibiliy than static `import statement`