### PR TITLE
Use bool as map key, and test for bytes

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -1125,6 +1125,13 @@ static int m_size(bvm *vm)
     be_return(vm);
 }
 
+static int m_tobool(bvm *vm)
+{
+    buf_impl attr = m_read_attributes(vm, 1);
+    be_pushbool(vm, attr.len > 0 ? 1 : 0);
+    be_return(vm);
+}
+
 static int m_resize(bvm *vm)
 {
     int argc = be_top(vm);
@@ -1668,6 +1675,7 @@ void be_load_byteslib(bvm *vm)
         { "deinit", m_deinit },
         { "tostring", m_tostring },
         { "asstring", m_asstring },
+        { "tobool", m_tobool },
         { "fromstring", m_fromstring },
         { "tob64", m_tob64 },
         { "fromb64", m_fromb64 },
@@ -1714,6 +1722,7 @@ class be_class_bytes (scope: global, name: bytes) {
     deinit, func(m_deinit)
     tostring, func(m_tostring)
     asstring, func(m_asstring)
+    tobool, func(m_tobool)
     fromstring, func(m_fromstring)
     tob64, func(m_tob64)
     fromb64, func(m_fromb64)

--- a/src/be_map.c
+++ b/src/be_map.c
@@ -112,6 +112,7 @@ static int eqnode(bvm *vm, bmapnode *node, bvalue *key, uint32_t hash)
 #endif
         if(keytype(k) == key->type && hashcode(k) == hash) {
             switch (key->type) {
+            case BE_BOOL: return var_tobool(key) == var_tobool(k);
             case BE_INT: return var_toint(key) == var_toint(k);
             case BE_REAL: return var_toreal(key) == var_toreal(k);
             case BE_STRING: return be_eqstr(var_tostr(key), var_tostr(k));

--- a/tests/bytes.be
+++ b/tests/bytes.be
@@ -248,3 +248,12 @@ assert(bytes("0011223344").reverse(1, nil) == bytes("0044332211"))
 
 assert(bytes("0011223344").reverse(nil, nil, 2) == bytes("2233001144"))
 assert(bytes("001122334455").reverse(nil, nil, 3) == bytes("334455001122"))
+
+# tobool returns `true` is bytes() is not null, `false` if empty
+assert(bool(bytes()) == false)
+assert(bytes().tobool() == false)
+assert(!bytes())
+
+assert(bool(bytes("00")) == true)
+assert(bytes("01").tobool() == true)
+assert(bytes("02"))

--- a/tests/map.be
+++ b/tests/map.be
@@ -30,3 +30,10 @@ m.remove(2)
 assert(str(m) == '{1: 2}')
 m.remove(1)
 assert(str(m) == '{}')
+
+# allow booleans to be used as keys
+m={true:10, false:20}
+assert(m.contains(true))
+assert(m.contains(false))
+assert(m[true] == 10)
+assert(m[false] == 20)


### PR DESCRIPTION
Allow booleans to be used as keys for maps.

Allow to test `bytes()` with `bool()` and `tobool()`. Returns `true` if the bytes instance is not empty.