### PR TITLE
Fix compilation warning

### DIFF
--- a/src/be_lexer.c
+++ b/src/be_lexer.c
@@ -337,7 +337,7 @@ static btokentype scan_decimal(blexer *lexer)
 {
     btokentype type = TokenInteger;
     match(lexer, is_digit);
-    if (decimal_dots(lexer) | scan_realexp(lexer)) {
+    if (decimal_dots(lexer) || scan_realexp(lexer)) {
         type = TokenReal;
     }
     lexer->buf.s[lexer->buf.len] = '\0';

--- a/src/be_lexer.c
+++ b/src/be_lexer.c
@@ -337,7 +337,11 @@ static btokentype scan_decimal(blexer *lexer)
 {
     btokentype type = TokenInteger;
     match(lexer, is_digit);
-    if (decimal_dots(lexer) || scan_realexp(lexer)) {
+    /* decimal_dots() and scan_realexp() have side effect, so we call each explicitly */
+    /* to prevent binary shortcut if the first is true */
+    bbool has_decimal_dots = decimal_dots(lexer);
+    bbool is_realexp = scan_realexp(lexer);
+    if (has_decimal_dots || is_realexp) {
         type = TokenReal;
     }
     lexer->buf.s[lexer->buf.len] = '\0';


### PR DESCRIPTION
Fix the following compiler warning

```
berry/src/be_lexer.c:340:9: warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
    if (decimal_dots(lexer) | scan_realexp(lexer)) {
```