### PR TITLE
Add weak string constants

### DIFF
--- a/src/be_constobj.h
+++ b/src/be_constobj.h
@@ -45,7 +45,7 @@ extern "C" {
 }
 
 /* try to use the predefined string in strtab, but don't create an instance if none is present */
-/* the behavior is exactly the same as `be_const_key()` but it not detected by pycoc */
+/* the behavior is exactly the same as `be_const_key()` but it not detected by coc */
 #define be_const_key_weak(_str, _next) {                        \
     .v.c = &be_const_str_##_str,                                \
     .type = BE_STRING,                                          \
@@ -309,7 +309,7 @@ const bcstring be_const_str_##_name = {                         \
 }
 
 /* try to use the predefined string in strtab, but don't create an instance if none is present */
-/* the behavior is exactly the same as `be_const_key()` but it not detected by pycoc */
+/* the behavior is exactly the same as `be_const_key()` but it not detected by coc */
 #define be_const_key_weak(_str, _next) {                        \
     bvaldata(&be_const_str_##_str),                             \
         BE_STRING,                                              \

--- a/src/be_constobj.h
+++ b/src/be_constobj.h
@@ -27,9 +27,40 @@ extern "C" {
     .type = (_t),                                               \
     .marked = GC_CONST
 
+#define be_define_const_str_weak(_name, _s, _len)               \
+    const bcstring be_const_str_##_name = {                     \
+        .next = NULL,                                           \
+        .type = BE_STRING,                                      \
+        .marked = GC_CONST,                                     \
+        .extra = 0,                                             \
+        .slen = _len,                                           \
+        .hash = 0,                                              \
+        .s = _s                                                 \
+    }
+
 #define be_const_key(_str, _next) {                             \
     .v.c = &be_const_str_##_str,                                \
     .type = BE_STRING,                                          \
+    .next = (uint32_t)(_next) & 0xFFFFFF                        \
+}
+
+/* try to use the predefined string in strtab, but don't create an instance if none is present */
+/* the behavior is exactly the same as `be_const_key()` but it not detected by pycoc */
+#define be_const_key_weak(_str, _next) {                        \
+    .v.c = &be_const_str_##_str,                                \
+    .type = BE_STRING,                                          \
+    .next = (uint32_t)(_next) & 0xFFFFFF                        \
+}
+
+#define be_const_key_literal(_str, _next) {                     \
+    .v.c = be_str_literal(#_str),                                \
+    .type = BE_STRING,                                          \
+    .next = (uint32_t)(_next) & 0xFFFFFF                        \
+}
+
+#define be_const_key_int(_i, _next) {                           \
+    .v.i = _i,                                                  \
+    .type = BE_INT,                                             \
     .next = (uint32_t)(_next) & 0xFFFFFF                        \
 }
 
@@ -224,8 +255,25 @@ const bntvmodule be_native_module(_module) = {                  \
     BE_STRING                                                   \
   }
 
+/* variant that does not trigger strtab */
+#define be_nested_str_weak(_name_)                              \
+  {                                                             \
+    { .s=((bstring*)&be_const_str_##_name_) },                  \
+    BE_STRING                                                   \
+  }
+
+#define be_nested_str_literal(_name_)                           \
+  {                                                             \
+    { .s=(be_nested_const_str(_name_, _hash, sizeof(_name_)-1 ))\
+    },                                                          \
+    BE_STRING                                                   \
+  }
+
 #define be_str_literal(_str)                                    \
   be_nested_const_str(_str, 0, sizeof(_str)-1 )
+
+#define be_str_weak(_str)                                       \
+  (bstring*) &be_const_str_##_str
 
 #define be_nested_string(_str, _hash, _len)                     \
   {                                                             \
@@ -243,9 +291,34 @@ const bntvmodule be_native_module(_module) = {                  \
 
 #else
 
+#define be_define_const_str_weak(_name, _s, _len)               \
+const bcstring be_const_str_##_name = {                         \
+    NULL,                                                       \
+    BE_STRING,                                                  \
+    GC_CONST,                                                   \
+    0,                                                          \
+    _len,                                                       \
+    0,                                                          \
+    _s                                                          \
+}
+
 #define be_const_key(_str, _next) {                             \
     bvaldata(&be_const_str_##_str),                             \
         BE_STRING,                                              \
+        uint32_t((_next)&0xFFFFFF)                              \
+}
+
+/* try to use the predefined string in strtab, but don't create an instance if none is present */
+/* the behavior is exactly the same as `be_const_key()` but it not detected by pycoc */
+#define be_const_key_weak(_str, _next) {                        \
+    bvaldata(&be_const_str_##_str),                             \
+        BE_STRING,                                              \
+        uint32_t((_next)&0xFFFFFF)                              \
+}
+
+#define be_const_key_int(_i, _next) {                           \
+    bvaldata(i),                                                \
+        BE_INT,                                                 \
         uint32_t((_next)&0xFFFFFF)                              \
 }
 

--- a/tools/coc/coc
+++ b/tools/coc/coc
@@ -18,6 +18,7 @@ class builder:
         self.config = macro_files
         self.macro = None
         self.strmap = {}
+        self.strmap_weak = {}
 
         self.macro = macro_table()
         for path in self.config:
@@ -26,7 +27,7 @@ class builder:
         for d in self.input:
             self.scandir(d)
         
-        sb = str_build(self.strmap)
+        sb = str_build(self.strmap, self.strmap_weak)
         sb.build(self.output)
     
     def parse_file(self, filename):
@@ -39,10 +40,14 @@ class builder:
             parser = coc_parser(text)
             for s in parser.strtab:
                 self.strmap[s] = 0
+            for s in parser.strtab_weak:
+                self.strmap_weak[s] = 0
             for obj in parser.objects:
                 builder = block_builder(obj, self.macro)
                 for s in builder.strtab:
                     self.strmap[s] = 0
+                for s in builder.strtab_weak:
+                    self.strmap_weak[s] = 0
                 builder.dumpfile(self.output)
 
     def scandir(self, srcpath):

--- a/tools/coc/coc_parser.py
+++ b/tools/coc/coc_parser.py
@@ -21,12 +21,16 @@ class coc_parser:
         """Parse text file"""
         self.objects = []
         self.strtab = set()
+        self.strtab_weak = set()
         self.text = text
         self.parsers = {
             "@const_object_info_begin": self.parse_object,
             "be_const_str_": self.parse_string,
             "be_const_key(": self.parse_string,
             "be_nested_str(": self.parse_string,
+            "be_const_key_weak(": self.parse_string_weak,
+            "be_nested_str_weak(": self.parse_string_weak,
+            "be_str_weak(": self.parse_string_weak,
         }
 
         while len(self.text) > 0:
@@ -74,9 +78,22 @@ class coc_parser:
         self.text = self.text[r.end(0):]
         return r[0]
 
+    # parse until the next comma or space (trim preceding spaces before)
+    # does not skip the comma
     def parse_tocomma(self):
         self.skip_space()
         r = re.match(r"[^,\s]*", self.text)
+        self.text = self.text[r.end(0):]
+        return r[0]
+
+    # parse until the next closing parenthesis or a single token if no parenthesis (trim preceding spaces before)
+    # matches:
+    #  'int'
+    #  'func(aa)'
+    #  'mapped_func(aa,"ee", "aa")
+    def parse_value(self):
+        self.skip_space()
+        r = re.match(r"(\S+\(.*?\))|([^,\s]*)", self.text)
         self.text = self.text[r.end(0):]
         return r[0]
 
@@ -87,6 +104,7 @@ class coc_parser:
         return r[0]
 
     def parse_object(self):
+        self.text = re.sub("\s+//.*?$", "", self.text, flags=re.MULTILINE)      # remove trailing comments
         while True:
             obj = self.parse_block()
             self.objects.append(obj)
@@ -105,11 +123,23 @@ class coc_parser:
             self.strtab.add(literal)
             # print(f"str '{ident}' -> {literal}")
 
+    def parse_string_weak(self):
+        if not self.text[0].isalnum() and self.text[0] != '_': return      # do not proceed, maybe false positive in solidify
+        ident = self.parse_word()
+        literal = unescape_operator(ident)
+        if not literal in self.strtab:
+            self.strtab_weak.add(literal)
+            # print(f"str '{ident}' -> {literal}")
+
+    #################################################################################
+    # Parse a block of definition like module, class...
+    #################################################################################
     def parse_block(self):
         obj = object_block()
         obj.type = self.parse_word()
         obj.name = self.parse_word()
         # print(f"parse_block: type={obj.type} name={obj.name}")
+        # # ex: 'parse_block: type=module name=gpio'
         self.parse_attr(obj)
         self.parse_body(obj)
         return obj
@@ -127,6 +157,9 @@ class coc_parser:
         value = self.parse_word()
         obj.attr[key] = value
     
+    #################################################################################
+    # Parse the body definition of a class, module...
+    #################################################################################
     def parse_body(self, obj):
         self.skip_char("{")
         if not self.parse_char("}"):
@@ -134,12 +167,16 @@ class coc_parser:
                 self.parse_body_item(obj)
                 if self.parse_char("}"): break
     
+    #################################################################################
+    # Parse each line item in the module/class/vartab
+    #################################################################################
     def parse_body_item(self, obj):
         value = data_value()
         key = self.parse_tocomma()
         # print(f"Key={key}")
-        self.parse_char_continue(",", True)
-        value.value = self.parse_tocomma()
+        self.parse_char_continue(",", True)     # skip the ',' after the key
+        value.value = self.parse_value()
+        # print(f"value.value={value.value}")
         if self.parse_char_continue(","):
             value.depend = self.parse_tonewline()
         obj.data[key] = value

--- a/tools/coc/hash_map.py
+++ b/tools/coc/hash_map.py
@@ -111,6 +111,9 @@ class hash_map:
             self.insert_p(key, value)
             self.count += 1
     
+    #################################################################################
+    # Compute entries in the hash for modules or classes
+    #################################################################################
     # return a list (entiry, var_count)
     def entry_modify(self, ent, var_count):
         ent.key = escape_operator(ent.key)
@@ -121,6 +124,7 @@ class hash_map:
             ent.value = "be_const_" + ent.value
         return (ent, var_count)
     
+    #  generate the final map
     def entry_list(self):
         l = []
         var_count = 0
@@ -128,6 +132,9 @@ class hash_map:
         self.resize(self.count)
         for it in self.bucket:
             (ent, var_count) = self.entry_modify(it, var_count)
+            # print(f"ent={ent} var_count={var_count}")
+            # # ex: ent=<entry object; key='arg', value='be_const_func(w_webserver_arg)', next=-1> var_count=0
+            # # ex: ent=<entry object; key='check_privileged_access2', value='be_const_func(w_webserver_check_privileged_access_ntv, "b", "")', next=-1> var_count=0
             l.append(ent)
         return l
     


### PR DESCRIPTION
Add an options to pre-compiled classes/modules so that string constants are "weak", i.e. they are declared but not included in `strtab` global structure.

This allows so modules/classes to be conditionally compiled but their strings not to be linked into the binary if they are not required (the linker only attaches necessary strings). This is used heavily in Tasmota to reduce the Flash size by not including string constants from non-included modules/classes.

The weak strings are triggered by `strings: weak` attirbute

Example:

``` C
/* @const_object_info_begin
module zigbee (scope: global, strings: weak) {
  init, func(zigbee_init)
}
@const_object_info_end */
```