### PR TITLE
Add cype_func for external mapping

### DIFF
--- a/src/be_gc.h
+++ b/src/be_gc.h
@@ -47,7 +47,7 @@ if (!gc_isconst(o)) { \
 #define gc_exmark(o)        (((o)->marked >> 4) & 0x0F)
 #define gc_setexmark(o, k)  ((o)->marked |= (k) << 4)
 
-#define be_isgcobj(o)       (var_primetype(o) >= BE_GCOBJECT)
+#define be_isgcobj(o)       (var_primetype(o) >= BE_GCOBJECT && var_primetype(o) < BE_GCOBJECT_MAX)
 #define be_gcnew(v, t, s)   be_newgcobj((v), (t), sizeof(s))
 
 #define set_fixed(s)        bbool _was_fixed = be_gc_fix_set(vm, cast(bgcobject*, (s)), 1)

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -21,6 +21,7 @@
 #define BE_FUNCTION     6
 
 #define BE_GCOBJECT     16      /* from this type can be gced */
+#define BE_GCOBJECT_MAX (3<<5)  /* from this type can't be gced */
 
 #define BE_STRING       16
 #define BE_CLASS        17
@@ -258,5 +259,6 @@ typedef const char* (*breader)(void*, size_t*);
 const char* be_vtype2str(bvalue *v);
 bvalue* be_indexof(bvm *vm, int idx);
 void be_commonobj_delete(bvm *vm, bgcobject *obj);
+int be_commonobj_destroy_generic(bvm* vm);
 
 #endif

--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -87,7 +87,7 @@ static bstring* sim2str(bvm *vm, bvalue *v)
     case BE_REAL:
         sprintf(sbuf, "%g", var_toreal(v));
         break;
-    case BE_CLOSURE: case BE_NTVCLOS: case BE_NTVFUNC:
+    case BE_CLOSURE: case BE_NTVCLOS: case BE_NTVFUNC: case BE_CTYPE_FUNC:
         sprintf(sbuf, "<function: %p>", var_toobj(v));
         break;
     case BE_CLASS:
@@ -266,18 +266,18 @@ BERRY_API bint be_str2int(const char *str, const char **endstr)
         return sum;
     } else {
         /* decimal literal */
-    sign = c = *str++;
-    if (c == '+' || c == '-') {
-        c = *str++;
-    }
-    while (is_digit(c)) {
-        sum = sum * 10 + c - '0';
-        c = *str++;
-    }
-    if (endstr) {
-        *endstr = str - 1;
-    }
-    return sign == '-' ? -sum : sum;
+        sign = c = *str++;
+        if (c == '+' || c == '-') {
+            c = *str++;
+        }
+        while (is_digit(c)) {
+            sum = sum * 10 + c - '0';
+            c = *str++;
+        }
+        if (endstr) {
+            *endstr = str - 1;
+        }
+        return sign == '-' ? -sum : sum;
     }
 }
 

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -1253,6 +1253,18 @@ static void do_ntvfunc(bvm *vm, int pos, int argc)
     ret_native(vm);
 }
 
+static void do_cfunc(bvm *vm, int pos, int argc)
+{
+    if (vm->ctypefunc) {
+        const void* args = var_toobj(vm->reg + pos);
+        push_native(vm, vm->reg + pos, argc, 0);
+        vm->ctypefunc(vm, args);
+        ret_native(vm);
+    } else {
+        vm_error(vm, "internal_error", "missing ctype_func handler");
+    }
+}
+
 static void do_class(bvm *vm, int pos, int argc)
 {
     if (be_class_newobj(vm, var_toobj(vm->reg + pos), pos, ++argc, 0)) {
@@ -1273,6 +1285,7 @@ void be_dofunc(bvm *vm, bvalue *v, int argc)
     case BE_CLOSURE: do_closure(vm, pos, argc); break;
     case BE_NTVCLOS: do_ntvclos(vm, pos, argc); break;
     case BE_NTVFUNC: do_ntvfunc(vm, pos, argc); break;
+    case BE_CTYPE_FUNC: do_cfunc(vm, pos, argc); break;
     default: call_error(vm, v);
     }
 }

--- a/src/berry.h
+++ b/src/berry.h
@@ -551,6 +551,8 @@ BERRY_API void be_vm_delete(bvm *vm);
 
 /* Observability hook */
 BERRY_API void be_set_obs_hook(bvm *vm, bobshook hook);
+BERRY_API void be_set_ctype_func_hanlder(bvm *vm, bctypefunc handler);
+BERRY_API bctypefunc be_get_ctype_func_hanlder(bvm *vm);
 
 /* code load APIs */
 BERRY_API int be_loadbuffer(bvm *vm,


### PR DESCRIPTION
This feature adds a new function type in addition to `BE_CLOSURE`, `BE_NTVCLOS`, `BE_NTVFUNC`.

`BE_CTYPE_FUNC` allows to define an external function type that will call `vm->ctypefunc` whenever such function is called. This allows to register a callback function that does the automatic mapping to a native C function based on a signature.

This scheme is used by [berry_mapping](https://github.com/berry-lang/berry_mapping)