### PR TITLE
Add `introspect.name()`

### DIFF
--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -188,6 +188,31 @@ static int m_ismethod(bvm *vm)
     be_return_nil(vm);
 }
 
+static int m_name(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        const char* name = NULL;
+        switch (var_type(v)) {
+            case BE_CLOSURE:
+                name = str(((bclosure*) var_toobj(v))->proto->name);
+                break;
+            case BE_CLASS:
+                name = str(((bclass*) var_toobj(v))->name);
+                break;
+            case BE_MODULE:
+                name = be_module_name(var_toobj(v));
+                break;
+        }
+        if (name) {
+            be_pushstring(vm, name);
+            be_return(vm);
+        }
+    }
+    be_return_nil(vm);
+}
+
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(introspect) {
     be_native_module_function("members", m_attrlist),
@@ -200,6 +225,8 @@ be_native_module_attr_table(introspect) {
 
     be_native_module_function("toptr", m_toptr),
     be_native_module_function("fromptr", m_fromptr),
+
+    be_native_module_function("name", m_name),
 
     be_native_module_function("ismethod", m_ismethod),
 };
@@ -218,6 +245,8 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     toptr, func(m_toptr)
     fromptr, func(m_fromptr)
+
+    name, func(m_name)
 
     ismethod, func(m_ismethod)
 }

--- a/tests/introspect.be
+++ b/tests/introspect.be
@@ -31,3 +31,14 @@ assert(a.a == 3)
 import introspect
 m = introspect.module("math") # load module `math`, assign to `m` and don't create a global variable
 assert(type(m.pi) == 'real')
+
+#- name -#
+import string
+assert(introspect.name(string) == 'string')
+assert(introspect.name(print) == nil)       # native C function don't have a registered name
+assert(introspect.name("foo") == nil)
+class A def a() end static def b() end static var c end
+assert(introspect.name(A) == 'A')
+assert(introspect.name(A.a) == 'a')
+assert(introspect.name(A.b) == 'b')
+assert(introspect.name(A.c) == nil)


### PR DESCRIPTION
Add `introspect.name(any) -> string or nil` to retrieve the name of a `class`, `method` or `module`. If no name can be retrieved (ex: native C function), it returns `nil`.