### PR TITLE
Add native function to test for list or map

### DIFF
--- a/src/be_api.c
+++ b/src/be_api.c
@@ -208,6 +208,31 @@ BERRY_API bbool be_isinstance(bvm *vm, int index)
     return var_isinstance(v);
 }
 
+static bbool be_isinstanceofbuiltin(bvm *vm, int rel_index, const char *classname)
+{
+    bbool ret = bfalse;
+    int index = be_absindex(vm, rel_index);
+    if (be_isinstance(vm, index)) {
+        be_getbuiltin(vm, classname);
+        if (be_isderived(vm, index)) {
+            ret = btrue;
+        }
+        be_pop(vm, 1);
+    }
+    return ret;
+}
+
+BERRY_API bbool be_ismapinstance(bvm *vm, int index)
+{
+    return be_isinstanceofbuiltin(vm, index, "map");
+}
+
+BERRY_API bbool be_islistinstance(bvm *vm, int index)
+{
+    return be_isinstanceofbuiltin(vm, index, "list");
+}
+
+
 BERRY_API bbool be_ismodule(bvm *vm, int index)
 {
     bvalue *v = be_indexof(vm, index);

--- a/src/berry.h
+++ b/src/berry.h
@@ -1070,6 +1070,34 @@ BERRY_API bbool be_isclass(bvm *vm, int index);
 BERRY_API bbool be_isinstance(bvm *vm, int index);
 
 /**
+ * @fn bool be_ismapinstance(bvm*, int)
+ * @note FFI function
+ * @brief value in virtual stack is instance
+ *
+ * This function returns whether the value indexed by the parameter index in the virtual stack is
+ * an instance of class map (or derived). If it is, it returns 1, otherwise it returns 0
+ *
+ * @param vm virtual machine instance virtual machine instance
+ * @param index value index
+ * @return true/false
+ */
+BERRY_API bbool be_ismapinstance(bvm *vm, int index);
+
+/**
+ * @fn bool be_ismapinstance(bvm*, int)
+ * @note FFI function
+ * @brief value in virtual stack is instance
+ *
+ * This function returns whether the value indexed by the parameter index in the virtual stack is
+ * an instance of class list (or derived). If it is, it returns 1, otherwise it returns 0
+ *
+ * @param vm virtual machine instance virtual machine instance
+ * @param index value index
+ * @return true/false
+ */
+BERRY_API bbool be_islistinstance(bvm *vm, int index);
+
+/**
  * @fn bool be_ismodule(bvm*, int)
  * @note FFI function
  * @brief value in virtual stack is module


### PR DESCRIPTION
Add simplified native C function to test if a parameter is of type `list` or `map:
- `bbool be_ismapinstance(bvm *vm, int index)`
- `bbool be_islistinstance(bvm *vm, int index)`