### PR TITLE
Add ability to customize max bytes() size

### DIFF
--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -36,6 +36,14 @@
  **/
 #define BE_USE_SINGLE_FLOAT             0
 
+/* Macro: BE_BYTES_MAX_SIZE
+ * Maximum size in bytes of a `bytes()` object.
+ * Putting too much pressure on the memory allocator can do
+ * harm, so we limit the maximum size.
+ * Default: 32kb
+ **/
+#define BE_BYTES_MAX_SIZE               (32*1024)   /* 32 kb default value */
+
 /* Macro: BE_USE_PRECOMPILED_OBJECT
  * Use precompiled objects to avoid creating these objects at
  * runtime. Enable this macro can greatly optimize RAM usage.

--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -18,7 +18,6 @@
 #include <ctype.h>
 
 #define BYTES_DEFAULT_SIZE          28              // default pre-reserved size for buffer (keep 4 bytes for len/size)
-#define BYTES_MAX_SIZE              (32*1024)       // max 32Kb
 #define BYTES_OVERHEAD              4               // bytes overhead to be added when allocating (used to store len and size)
 #define BYTES_HEADROOM              8               // keep a natural headroom of 8 bytes when resizing
 
@@ -506,7 +505,7 @@ void m_write_attributes(bvm *vm, int rel_idx, const buf_impl * attr)
 void bytes_realloc(bvm *vm, buf_impl * attr, int32_t size)
 {
     if (!attr->fixed && size < 4) { size = 4; }
-    if (size > BYTES_MAX_SIZE) { size = BYTES_MAX_SIZE; }
+    if (size > vm->bytesmaxsize) { size = vm->bytesmaxsize; }
     size_t oldsize = attr->bufptr ? attr->size : 0;
     attr->bufptr = (uint8_t*) be_realloc(vm, attr->bufptr, oldsize, size);  /* malloc */
     attr->size = size;

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -469,6 +469,7 @@ BERRY_API bvm* be_vm_new(void)
     be_gc_setpause(vm, 1);
     be_loadlibs(vm);
     vm->compopt = 0;
+    vm->bytesmaxsize = BE_BYTES_MAX_SIZE;
     vm->obshook = NULL;
     vm->ctypefunc = NULL;
 #if BE_USE_PERF_COUNTERS

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -105,6 +105,7 @@ struct bvm {
     struct bgc gc;
     bctypefunc ctypefunc; /* handler to ctype_func */
     bbyte compopt; /* compilation options */
+    int32_t bytesmaxsize; /* max allowed size for bytes() object, default 32kb but can be increased */
     bobshook obshook;
 #if BE_USE_PERF_COUNTERS
     uint32_t counter_ins; /* instructions counter */


### PR DESCRIPTION
Previously the max size for `bytes()` object was 32KB. For ESP32 this is reasonable, but too small when attached PSRAM of 4/8 MB. It is now possible to change the compile time default `BE_BYTES_MAX_SIZE` and to dynamically change this size with `vm->bytesmaxsize`. This makes it possible to dynamically detect the presence of PSRAM and adjust max size accordingly.