### PR TITLE
"-m paths" option to specify custom module search path

### DIFF
--- a/default/berry.c
+++ b/default/berry.c
@@ -57,6 +57,13 @@
     FULL_VERSION " (build in " __DATE__ ", " __TIME__ ")\n"         \
     "[" COMPILER "] on " OS_NAME " (default)\n"                     \
 
+#if defined(_WIN32)
+#define PATH_SEPARATOR ";"
+#else
+#define PATH_SEPARATOR ":"
+#endif
+
+
 /* command help information */
 #define help_information                                            \
     "Usage: berry [options] [script [args]]\n"                      \
@@ -64,6 +71,7 @@
     "  -i        enter interactive mode after executing 'file'\n"   \
     "  -l        all variables in 'file' are parsed as local\n"     \
     "  -e        load 'script' source string and execute\n"         \
+    "  -m <path> custom module search path(s) separated by '" PATH_SEPARATOR "'\n"\
     "  -c <file> compile script 'file' to bytecode file\n"          \
     "  -o <file> save bytecode to 'file'\n"                         \
     "  -g        force named globals in VM\n"                       \
@@ -85,6 +93,7 @@
 #define arg_g       (1 << 7)
 #define arg_s       (1 << 8)
 #define arg_err     (1 << 9)
+#define arg_m       (1 << 10)
 
 struct arg_opts {
     int idx;
@@ -93,6 +102,7 @@ struct arg_opts {
     const char *errarg;
     const char *src;
     const char *dst;
+    const char *modulepath;
 };
 
 /* check if the character is a letter */
@@ -255,6 +265,10 @@ static int parse_arg(struct arg_opts *opt, int argc, char *argv[])
         case 'e': args |= arg_e; break;
         case 'g': args |= arg_g; break;
         case 's': args |= arg_s; break;
+        case 'm':
+            args |= arg_m;
+            opt->modulepath = opt->optarg;
+            break;
         case '?': return args | arg_err;
         case 'c':
             args |= arg_c;
@@ -284,12 +298,47 @@ static void push_args(bvm *vm, int argc, char *argv[])
     be_pop(vm, 1);
 }
 
+#if defined(_WIN32)
+#define BERRY_ROOT "\\Windows\\system32"
+static const char *module_paths[] = {
+    BERRY_ROOT "\\berry\\packages",
+};
+#else
+#define BERRY_ROOT "/usr/local"
+static const char *module_paths[] = {
+    BERRY_ROOT "/lib/berry/packages",
+};
+#endif
+
+static void berry_paths(bvm * vm)
+{
+    size_t i;
+    for (i = 0; i < array_count(module_paths); ++i) {
+        be_module_path_set(vm, module_paths[i]);
+    }
+}
+
+static void berry_custom_paths(bvm * vm, const char *modulepath)
+{
+    const char delim[] = PATH_SEPARATOR;
+    char copy[strlen(modulepath)+1];
+    strcpy(copy, modulepath);
+        
+    char *ptr = strtok(copy, delim);
+
+    while (ptr != NULL) {
+        be_module_path_set(vm, ptr);
+        ptr = strtok(NULL, delim);
+    }        
+}
+
 /* 
  * command format: berry [options] [script [args]]
  *  command options:
  *   -i: enter interactive mode after executing 'script'
  *   -b: load code from bytecode file
  *   -e: load 'script' source and execute
+ *   -m: specify custom module search path(s)
  * command format: berry options
  *  command options:
  *   -v: show version information
@@ -303,7 +352,7 @@ static int analysis_args(bvm *vm, int argc, char *argv[])
 {
     int args = 0;
     struct arg_opts opt = { 0 };
-    opt.pattern = "vhilegsc?o?";
+    opt.pattern = "m?vhilegsc?o?";
     args = parse_arg(&opt, argc, argv);
     argc -= opt.idx;
     argv += opt.idx;
@@ -313,6 +362,16 @@ static int analysis_args(bvm *vm, int argc, char *argv[])
         be_pop(vm, 1);
         return -1;
     }
+    
+    if (args & arg_m) {
+        berry_custom_paths(vm, opt.modulepath);        
+        args &= ~arg_m;
+    }
+    else {
+        // use default module paths
+        berry_paths(vm);
+    }
+    
     if (args & arg_g) {
         comp_set_named_gbl(vm); /* forced named global in VM code */
         args &= ~arg_g;         /* clear the flag for this option not to interfere with other options */
@@ -337,31 +396,11 @@ static int analysis_args(bvm *vm, int argc, char *argv[])
     return load_script(vm, argc, argv, args);
 }
 
-#if defined(_WIN32)
-#define BERRY_ROOT "\\Windows\\system32"
-static const char *module_paths[] = {
-    BERRY_ROOT "\\berry\\packages",
-};
-#else
-#define BERRY_ROOT "/usr/local"
-static const char *module_paths[] = {
-    BERRY_ROOT "/lib/berry/packages",
-};
-#endif
-
-static void berry_paths(bvm * vm)
-{
-    size_t i;
-    for (i = 0; i < array_count(module_paths); ++i) {
-        be_module_path_set(vm, module_paths[i]);
-    }
-}
 
 int main(int argc, char *argv[])
 {
     int res;
     bvm *vm = be_vm_new(); /* create a virtual machine instance */
-    berry_paths(vm);
     res = analysis_args(vm, argc, argv);
     be_vm_delete(vm); /* free all objects and vm */
     return res;


### PR DESCRIPTION
hi, i added a -m option to specify a different search path than standard. It works like this: if it's not specified, the program works as usual with no differences. If it's specified, the paths are used to fill the sys.path list, *instead* of the default (ie \Windows\system32\berry\packages in windows).

This allow more control over the search path, such as having a folder with all your favorite libraries, or to make more advanced building and dependency management systems.

It was also discussed recently [here](https://github.com/berry-lang/berry/discussions/243).

PS path separator is ; on windows and : on other systems (it should be standard)