### PR TITLE
Add string.replace()

### DIFF
--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -845,6 +845,26 @@ static int str_tr(bvm *vm)
     be_return_nil(vm);
 }
 
+static int str_replace(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 3 && be_isstring(vm, 1) && be_isstring(vm, 2) && be_isstring(vm, 3)) {
+        be_pushntvfunction(vm, &str_split);
+        be_pushvalue(vm, 1);
+        be_pushvalue(vm, 2);
+        be_call(vm, 2);
+        be_pop(vm, 2);
+
+        be_getmember(vm, -1, "concat");     /* get `concat` method of list */
+        be_pushvalue(vm, -2);               /* get list instance as first arg */
+        be_pushvalue(vm, 3);
+        be_call(vm, 2);
+        be_pop(vm, 2);
+        be_return(vm);
+    }
+    be_return_nil(vm);
+}
+
 static int str_escape(bvm *vm)
 {
     int top = be_top(vm);
@@ -876,6 +896,7 @@ be_native_module_attr_table(string) {
     be_native_module_function("toupper", str_toupper),
     be_native_module_function("tr", str_tr),
     be_native_module_function("escape", str_escape),
+    be_native_module_function("replace", str_replace),
 };
 
 be_define_native_module(string, NULL);
@@ -893,6 +914,7 @@ module string (scope: global, depend: BE_USE_STRING_MODULE) {
     toupper, func(str_toupper)
     tr, func(str_tr)
     escape, func(str_escape)
+    replace, func(str_replace)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_string.h"

--- a/tests/string.be
+++ b/tests/string.be
@@ -80,3 +80,11 @@ assert(string.tr("qwerty", "qwe", "_") == '_rty')
 # the following should not crash
 var s1 = 'A string of more than 128 bytes 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'
 var s2 = string.format("%i, %s", 1, s1)
+
+# replace
+assert(string.replace("hello", "ll", "xx") == "hexxo")
+assert(string.replace("hellollo", "ll", "xx") == "hexxoxxo")
+assert(string.replace("hellollo", "aa", "xx") == "hellollo")
+assert(string.replace("hello", "ll", "") == "heo")
+assert(string.replace("hello", "", "xx") == "hello")
+assert(string.replace("hello", "", "") == "hello")


### PR DESCRIPTION
Add Berry `string.replace(haystack:string, needle:string, food:string) -> string` as discussed in https://github.com/arendst/Tasmota/discussions/15805

It is equivalent to:

``` berry
def replace(haystack, needle, food)
  import string
  return string.split(haystack, needle).concat(food)
end
```

Example:

``` berry
> import string
> string.replace("foobaroo", "oo", "u")
'fubaru'
```