### PR TITLE
Fix reference count when exception is raised

### DIFF
--- a/src/be_exec.h
+++ b/src/be_exec.h
@@ -45,6 +45,7 @@ struct bexecptframe {
     struct blongjmp errjmp; /* long jump information */
     int depth; /* function call stack depth */
     binstruction *ip; /* instruction pointer */
+    int refcount; /* save object reference stack */
 };
 
 void be_throw(bvm *vm, int errorcode);

--- a/tests/reference.be
+++ b/tests/reference.be
@@ -1,0 +1,31 @@
+# try to exercise bug in reference
+
+class failable
+    var fail        # if 'true', tostring() raises an exception
+
+    def tostring()
+        if self.fail
+            raise "internal_error", "FAIL"
+            return "FAIL"
+        else
+            return "SUCCESS"
+        end
+    end
+end
+f = failable()
+
+l1 = [1, 2, f]
+l2 = ["foo", l1]
+l1.push(l1)
+
+assert(str(l2) == "['foo', [1, 2, SUCCESS, [...]]]")
+assert(str(l1) == "[1, 2, SUCCESS, [...]]")
+
+f.fail = true
+try
+    print(str(l1))
+except ..
+end
+
+f.fail = false
+assert(str(l1) == "[1, 2, SUCCESS, [...]]")  # FAILS


### PR DESCRIPTION
I realized that list/map `tostring()` use `be_refpush()` to detect any circular reference that would lead to an infinite loop. However if an exception is raised, the reference remains in the stack and is never cleared. This object would then be wrongly  rejected from any further call.

I did a test case to show this behavior.

This patch saves `vm->refstack.count` during `try` or just before calling `be_pcall()` and restores the original `vm->refstack.count` when an exception is raised.