### PR TITLE
Add native class definitions

### DIFF
--- a/default/be_modtab.c
+++ b/default/be_modtab.c
@@ -71,3 +71,13 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
     /* user-defined modules register end */
     NULL /* do not remove */
 };
+
+/* user-defined classes declare start */
+/* be_extern_native_class(my_class); */
+/* user-defined classes declare end */
+
+BERRY_LOCAL bclass_array be_class_table = {
+    /* first list are direct classes */
+    /* &be_native_class(my_class), */
+    NULL, /* do not remove */
+};

--- a/src/berry.h
+++ b/src/berry.h
@@ -174,6 +174,11 @@ typedef struct bntvmodule {
     const struct bmodule *module; /* const module object */
 } bntvmodule;
 
+/* native class object */
+struct bclass;    /* we need only the pointer to `bclass` here */
+typedef const struct bclass *bclass_ptr;
+typedef bclass_ptr bclass_array[];              /* array of bclass* pointers, NULL terminated */
+
 /* native module node definition macro */
 #ifndef __cplusplus
 #define be_native_module_nil(_name)                     \
@@ -223,10 +228,15 @@ typedef struct bntvmodule {
     static const bntvmodobj name##_attrs[] =
 
 #define be_native_module(name)  be_native_module_##name
+#define be_native_class(name)  be_class_##name
 
 /* native module declaration macro */
 #define be_extern_native_module(name)                   \
     extern const bntvmodule be_native_module(name)
+
+/* native class declaration macro */
+#define be_extern_native_class(name)                   \
+    extern const struct bclass be_native_class(name)
 
 /* native module definition macro */
 #ifndef __cplusplus


### PR DESCRIPTION
Add a native class definition mechanisms, which makes it not necessary anymore to run code storing each class in globals. This also prevents from using global memory for classes that are never called. There is a small performance hit when the class is first accessed, it is then stored as global.

``` C
/* user-defined classes declare start */
be_extern_native_class(my_class1);
be_extern_native_class(my_class2);

/* user-defined classes declare end */


BERRY_LOCAL bclass_array be_class_table = {
    /* first list are direct classes */
    &be_native_class(my_class1),
    &be_native_class(my_class2),

    NULL, /* do not remove */
};
```