### PR TITLE
Add introspect.setmodule()

### DIFF
--- a/src/be_module.c
+++ b/src/be_module.c
@@ -245,7 +245,7 @@ static bvalue* load_cached(bvm *vm, bstring *path)
     return v;
 }
 
-static void cache_module(bvm *vm, bstring *name)
+void be_cache_module(bvm *vm, bstring *name)
 {
     bvalue *v;
     if (vm->module.loaded == NULL) {
@@ -282,7 +282,7 @@ int be_module_load(bvm *vm, bstring *path)
         if (res == BE_OK) {
             /* on first load of the module, try running the '()' function */
             module_init(vm);
-            cache_module(vm, path);
+            be_cache_module(vm, path);
         }
     }
     return res;

--- a/src/be_module.h
+++ b/src/be_module.h
@@ -34,6 +34,7 @@ typedef struct bmodule {
 bmodule* be_module_new(bvm *vm);
 void be_module_delete(bvm *vm, bmodule *module);
 int be_module_load(bvm *vm, bstring *path);
+void be_cache_module(bvm *vm, bstring *name);
 int be_module_attr(bvm *vm, bmodule *module, bstring *attr, bvalue *dst);
 bbool be_module_setmember(bvm *vm, bmodule *module, bstring *attr, bvalue *src);
 const char* be_module_name(bmodule *module);

--- a/tests/module.be
+++ b/tests/module.be
@@ -1,0 +1,45 @@
+# test for monkey patching of modules
+
+import string
+import introspect
+
+var string_orig = string
+
+introspect.setmodule("string", 42)
+import string
+assert(string == 42)
+
+# set back original value
+introspect.setmodule("string", string_orig)
+import string
+assert(type(string) == 'module')
+assert(str(string) == '<module: string>')
+
+#
+# demo, how to monkey patch string with a new function `foo()` returning `bar`
+#
+import string
+import introspect
+var string_orig = string            # keep a copy of the original string module
+var string_alt = module('string')   # create a new module
+
+# function `super()` is a closure to capture the original value of string
+string_alt.super = def()
+    return string_orig
+end
+
+# function `member()` is a clousre to capture the original value of string module
+string_alt.member = def(k)
+    import introspect
+    return introspect.get(string_orig, k, true)
+end
+
+string_alt.foo = def() return 'bar' end
+
+# replace the entry for module "string", from now on each `import string` will use `string_alt`
+introspect.setmodule("string", string_alt)
+import string
+
+# test the new string module
+assert(string.tolower('abCD') == 'abcd')
+assert(string.foo() == 'bar')


### PR DESCRIPTION
Add the ability to change an entry for an existing module. This allows for monkey patching, but can be risky.

Simple example of extending the `string` module with `string.foo()` to return `'bar'`:

``` berry
#
# demo, how to monkey patch string with a new function `foo()` returning `bar`
#
import string
import introspect
var string_orig = string            # keep a copy of the original string module
var string_alt = module('string')   # create a new module

# function `super()` is a closure to capture the original value of string
string_alt.super = def()
    return string_orig
end

# function `member()` is a clousre to capture the original value of string module
string_alt.member = def(k)
    import introspect
    return introspect.get(string_orig, k, true)
end

string_alt.foo = def() return 'bar' end

# replace the entry for module "string", from now on each `import string` will use `string_alt`
introspect.setmodule("string", string_alt)
import string
```

Report of https://github.com/arendst/Tasmota/pull/16652