### PR TITLE
Fix: properly expand the stack when loading/dumping JSON

### DIFF
--- a/tests/json.be
+++ b/tests/json.be
@@ -80,3 +80,16 @@ class map2 : map def init() super(self).init() end end
 var m = map2()
 m['key'] = 1
 assert_dump(m, '{"key":1}')
+
+# sweep dumping nested arrays of diffrent sizes
+# this tests for any unexpanded stack conditions
+for count : 10..200
+    var arr = [[]]
+    var last_arr = arr
+    for i : 0..count
+        var pushed = [i]
+        last_arr.push(pushed)
+        last_arr = pushed
+    end
+    json.dump(arr)
+end

--- a/tests/json_test_stack_size.be
+++ b/tests/json_test_stack_size.be
@@ -1,0 +1,11 @@
+import json
+
+# this test must be in a separate file, so that the stack is not expanded yet by other tests
+
+arr = "{"
+for i : 0..1000
+    arr += '"k' + str(i) + '": "v' + str(i) + '",'
+end
+arr += "}"
+
+json.load(arr)


### PR DESCRIPTION
Another PR in my quest to fixup JSON in berry :P

When in a native function the stack needs to be expanded manually, this is especially important when working in loops over objects and arrays. This should get rid of most mysterious crashes when parsing or dumping JSON. They were especially annoying because they would happen or not depending on whether you did some stuff which expanded the stack before handling JSON (for example printing the value before serializing it will usually help :)).

Also added tests for these conditions, which caused crashes.