### PR TITLE
fix: Prevent passing a NULL pointer to strncmp when creating an empty string

### DIFF
--- a/src/be_string.c
+++ b/src/be_string.c
@@ -167,6 +167,12 @@ static bstring* find_conststr(const char *str, size_t len)
     uint32_t hash = str_hash(str, len);
     bcstring *s = (bcstring*)tab->table[hash % tab->size];
     for (; s != NULL; s = next(s)) {
+        if(len == 0 && s->slen == 0) {
+            /* special case for the empty string,
+               since we don't want to compare it using strncmp, 
+               because str might be NULL */
+            return (bstring*)s;
+        }
         if (len == s->slen && !strncmp(str, s->s, len)) {
             return (bstring*)s;
         }

--- a/tests/json.be
+++ b/tests/json.be
@@ -30,6 +30,12 @@ assert_load_failed('[1, null')
 # object
 var o = json.load('{"key": 1}')
 assert(o['key'] == 1 && o.size() == 1)
+
+# parsing an empty string used to cause berry to pass a NULL to strncmp
+# make sure we catch this
+o = json.load('{"key": ""}')
+assert(o['key'] == '' && o.size() == 1)
+
 assert_load_failed('{"ke: 1}')
 assert_load_failed('{"key": 1x}')
 assert_load_failed('{"key"}')


### PR DESCRIPTION
While trying to find a conststr for a zero-length (empty) it might happen that the string pointer is NULL (for example during parsing a JSON string). This caused berry to pass the NULL pointer to strncmp which is Undefined Behaviour, and caused the address sanitizer to print a warning (also this could cause crashes on some configurations).

Additionally a test case has been added for this behaviour.