### PR TITLE
Remove unused registry

### DIFF
--- a/src/be_api.c
+++ b/src/be_api.c
@@ -1138,29 +1138,3 @@ BERRY_API bbool be_isge(bvm *vm)
     be_assert(vm->reg + 2 <= vm->top);
     return be_vm_isge(vm, vm->top - 2, vm->top - 1);
 }
-
-BERRY_API int be_register(bvm *vm, int index)
-{
-    bvalue *v;
-    if (!vm->registry) {
-        vm->registry = be_list_new(vm);
-        be_list_pool_init(vm, vm->registry);
-    }
-    be_assert(vm->registry != NULL);
-    v = be_indexof(vm, index);
-    return be_list_pool_alloc(vm, vm->registry, v);
-}
-
-BERRY_API void be_unregister(bvm *vm, int id)
-{
-    be_assert(vm->registry != NULL);
-    be_list_pool_free(vm->registry, id);
-}
-
-BERRY_API void be_getregister(bvm *vm, int id)
-{
-    blist *reg = vm->registry;
-    be_assert(reg && id > 0 && id < be_list_count(reg));
-    var_setval(vm->top, be_list_at(reg, id));
-    be_incrtop(vm);
-}

--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -370,7 +370,6 @@ static void premark_internal(bvm *vm)
     mark_gray(vm, gc_object(vm->module.loaded));
     mark_gray(vm, gc_object(vm->module.path));
     mark_gray(vm, gc_object(vm->ntvclass));
-    mark_gray(vm, gc_object(vm->registry));
 #if BE_USE_DEBUG_HOOK
     if (be_isgcobj(&vm->hook)) {
         mark_gray(vm, gc_object(var_toobj(&vm->hook)));

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -102,7 +102,6 @@ struct bvm {
     struct bstringtable strtab; /* short string table */
     bstack tracestack; /* call state trace-stack */
     bmap *ntvclass; /* native class table */
-    blist *registry; /* registry list */
     struct bgc gc;
     bctypefunc ctypefunc; /* handler to ctype_func */
     bbyte compopt; /* compilation options */

--- a/src/berry.h
+++ b/src/berry.h
@@ -567,11 +567,6 @@ BERRY_API void be_module_path_set(bvm *vm, const char *path);
 BERRY_API void* be_pushbytes(bvm *vm, const void *buf, size_t len);
 BERRY_API const void* be_tobytes(bvm *vm, int index, size_t *len);
 
-/* registry operation */
-BERRY_API int be_register(bvm *vm, int index);
-BERRY_API void be_unregister(bvm *vm, int id);
-BERRY_API void be_getregister(bvm *vm, int id);
-
 /* debug APIs */
 BERRY_API void be_sethook(bvm *vm, const char *mask);
 BERRY_API void be_setntvhook(bvm *vm, bntvhook hook, void *data, int mask);


### PR DESCRIPTION
Remove registry functions as they are not used anywhere nor documented. I suppose it is a leftover from a changed feature.