### PR TITLE
int() now parses hex

### DIFF
--- a/src/be_lexer.c
+++ b/src/be_lexer.c
@@ -12,6 +12,7 @@
 #include "be_exec.h"
 #include "be_map.h"
 #include "be_vm.h"
+#include "be_strlib.h"
 
 #define SHORT_STR_LEN       32
 #define EOS                 '\0' /* end of source */
@@ -168,21 +169,9 @@ static int check_next(blexer *lexer, int c)
     return 0;
 }
 
-static int char2hex(int c)
-{
-    if (c >= '0' && c <= '9') {
-        return c - '0';
-    } else if (c >= 'a' && c <= 'f') {
-        return c - 'a' + 0x0A;
-    } else if (c >= 'A' && c <= 'F') {
-        return c - 'A' + 0x0A;
-    }
-    return -1;
-}
-
 static int check2hex(blexer *lexer, int c)
 {
-    c = char2hex(c);
+    c = be_char2hex(c);
     if (c < 0) {
         be_lexerror(lexer, "invalid hexadecimal number");
     }
@@ -333,7 +322,7 @@ static bint scan_hexadecimal(blexer *lexer)
 {
     bint res = 0;
     int dig, num = 0;
-    while ((dig = char2hex(lgetc(lexer))) >= 0) {
+    while ((dig = be_char2hex(lgetc(lexer))) >= 0) {
         res = ((bint)res << 4) + dig;
         next(lexer);
         ++num;
@@ -396,19 +385,44 @@ static btokentype scan_identifier(blexer *lexer)
     return TokenId;
 }
 
+/* munch any delimeter and return 1 if any found */
+static int skip_delimiter(blexer *lexer) {
+    int c = lgetc(lexer);
+    int delimeter_present = 0;
+    while (1) {
+        if (c == '\r' || c == '\n') {
+            skip_newline(lexer);
+        } else if (c == ' ' || c == '\t' || c == '\f' || c ==  '\v') {
+            next(lexer);
+        } else {
+            break;
+        }
+        c = lgetc(lexer);
+        delimeter_present = 1;
+    }
+    return delimeter_present;
+}
+
 static btokentype scan_string(blexer *lexer)
 {
-    int c, end = lgetc(lexer);
-    next(lexer); /* skip '"' or '\'' */
-    while ((c = lgetc(lexer)) != EOS && (c != end)) {
-        save(lexer);
-        if (c == '\\') {
-            save(lexer); /* skip '\\.' */
+    while (1) {     /* handle multiple string literals in a row */
+        int c;
+        int end = lgetc(lexer);     /* string delimiter, either '"' or '\'' */
+        next(lexer); /* skip '"' or '\'' */
+        while ((c = lgetc(lexer)) != EOS && (c != end)) {
+            save(lexer);
+            if (c == '\\') {
+                save(lexer); /* skip '\\.' */
+            }
         }
+        c = next(lexer); /* skip '"' or '\'' */
+        /* check if there's an additional string literal right after */
+        skip_delimiter(lexer);
+        c = lgetc(lexer);
+        if (c != '"' && c != '\'') { break; }
     }
     tr_string(lexer);
     setstr(lexer, buf_tostr(lexer));
-    next(lexer); /* skip '"' or '\'' */
     return TokenString;
 }
 

--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -231,17 +231,41 @@ const char* be_pushvfstr(bvm *vm, const char *format, va_list arg)
     return concat2(vm);
 }
 
+int be_char2hex(int c)
+{
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    } else if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 0x0A;
+    } else if (c >= 'A' && c <= 'F') {
+        return c - 'A' + 0x0A;
+    }
+    return -1;
+}
+
 /*******************************************************************
  * the function be_str2int():
- * >>-+------------+--+-----+----digits----><
- *    '-whitespace-'  +- + -+
- *                    '- - -'
+ * >>-+------------+--+--+-----+----digits-------+----------------><
+ *    '-whitespace-'  |  +- + -+                 |
+ *                    |  '- - -'                 |
+ *                    |                          |
+ *                    +- 0x or 0X ---hex_digits--+
+ * 
  *******************************************************************/
 BERRY_API bint be_str2int(const char *str, const char **endstr)
 {
     int c, sign;
     bint sum = 0;
     skip_space(str);
+    if (str[0] == '0' && (str[1] == 'x' || str[1] == 'X')) {
+        /* hex literal */
+        str += 2;       /* skip 0x or 0X */
+        while ((c = be_char2hex(*str++)) >= 0) {
+            sum = sum * 16 + c;
+        }
+        return sum;
+    } else {
+        /* decimal literal */
     sign = c = *str++;
     if (c == '+' || c == '-') {
         c = *str++;
@@ -254,6 +278,7 @@ BERRY_API bint be_str2int(const char *str, const char **endstr)
         *endstr = str - 1;
     }
     return sign == '-' ? -sum : sum;
+    }
 }
 
 /*******************************************************************

--- a/src/be_strlib.h
+++ b/src/be_strlib.h
@@ -19,6 +19,7 @@ bstring* be_strcat(bvm *vm, bstring *s1, bstring *s2);
 int be_strcmp(bstring *s1, bstring *s2);
 bstring* be_num2str(bvm *vm, bvalue *v);
 void be_val2str(bvm *vm, int index);
+int be_char2hex(int c);
 size_t be_strlcpy(char *dst, const char *src, size_t size);
 const char* be_splitpath(const char *path);
 const char* be_splitname(const char *path);

--- a/tests/int.be
+++ b/tests/int.be
@@ -6,3 +6,9 @@ class Test_int
 end
 t=Test_int()
 assert(int(t) == 42)
+
+#- int can parse hex strings -#
+assert(int("0x00") == 0)
+assert(int("0X1") == 1)
+assert(int("0x000000F") == 15)
+assert(int("0x1000") == 0x1000)


### PR DESCRIPTION
`int()` is now able to parse hex strings starting with `0x` or `0X. This is now consistent with Barry lexer and parser.

``` berry
> print(int("0x10"))
16
```