### PR TITLE
Improved implicit bool for string and comobj/comptr

### DIFF
--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -280,6 +280,12 @@ bbool be_value2bool(bvm *vm, bvalue *v)
         return val2bool(v->v.i);
     case BE_REAL:
         return val2bool(v->v.r);
+    case BE_STRING:
+        return str_len(var_tostr(v)) != 0;
+    case BE_COMPTR:
+        return var_toobj(v) != NULL;
+    case BE_COMOBJ:
+        return ((bcommomobj*)var_toobj(v))->data != NULL;
     case BE_INSTANCE:
         return obj2bool(vm, v);
     default:

--- a/tests/bool.be
+++ b/tests/bool.be
@@ -33,7 +33,11 @@ assert(bool(nil) == false)
 
 assert(bool(-1) == true)
 assert(bool(3.5) == true)
-assert(bool('') == true)
+assert(bool('') == false)       # changed behavior
 assert(bool('a') == true)
 assert(bool(list) == true)
 assert(bool(list()) == true)
+
+import introspect
+assert(bool(introspect.toptr(0x1000)) == true)
+assert(bool(introspect.toptr(0)) == false)


### PR DESCRIPTION
This is a proposal to improve the implicit conversion for strings and pointers.

Proposal:

1/ `bool(<string>)` now returns `false` if the string is empty - instead of returning always `true`

This allow for simpler tests like 

``` berry
if my_str
  <do_something>
end

# instead of
if my_str != nil && size(my_strt) > 0
  <do_something>
end
```

2/ `bool(<comptr>)` and `bool(<comobj>)` now return `false` if the pointer is NULL (it used to always return `true`) 