### PR TITLE
Provide a default comobj destroy function

### DIFF
--- a/src/be_object.c
+++ b/src/be_object.c
@@ -71,3 +71,14 @@ void be_commonobj_delete(bvm *vm, bgcobject *obj)
         be_free(vm, co, sizeof(bcommomobj));
     }
 }
+
+/* generic destroy method for comobj, just call be_os_free() on the pointer */
+int be_commonobj_destroy_generic(bvm* vm)
+{
+    int argc = be_top(vm);
+    if (argc > 0) {
+        void * obj = be_tocomptr(vm, 1);
+        if (obj != NULL) { be_os_free(obj); }
+    }
+    be_return_nil(vm);
+}

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -258,5 +258,6 @@ typedef const char* (*breader)(void*, size_t*);
 const char* be_vtype2str(bvalue *v);
 bvalue* be_indexof(bvm *vm, int idx);
 void be_commonobj_delete(bvm *vm, bgcobject *obj);
+int be_commonobj_destroy_generic(bvm* vm);
 
 #endif


### PR DESCRIPTION
Convenience function `be_commonobj_destroy_generic(vm)`to be used as a default destructor for `comobj`. This avoids each comobj implementation to reinvent the wheel.