### PR TITLE
Fixing a typo in bntvmodobj constructors (C++).

### DIFF
--- a/src/berry.h
+++ b/src/berry.h
@@ -199,19 +199,19 @@ typedef struct bntvmodobj {
 #endif
     } u;                                            /**< u */
 #ifdef __cplusplus
-    BE_CONSTEXPR bntvmodobj_t(const char *name) :
+    BE_CONSTEXPR bntvmodobj(const char *name) :
         name(name), type(BE_CNIL), u(bint(0)) {}    /**< bntvmodobj */
-    BE_CONSTEXPR bntvmodobj_t(const char *name, bint v) :
+    BE_CONSTEXPR bntvmodobj(const char *name, bint v) :
         name(name), type(BE_CINT), u(v) {}          /**< bntvmodobj */
-    BE_CONSTEXPR bntvmodobj_t(const char *name, breal v) :
+    BE_CONSTEXPR bntvmodobj(const char *name, breal v) :
         name(name), type(BE_CREAL), u(v) {}         /**< bntvmodobj */
-    BE_CONSTEXPR bntvmodobj_t(const char *name, bbool v) :
+    BE_CONSTEXPR bntvmodobj(const char *name, bbool v) :
         name(name), type(BE_CBOOL), u(v) {}         /**< bntvmodobj */
-    BE_CONSTEXPR bntvmodobj_t(const char *name, bntvfunc v) :
+    BE_CONSTEXPR bntvmodobj(const char *name, bntvfunc v) :
         name(name), type(BE_CFUNCTION), u(v) {}     /**< bntvmodobj */
-    BE_CONSTEXPR bntvmodobj_t(const char *name, const char *v) :
+    BE_CONSTEXPR bntvmodobj(const char *name, const char *v) :
         name(name), type(BE_CSTRING), u(v) {}       /**< bntvmodobj */
-    BE_CONSTEXPR bntvmodobj_t(const char *name, int _tpye, const void *v) :
+    BE_CONSTEXPR bntvmodobj(const char *name, int _tpye, const void *v) :
         name(name), type(_tpye), u(v) {}            /**< bntvmodobj */
 #endif
 } bntvmodobj_t; /**< bntvmodobj_t */


### PR DESCRIPTION
Hello,
I have done a small fix to the constructors of bntvmodobj (since bntvmodobj_t is declared after the bntvmodobj structure, it cannot be used as a alias for bntvmodobj).
Thank you for your awsome work.