### PR TITLE
Add default `init()` to modules

### DIFF
--- a/src/be_class.c
+++ b/src/be_class.c
@@ -12,6 +12,7 @@
 #include "be_gc.h"
 #include "be_vm.h"
 #include "be_func.h"
+#include "be_module.h"
 #include <string.h>
 
 #define check_members(vm, c)            \
@@ -240,12 +241,6 @@ bbool be_class_newobj(bvm *vm, bclass *c, int pos, int argc, int mode)
     return bfalse;
 }
 
-/* Default empty constructor */
-static int default_init_native_method(bvm *vm)
-{
-    be_return_nil(vm);
-}
-
 /* Find instance member by name and copy value to `dst` */
 /* Do not look into virtual members */
 int be_instance_member_simple(bvm *vm, binstance *instance, bstring *name, bvalue *dst)
@@ -280,7 +275,7 @@ int be_instance_member(bvm *vm, binstance *instance, bstring *name, bvalue *dst)
     } else {  /* if no method found, try virtual */
         /* if 'init' does not exist, create a virtual empty constructor */
         if (strcmp(str(name), "init") == 0) {
-            var_setntvfunc(dst, default_init_native_method);
+            var_setntvfunc(dst, be_default_init_native_function);
             return var_primetype(dst);
         } else {
             /* get method 'member' */

--- a/src/be_module.c
+++ b/src/be_module.c
@@ -255,7 +255,7 @@ static void cache_module(bvm *vm, bstring *name)
     *v = vm->top[-1];
 }
 
-/* Try to run '()' function of module. Module is already loaded. */
+/* Try to run 'init(m)' function of module. Module is already loaded. */
 static void module_init(bvm *vm) {
     if (be_ismodule(vm, -1)) {
         if (be_getmember(vm, -1, "init")) {
@@ -318,6 +318,11 @@ int be_module_attr(bvm *vm, bmodule *module, bstring *attr, bvalue *dst)
 {
     bvalue *member = be_map_findstr(vm, module->table, attr);
     if (!member) {  /* try the 'member' function */
+        /* if 'init' does not exist, don't call member() */
+        if (strcmp(str(attr), "init") == 0) {
+            var_setntvfunc(dst, be_default_init_native_function);
+            return var_primetype(dst);
+        }
         member = be_map_findstr(vm, module->table, str_literal(vm, "member"));
         if (member && var_basetype(member) == BE_FUNCTION) {
             bvalue *top = vm->top;

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -1277,6 +1277,18 @@ void be_dofunc(bvm *vm, bvalue *v, int argc)
     }
 }
 
+/* Default empty constructor */
+int be_default_init_native_function(bvm *vm)
+{
+    int argc = be_top(vm);
+    if (argc >= 1) {
+        be_pushvalue(vm, 1);
+    } else {
+        be_pushnil(vm);
+    }
+    be_return(vm);
+}
+
 BERRY_API void be_set_obs_hook(bvm *vm, bobshook hook)
 {
     (void)vm;       /* avoid comiler warning */

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -128,6 +128,7 @@ struct bvm {
 #define BASE_FRAME          (1 << 0)
 #define PRIM_FUNC           (1 << 1)
 
+int be_default_init_native_function(bvm *vm);
 void be_dofunc(bvm *vm, bvalue *v, int argc);
 bbool be_value2bool(bvm *vm, bvalue *v);
 bbool be_vm_iseq(bvm *vm, bvalue *a, bvalue *b);


### PR DESCRIPTION
Add a default implicit `init()` function that does nothing to all modules, like for classes.

``` berry
> m = module()
> m.init()
>                             # no error here
> class A end
> a = A()
> a.init()
>                             # no error here
```

