### PR TITLE
fix: Disallow unescaped control characters in JSON strings

### DIFF
--- a/src/be_jsonlib.c
+++ b/src/be_jsonlib.c
@@ -178,6 +178,11 @@ static const char* parser_string(bvm *vm, const char *json)
                     }
                     default: be_free(vm, buf, len); return NULL; /* error */
                     }
+                } else if(ch >= 0 && ch <= 0x1f) {
+                    /* control characters must be escaped
+                       as per https://www.rfc-editor.org/rfc/rfc7159#section-7 */
+                    be_free(vm, buf, len);
+                    return NULL;
                 } else {
                     *dst++ = (char)ch;
                 }


### PR DESCRIPTION
See: https://www.rfc-editor.org/rfc/rfc7159#section-7

   All Unicode characters may be placed within the
   quotation marks, except for the characters that must be escaped:
   quotation mark, reverse solidus, and the control characters (U+0000
   through U+001F).