### PR TITLE
Add `static var` as preferred syntax

### DIFF
--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -1439,26 +1439,32 @@ static void classdef_stmt(bparser *parser, bclass *c, bbool is_static)
 static void classstatic_stmt(bparser *parser, bclass *c, bexpdesc *e)
 {
     bstring *name;
-    /* 'static' ID ['=' expr] {',' ID ['=' expr] } */
+    /* 'static' ['var'] ID ['=' expr] {',' ID ['=' expr] } */
+    /* 'static' 'def' ID '(' varlist ')' block 'end' */
     scan_next_token(parser); /* skip 'static' */
     if (next_type(parser) == KeyDef) {  /* 'static' 'def' ... */
         classdef_stmt(parser, c, btrue);
-    } else if (match_id(parser, name) != NULL) {
-        check_class_attr(parser, c, name);
-        be_class_member_bind(parser->vm, c, name, bfalse);
-        class_static_assignment_expr(parser, e, name);
-
-        while (match_skip(parser, OptComma)) { /* ',' */
-            if (match_id(parser, name) != NULL) {
-                check_class_attr(parser, c, name);
-                be_class_member_bind(parser->vm, c, name, bfalse);
-                class_static_assignment_expr(parser, e, name);
-            } else {
-                parser_error(parser, "class static error");
-            }
-        }
     } else {
-        parser_error(parser, "class static error");
+        if (next_type(parser) == KeyVar) {
+            scan_next_token(parser); /* skip 'var' if any */
+        }
+        if (match_id(parser, name) != NULL) {
+            check_class_attr(parser, c, name);
+            be_class_member_bind(parser->vm, c, name, bfalse);
+            class_static_assignment_expr(parser, e, name);
+
+            while (match_skip(parser, OptComma)) { /* ',' */
+                if (match_id(parser, name) != NULL) {
+                    check_class_attr(parser, c, name);
+                    be_class_member_bind(parser->vm, c, name, bfalse);
+                    class_static_assignment_expr(parser, e, name);
+                } else {
+                    parser_error(parser, "class static error");
+                }
+            }
+        } else {
+            parser_error(parser, "class static error");
+        }
     }
 }
 

--- a/tests/class_const.be
+++ b/tests/class_const.be
@@ -1,0 +1,122 @@
+def assert_attribute_error(f)
+    try
+        f()
+        assert(false, 'unexpected execution flow')
+    except .. as e, m
+        assert(e == 'attribute_error')
+    end
+end
+
+class A
+    static var a
+    def init() self.b = 2 end
+    def f() end 
+    var b 
+    static var c, s, r
+end
+
+assert(A.a == nil)
+assert(A.c == nil)
+assert(A.s == nil)
+assert_attribute_error(/-> A.b)
+assert_attribute_error(/-> A.d)
+
+a = A()
+assert(a.b == 2)
+assert(a.a == nil)
+assert(a.c == nil)
+
+A.a = 1
+A.c = 3
+A.s = "foo"
+A.r = 3.5
+assert(a.a == 1)
+assert(a.c == 3)
+assert(A.a == 1)
+assert(A.c == 3)
+import gc gc.collect()
+assert(A.s == "foo")
+assert(a.s == "foo")
+assert(A.r == 3.5)
+assert(a.r == 3.5)
+
+#- test valid or invalid methods and members -#
+
+def assert_attribute_error(c)
+    try
+        compile(c)()
+        assert(false, 'unexpected execution flow')
+    except .. as e, m
+        assert(e == 'attribute_error')
+    end
+end
+
+class A
+    var a, g
+    static h
+    def init() self.a = 1 end
+    def f(x, y) return type(self) end
+end
+a=A()
+a.g = def (x, y) return type(x) end
+A.h = def (x, y) return type(x) end
+
+assert(type(a.g) == 'function')
+assert(type(a.h) == 'function')
+
+assert(a.g(1) == 'int')
+assert(a.h(1) == 'int')
+assert(A.h(1) == 'int')
+
+
+class A
+    var a
+    static def g(x, y) return [x,y] end
+    static h = def (x, y) return [x,y] end
+    def init() self.a = 1 end
+    def f(x, y) return type(self) end
+end
+a=A()
+assert(type(a.g) == 'function')
+assert(type(a.h) == 'function')
+assert(type(A.g) == 'function')
+assert(type(A.h) == 'function')
+assert(a.g(1,2) == [1,2])
+assert(a.h(1,2) == [1,2])
+assert(A.g(1,2) == [1,2])
+assert(A.h(1,2) == [1,2])
+a.a = def (x,y) return [x,y] end
+assert(a.a(1,2) == [1,2])
+
+
+#- test static initializers -#
+class A
+    static a = 1, b, c = 3.5, d = 42, e = "foo", f = [1], g = {}
+    var aa,ab
+end
+
+assert(A.a == 1)
+assert(A.b == nil)
+assert(A.c == 3.5)
+assert(A.d == 42)
+assert(A.e == "foo")
+assert(A.f == [1])
+
+a = A()
+assert(a.a == 1)
+assert(a.b == nil)
+assert(a.c == 3.5)
+assert(a.d == 42)
+assert(a.e == "foo")
+assert(a.f == [1])
+assert(a.g == A.g)
+assert(a.aa == nil)
+assert(a.ab == nil)
+
+#- used to fail for subclasses -#
+class A static a=1 end
+class B:A static a=A def f() end static b=1 static c=A end
+assert(A.a == 1)
+assert(B.a == A)
+assert(B.b == 1)
+assert(B.c == A)

--- a/tests/class_static.be
+++ b/tests/class_static.be
@@ -8,11 +8,11 @@ def assert_attribute_error(f)
 end
 
 class A
-    static a
+    static a    #- deprecated syntax -#
     def init() self.b = 2 end
     def f() end 
     var b 
-    static c, s, r
+    static var c, s, r  #- preferred syntax -#
 end
 
 assert(A.a == nil)

--- a/tools/grammar/berry.ebnf
+++ b/tools/grammar/berry.ebnf
@@ -17,7 +17,7 @@ func_body = '(' [arg_field {',' arg_field}] ')' block 'end';
 arg_field = ['*'] ID;
 (* class define statement *)
 class_stmt = 'class' ID [':' ID] class_block 'end';
-class_block = {'var' ID {',' ID} | 'static' ID ['=' expr] {',' ID ['=' expr] } | 'static' func_stmt | func_stmt};
+class_block = {'var' ID {',' ID} | 'static' ['var'] ID ['=' expr] {',' ID ['=' expr] } | 'static' func_stmt | func_stmt};
 import_stmt = 'import' (ID (['as' ID] | {',' ID}) | STRING 'as' ID);
 (* exceptional handling statement *)
 try_stmt = 'try' block except_block {except_block} 'end';


### PR DESCRIPTION
Original syntax:

``` berry
class A
  static a = 1
  static b = "foo"
  static def f()
    return 0
  end
end
```

The new preferred syntax is to use `static var` instead of just `static` (the original syntax is still accepted):

``` berry
class A
  static var a = 1
  static var b = "foo"
  static def f()
    return 0
  end
end
```
