### PR TITLE
Stack resize fix & debug

### DIFF
--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -170,6 +170,14 @@
  **/
 #define BE_USE_DEBUG_GC                  0
 
+/* Macro: BE_USE_DEBUG_STACK
+ * Enable Stack Resize debug mode. At each function call
+ * the stack is reallocated at a different memory location
+ * and the previous location is cleared with toxic data.
+ * Default: 0
+ **/
+#define BE_USE_DEBUG_STACK               0
+
 /* Macro: BE_USE_XXX_MODULE
  * These macros control whether the related module is compiled.
  * When they are true, they will enable related modules. At this

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -1195,11 +1195,12 @@ static void prep_closure(bvm *vm, int pos, int argc, int mode)
     for (v = vm->reg + argc; v <= end; ++v) {
         var_setnil(v);
     }
+    int v_offset = v - vm->stack;   /* offset from stack base, stack may be reallocated */
     if (proto->varg & BE_VA_VARARG) {  /* there are vararg at the last argument, build the list */
         /* code below uses mostly low-level calls for performance */
-        be_stack_require(vm, argc + 2);   /* make sure we don't overflow the stack */
-        bvalue *top_save = vm->top;  /* save original stack, we need fresh slots to create the 'list' instance */
-        vm->top = v;  /* move top of stack right after last argument */
+        be_stack_require(vm, argc + 4);   /* make sure we don't overflow the stack */
+        int top_save_offset = vm->top - vm->stack;  /* save original stack, we need fresh slots to create the 'list' instance */
+        vm->top = vm->stack + v_offset;  /* move top of stack right after last argument */
         be_newobject(vm, "list");  /* this creates 2 objects on stack: list instance, BE_LIST object */
         blist *list = var_toobj(vm->top-1);  /* get low-level BE_LIST structure */
         v = vm->reg + proto->argc - 1;  /* last argument */
@@ -1207,7 +1208,7 @@ static void prep_closure(bvm *vm, int pos, int argc, int mode)
             be_list_push(vm, list, v); /* push all varargs into list */       
         }
         *(vm->reg + proto->argc - 1) = *(vm->top-2);  /* change the vararg argument to now contain the list instance */
-        vm->top = top_save;  /* restore top of stack pointer */
+        vm->top = vm->stack + top_save_offset;  /* restore top of stack pointer */
     }
 }
 


### PR DESCRIPTION
Fix a memory corruption when a stack resize occurs while a vararg function is called.

Added new option `BE_USE_DEBUG_STACK` to force a stack resize at every function call. This is very slow but triggers any memory corruption caused by stack resize.