### PR TITLE
fix: crash while parsing JSON strings by ensuring free stack space

### DIFF
--- a/src/be_jsonlib.c
+++ b/src/be_jsonlib.c
@@ -183,6 +183,10 @@ static const char* parser_string(bvm *vm, const char *json)
                 }
             }
             be_assert(ch == '"');
+            /* require the stack to have some free space for the string, 
+               since parsing deeply nested objects might
+               crash the VM due to insufficient stack space. */
+            be_stack_require(vm, 1 + BE_STACK_FREE_MIN);
             be_pushnstring(vm, buf, cast_int(dst - buf));
             be_free(vm, buf, len);
             return json + 1; /* skip '"' */

--- a/tests/json.be
+++ b/tests/json.be
@@ -34,6 +34,12 @@ assert_load_failed('{"ke: 1}')
 assert_load_failed('{"key": 1x}')
 assert_load_failed('{"key"}')
 assert_load_failed('{"key": 1, }')
+# insanely long, nested object
+var text = 'null'
+for i : 0 .. 200
+    text = '{"nested":' + text + ', "num": 1, "bool": true, "str": "abc", "n": null, "arr": [1, 2, 3]}'
+end
+json.load(text) # do nothing, just check that it doesn't crash
 
 # dump tests
 


### PR DESCRIPTION
Improve the string parsing logic by requiring the stack to have some free space for the string, since parsing deeply nested objects might crash the VM due to insufficient stack space.

Also, add a non-trivial test case with an insanely long and nested object to ensure that JSON loading doesn't crash due to stack space issues.

The check of the stack might incur a runtime performance penalty while parsing JSON, but I believe not crashing with a segmentation fault is more important, since the JSON could be parsed from untrusted user input.