### PR TITLE
Allow virtual members to return nil

### DIFF
--- a/default/be_modtab.c
+++ b/default/be_modtab.c
@@ -22,6 +22,7 @@ be_extern_native_module(gc);
 be_extern_native_module(solidify);
 be_extern_native_module(introspect);
 be_extern_native_module(strict);
+be_extern_native_module(undefined);
 
 /* user-defined modules declare start */
 
@@ -66,6 +67,7 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
 #if BE_USE_STRICT_MODULE
     &be_native_module(strict),
 #endif
+    &be_native_module(undefined),
     /* user-defined modules register start */
 
     /* user-defined modules register end */

--- a/src/be_class.c
+++ b/src/be_class.c
@@ -12,6 +12,7 @@
 #include "be_gc.h"
 #include "be_vm.h"
 #include "be_func.h"
+#include "be_module.h"
 #include <string.h>
 
 #define check_members(vm, c)            \
@@ -297,10 +298,15 @@ int be_instance_member(bvm *vm, binstance *instance, bstring *name, bvalue *dst)
                     *dst = obj->members[dst->v.i];
                 }
                 type = var_type(dst);
-                if (type != BE_NIL) {
+                if (type == BE_MODULE) {
+                    /* check if the module is named `undefined` */
+                    bmodule *mod = var_toobj(dst);
+                    if (strcmp(be_module_name(mod), "undefined") == 0) {
+                        return BE_NONE;     /* if the return value is module `undefined`, consider it is an error */
+                    }
+                }
                     var_clearstatic(dst);
                     return type;
-                }
             }
         }
     }

--- a/src/be_class.c
+++ b/src/be_class.c
@@ -345,6 +345,20 @@ bbool be_instance_setmember(bvm *vm, binstance *o, bstring *name, bvalue *src)
             vm->top += 4;   /* prevent collection results */
             be_dofunc(vm, top, 3); /* call method 'member' */
             vm->top -= 4;
+            /* if return value is `false` or `undefined` signal an unknown attribute */
+            int type = var_type(vm->top);
+            if (type == BE_BOOL) {
+                bbool ret = var_tobool(vm->top);
+                if (!ret) {
+                    return bfalse;
+                }
+            } else if (type == BE_MODULE) {
+                /* check if the module is named `undefined` */
+                bmodule *mod = var_toobj(vm->top);
+                if (strcmp(be_module_name(mod), "undefined") == 0) {
+                    return bfalse;     /* if the return value is module `undefined`, consider it is an error */
+                }
+            }
             return btrue;
         }
     }

--- a/src/be_globallib.c
+++ b/src/be_globallib.c
@@ -72,7 +72,6 @@ static int m_setglobal(bvm *vm)
     if (top >= 2 && be_isstring(vm, 1)) {
         const char * name = be_tostring(vm, 1);
         be_setglobal(vm, name);
-        be_return(vm);
     }
     be_return_nil(vm);
 }

--- a/src/be_module.c
+++ b/src/be_module.c
@@ -327,9 +327,16 @@ int be_module_attr(bvm *vm, bmodule *module, bstring *attr, bvalue *dst)
             be_dofunc(vm, top, 1); /* call method 'method' */
             vm->top -= 2;
             *dst = *vm->top;   /* copy result to R(A) */
-            if (var_basetype(dst) != BE_NIL) {
-                return var_type(dst);
+            
+            int type = var_type(dst);
+            if (type == BE_MODULE) {
+                /* check if the module is named `undefined` */
+                bmodule *mod = var_toobj(dst);
+                if (strcmp(be_module_name(mod), "undefined") == 0) {
+                    return BE_NONE;     /* if the return value is module `undefined`, consider it is an error */
             }
+            }
+            return type;
         }
         return BE_NONE;
     }

--- a/src/be_module.c
+++ b/src/be_module.c
@@ -368,6 +368,19 @@ bbool be_module_setmember(bvm *vm, bmodule *module, bstring *attr, bvalue *src)
             vm->top += 3;   /* prevent collection results */
             be_dofunc(vm, top, 2); /* call method 'setmember' */
             vm->top -= 3;
+            int type = var_type(vm->top);
+            if (type == BE_BOOL) {
+                bbool ret = var_tobool(vm->top);
+                if (!ret) {
+                    return bfalse;
+                }
+            } else if (type == BE_MODULE) {
+                /* check if the module is named `undefined` */
+                bmodule *mod = var_toobj(vm->top);
+                if (strcmp(be_module_name(mod), "undefined") == 0) {
+                    return bfalse;     /* if the return value is module `undefined`, consider it is an error */
+                }
+            }
             return btrue;
         }
     }

--- a/src/be_undefinedlib.c
+++ b/src/be_undefinedlib.c
@@ -1,0 +1,34 @@
+/********************************************************************
+** Copyright (c) 2018-2020 Guan Wenliang, Stephan Hadinger
+** This file is part of the Berry default interpreter.
+** skiars@qq.com, https://github.com/Skiars/berry
+** See Copyright Notice in the LICENSE file or at
+** https://github.com/Skiars/berry/blob/master/LICENSE
+********************************************************************/
+#include "be_object.h"
+#include "be_module.h"
+#include "be_string.h"
+#include "be_vector.h"
+#include "be_class.h"
+#include "be_debug.h"
+#include "be_map.h"
+#include "be_vm.h"
+#include "be_exec.h"
+#include "be_gc.h"
+#include <string.h>
+
+
+#if !BE_USE_PRECOMPILED_OBJECT
+be_native_module_attr_table(undefined) {
+    be_native_module_nil(".p"),         /* not needed but can't be empty */
+};
+
+be_define_native_module(undefined, NULL);
+#else
+/* @const_object_info_begin
+module undefined (scope: global) {
+    .p, nil()
+}
+@const_object_info_end */
+#include "../generate/be_fixed_undefined.h"
+#endif

--- a/tests/global.be
+++ b/tests/global.be
@@ -8,14 +8,6 @@ def assert_syntax_error(code)
         assert(e == 'syntax_error')
     end
 end
-def assert_attribute_error(f)
-    try
-        f()
-        assert(false, 'unexpected execution flow')
-    except .. as e, m
-        assert(e == 'attribute_error')
-    end
-end
 def findinlist(l, e)
     var i
     for i: 0..size(l)-1
@@ -42,8 +34,8 @@ global.global_c = 3
 f = compile("return global_c")
 assert(f() == 3)
 
-#- check that access to non-existent global returns an exception -#
-assert_attribute_error(/-> global.d)
+#- check that access to non-existent global returns nil (new behavior) -#
+assert(global.d == nil)
 
 #- check the glbal list -#
 assert(findinlist(global(), 'global_a') != nil)

--- a/tests/virtual_methods.be
+++ b/tests/virtual_methods.be
@@ -32,9 +32,11 @@ assert_attribute_error(/-> t.c)
 
 class T2 : T1
     def member(n)
+        import undefined
         if (n == 'f1') return / n -> n end
         if (n == 'f2') return /-> 4 end
         if (n == 'a1') return 10 end
+        if (n == 'h')  return undefined end
     end
 end
 t2 = T2()
@@ -50,6 +52,7 @@ assert_attribute_error(/-> t2.h())
 assert(t2.f1() == t2)
 assert(t2.f2() == 4)
 assert(t2.a1 == 10)
+assert(t2.foo == nil)
 
 #- module -#
 m = module("m")
@@ -59,8 +62,11 @@ assert(m.a == 1)
 assert_attribute_error(/-> m.b)
 
 m.member = def(n)
+    import undefined
     if n == "b" return 2 end
+    if n == "c" return undefined end
 end
 
 assert(m.b == 2)
 assert_attribute_error(/-> m.c)
+assert(m.d == nil)  #- returns nil if no response -#

--- a/tests/virtual_methods2.be
+++ b/tests/virtual_methods2.be
@@ -1,4 +1,14 @@
 #- virtual attributes -#
+
+def assert_attribute_error(f)
+    try
+        f()
+        assert(false, 'unexpected execution flow')
+    except .. as e, m
+        assert(e == 'attribute_error')
+    end
+end
+
 class Ta
     var a, b, virtual_c
     def init()
@@ -26,3 +36,4 @@ assert(ta.c == 3)
 ta.c = 30
 assert(ta.c == 30)
 assert(ta.virtual_c == 30)
+assert_attribute_error(def() ta.d = 0 end)


### PR DESCRIPTION
Until now, virtual members via `member(name)` treated `nil` response as the attribute being undefined. This generates some problems since it's not possible to distinguish between non-existent attribute and attribute with value `nil`.

After this change, a virtual member can return `nil` to indicate a `nil` value. To trigger an attribute not existing it has two options:
- raise an exception within the `member()` method
- return the special `undefined` module which is used as a marker so an attribute error is triggered.

Example, `class dyn` simulates dynamic attributes

``` berry
class dyn
    var _attr
    def init()
        self._attr = {}
    end
    def setmember(name, value)
        self._attr[name] = value
    end
    def member(name)
        if self._attr.contains(name)
            return self._attr[name]
        else
            import undefined
            return undefined
        end
    end
end
```

``` berry
> a = dyn()
> a.a
attribute_error: the 'dyn' object has no attribute 'a'
stack traceback:
	stdin:1: in function `main`
> a.a = 1
> a.a
1
> a.a = nil
> a.a
>
```