### PR TITLE
ESP32 fix IRAM

### DIFF
--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -109,25 +109,54 @@
     } \
     return res
 
-#define relop_rule(op) \
-    bbool res; \
-    if (var_isint(a) && var_isint(b)) { \
-        res = ibinop(op, a, b); \
-    } else if (var_isnumber(a) && var_isnumber(b)) { \
-        res = var2real(a) op var2real(b); \
-    } else if (var_isstr(a) && var_isstr(b)) { \
-        bstring *s1 = var_tostr(a), *s2 = var_tostr(b); \
-        res = be_strcmp(s1, s2) op 0; \
-    } else if (var_isinstance(a)) { \
-        binstance *obj = var_toobj(a); \
-        object_binop(vm, #op, *a, *b); \
-        check_bool(vm, obj, #op); \
-        res = var_tobool(vm->top); \
-    } else { \
-        binop_error(vm, #op, a, b); \
-        res = bfalse; /* will not be executed */ \
-    } \
-    return res
+/* when running on ESP32 in IRAM, there is a bug in early chip revision */
+#ifdef ESP32
+    #define relop_rule(op) \
+        bbool res; \
+        if (var_isint(a) && var_isint(b)) { \
+            res = ibinop(op, a, b); \
+        } else if (var_isnumber(a) && var_isnumber(b)) { \
+            /* res = var2real(a) op var2real(b); */ \
+            union bvaldata x, y;        /* TASMOTA workaround for ESP32 rev0 bug */ \
+            x.i = a->v.i;\
+            if (var_isint(a)) { x.r = (breal) x.i; }\
+            y.i = b->v.i;\
+            if (var_isint(b)) { y.r = (breal) y.i; }\
+            res = x.r op y.r; \
+        } else if (var_isstr(a) && var_isstr(b)) { \
+            bstring *s1 = var_tostr(a), *s2 = var_tostr(b); \
+            res = be_strcmp(s1, s2) op 0; \
+        } else if (var_isinstance(a)) { \
+            binstance *obj = var_toobj(a); \
+            object_binop(vm, #op, *a, *b); \
+            check_bool(vm, obj, #op); \
+            res = var_tobool(vm->top); \
+        } else { \
+            binop_error(vm, #op, a, b); \
+            res = bfalse; /* will not be executed */ \
+        } \
+        return res
+#else  // ESP32
+    #define relop_rule(op) \
+        bbool res; \
+        if (var_isint(a) && var_isint(b)) { \
+            res = ibinop(op, a, b); \
+        } else if (var_isnumber(a) && var_isnumber(b)) { \
+            res = var2real(a) op var2real(b); \
+        } else if (var_isstr(a) && var_isstr(b)) { \
+            bstring *s1 = var_tostr(a), *s2 = var_tostr(b); \
+            res = be_strcmp(s1, s2) op 0; \
+        } else if (var_isinstance(a)) { \
+            binstance *obj = var_toobj(a); \
+            object_binop(vm, #op, *a, *b); \
+            check_bool(vm, obj, #op); \
+            res = var_tobool(vm->top); \
+        } else { \
+            binop_error(vm, #op, a, b); \
+            res = bfalse; /* will not be executed */ \
+        } \
+        return res
+#endif // ESP32
 
 #define bitwise_block(op) \
     bvalue *dst = RA(), *a = RKB(), *b = RKC(); \
@@ -607,8 +636,17 @@ newframe: /* a new call frame */
             if (var_isint(a) && var_isint(b)) {
                 var_setint(dst, ibinop(+, a, b));
             } else if (var_isnumber(a) && var_isnumber(b)) {
+#ifdef ESP32    /* when running on ESP32 in IRAM, there is a bug in early chip revision */
+                union bvaldata x, y;        // TASMOTA workaround for ESP32 rev0 bug
+                x.i = a->v.i;
+                if (var_isint(a)) { x.r = (breal) x.i; }
+                y.i = b->v.i;
+                if (var_isint(b)) { y.r = (breal) y.i; }
+                var_setreal(dst, x.r + y.r);
+#else  // ESP32
                 breal x = var2real(a), y = var2real(b);
                 var_setreal(dst, x + y);
+#endif // ESP32
             } else if (var_isstr(a) && var_isstr(b)) { /* strcat */
                 bstring *s = be_strcat(vm, var_tostr(a), var_tostr(b));
                 reg = vm->reg;


### PR DESCRIPTION
Fix for a silicon bug in early revision of ESP32 chips when running from IRAM. Loading directly float from IRAM is considered as a memory alignment violation although the read is 32 bits aligned. In such case, we load first as 32 bits int and cast as 32 bits float from a register.