### PR TITLE
stricter mode

### DIFF
--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -462,6 +462,12 @@ static int new_upval(bvm *vm, bfuncinfo *finfo, bstring *name, bexpdesc *var)
 static void new_var(bparser *parser, bstring *name, bexpdesc *var)
 {
     bfuncinfo *finfo = parser->finfo;
+    if (comp_is_strict(parser->vm)) {
+        /* check if we are masking a builtin */
+        if (be_builtin_find(parser->vm, name) >= 0) {
+            push_error(parser, "strict: redefinition of builtin '%s'", str(name));
+        }
+    }
     if (finfo->prev || finfo->binfo->prev || parser->islocal) {
         init_exp(var, ETLOCAL, 0);
         var->v.idx = new_localvar(parser, name); /* if local, contains the index in current local var list */
@@ -975,7 +981,6 @@ static void compound_assign(bparser *parser, int op, bexpdesc *l, bexpdesc *r)
 /* A new implicit local variable is created if no global has the same name (excluding builtins) */
 /* This means that you can override a builtin silently */
 /* This also means that a function cannot create a global, they must preexist or create with `global` module */
-/* TODO add warning in strict mode */
 static int check_newvar(bparser *parser, bexpdesc *e)
 {
     if (e->type == ETGLOBAL) {


### PR DESCRIPTION
Make strict mode even stricter and forbid declaring a local variable with the same name as a builtin. A common mistake was to call a local variable `size` and hide the builtin

``` berry
> def f() var size = 1 end
syntax_error: stdin:1: strict: redefinition of builtin 'size'
```