### PR TITLE
Fix failed assertion when loading bytecode

### DIFF
--- a/src/be_bytecode.c
+++ b/src/be_bytecode.c
@@ -492,7 +492,7 @@ static void load_constant(bvm *vm, void *fp, bproto *proto, int version)
     }
 }
 
-static void load_proto_table(bvm *vm, void *fp, bproto *proto, int version)
+static void load_proto_table(bvm *vm, void *fp, bproto *proto, int info, int version)
 {
     int size = (int)load_long(fp); /* proto count */
     if (size) {
@@ -501,7 +501,7 @@ static void load_proto_table(bvm *vm, void *fp, bproto *proto, int version)
         proto->ptab = p;
         proto->nproto = size;
         while (size--) {
-            load_proto(vm, fp, p++, -1, version);
+            load_proto(vm, fp, p++, info, version);
         }
     }
 }
@@ -538,7 +538,7 @@ static bbool load_proto(bvm *vm, void *fp, bproto **proto, int info, int version
         }
         load_bytecode(vm, fp, *proto, info);
         load_constant(vm, fp, *proto, version);
-        load_proto_table(vm, fp, *proto, version);
+        load_proto_table(vm, fp, *proto, info, version);
         load_upvals(vm, fp, *proto);
         return btrue;
     }


### PR DESCRIPTION
When loading bytecode containing a closure, there is an assertion failing:

```
ASSERT 'be_islist(vm, info)', lib/libesp32/berry/src/be_bytecode.c - 460
```

A simple test case is compiling the following code, and loading from file:

``` berry
class A
  def f()
    self.f(/ -> self.f())
  end
end
```

Then `./berry test.be -o test.bec` and `compile('test.bec','file')`

It appears that when loading a proto from a sub-proto, the `info` field needs to be `-3` and not the default `-1`. This change just passes the adequate `info` value.

