### PR TITLE
Add static class and _class argument

### DIFF
--- a/src/be_bytecode.c
+++ b/src/be_bytecode.c
@@ -160,17 +160,19 @@ static bstring** save_members(bvm *vm, void *fp, bclass *c, int nvar)
 static void save_class(bvm *vm, void *fp, bclass *c)
 {
     bstring **vars;
-    int i, count = be_map_count(c->members);
+    int i, count = c->members ? be_map_count(c->members) : 0;
     int nvar = c->nvar - be_class_closure_count(c);
     save_string(fp, c->name);
     save_long(fp, nvar); /* member variables count */
     save_long(fp, count - nvar); /* method count */
-    vars = save_members(vm, fp, c, nvar);
-    if (vars != NULL) {
-        for (i = 0; i < nvar; ++i) {
-            save_string(fp, vars[i]);
+    if (count > 0) {
+        vars = save_members(vm, fp, c, nvar);
+        if (vars != NULL) {
+            for (i = 0; i < nvar; ++i) {
+                save_string(fp, vars[i]);
+            }
+            be_free(vm, vars, sizeof(bstring *) * nvar);
         }
-        be_free(vm, vars, sizeof(bstring *) * nvar);
     }
 }
 
@@ -206,7 +208,15 @@ static void save_constants(bvm *vm, void *fp, bproto *proto)
     bvalue *v = proto->ktab, *end;
     save_long(fp, proto->nconst); /* constants count */
     for (end = v + proto->nconst; v < end; ++v) {
-        save_value(vm, fp, v);
+        if ((v == proto->ktab) && (proto->varg & BE_VA_STATICMETHOD) && (v->type == BE_CLASS)) {
+            /* implicit `_class` parameter, output nil */
+            bvalue v_nil;
+            v_nil.v.i = 0;
+            v_nil.type = BE_NIL;
+            save_value(vm, fp, &v_nil);
+        } else {
+            save_value(vm, fp, v);
+        }
     }
 }
 
@@ -428,7 +438,15 @@ static void load_class(bvm *vm, void *fp, bvalue *v, int version)
         be_incrtop(vm);
         if (load_proto(vm, fp, (bproto**)&var_toobj(value), -3, version)) {
             /* actual method */
-            bbool is_method = ((bproto*)var_toobj(value))->varg & BE_VA_METHOD;
+            bproto *proto = (bproto*)var_toobj(value);
+            bbool is_method = proto->varg & BE_VA_METHOD;
+            if (!is_method) {
+                if ((proto->nconst > 0) && (proto->ktab->type == BE_NIL)) {
+                    /* The first argument is nil so we replace with the class as implicit '_class' */
+                    proto->ktab->type = BE_CLASS;
+                    proto->ktab->v.p = c;
+                }
+            }
             be_class_method_bind(vm, c, name, var_toobj(value), !is_method);
         } else {
             /* no proto, static member set to nil */

--- a/src/be_code.c
+++ b/src/be_code.c
@@ -927,4 +927,14 @@ void be_code_raise(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2)
     free_expreg(finfo, e2);
 }
 
+void be_code_implicit_class(bfuncinfo *finfo, bexpdesc *e, bclass *c)
+{
+    bvalue k;
+    k.type = BE_CLASS;
+    k.v.p = c;
+    int idx = newconst(finfo, &k);  /* create new constant */
+    e->type = ETCONST;  /* new type is constant by index */
+    e->v.idx = setK(idx);
+}
+
 #endif

--- a/src/be_code.h
+++ b/src/be_code.h
@@ -39,5 +39,6 @@ void be_code_import(bfuncinfo *finfo, bexpdesc *m, bexpdesc *v);
 int be_code_exblk(bfuncinfo *finfo, int depth);
 void be_code_catch(bfuncinfo *finfo, int base, int ecnt, int vcnt, int *jmp);
 void be_code_raise(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2);
+void be_code_implicit_class(bfuncinfo *finfo, bexpdesc *e, bclass *c);
 
 #endif

--- a/src/be_constobj.h
+++ b/src/be_constobj.h
@@ -422,7 +422,7 @@ const bvector _name = {                                         \
 }
 
 #define be_define_const_native_module(_module)                  \
-const bntvmodule be_native_module_##_module = {                 \
+const bntvmodule_t be_native_module_##_module = {               \
     #_module,                                                   \
     0, 0,                                                       \
     (bmodule*)&(m_lib##_module)                                 \

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -43,8 +43,9 @@
 #define func_clearstatic(o)    ((o)->type &= ~BE_STATIC)
 
 /* values for bproto.varg */
-#define BE_VA_VARARG    (1 << 0)    /* function has variable number of arguments */
-#define BE_VA_METHOD    (1 << 1)    /* function is a method (this is only a hint) */
+#define BE_VA_VARARG            (1 << 0)    /* function has variable number of arguments */
+#define BE_VA_METHOD            (1 << 1)    /* function is a method (this is only a hint) */
+#define BE_VA_STATICMETHOD      (1 << 2)    /* the function is a static method and has the class as implicit '_class' variable */
 #define array_count(a)   (sizeof(a) / sizeof((a)[0]))
 
 #define bcommon_header          \

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -29,6 +29,7 @@
 
 #define FUNC_METHOD             1
 #define FUNC_ANONYMOUS          2
+#define FUNC_STATIC             4
 
 #if BE_INTGER_TYPE == 0 /* int */
   #define M_IMAX    INT_MAX
@@ -399,7 +400,7 @@ static int new_localvar(bparser *parser, bstring *name)
     if (reg == -1) {
         bvalue *var;
         if (comp_is_strict(parser->vm)) {
-            if (find_localvar(finfo, name, 0) >= 0 && str(name)[0] != '.') {  /* we do accept nested redifinition of internal variables starting with ':' */
+            if (find_localvar(finfo, name, 0) >= 0 && str(name)[0] != '.') {  /* we do accept nested redefinition of internal variables starting with '.' */
                 push_error(parser, "strict: redefinition of '%s' from outer scope", str(name));
             }
         }
@@ -601,7 +602,7 @@ static void func_varlist(bparser *parser)
 /* Parse a function includind arg list and body */
 /* Given name and type (function or method) */
 /* Returns `bproto` object */
-static bproto* funcbody(bparser *parser, bstring *name, int type)
+static bproto* funcbody(bparser *parser, bstring *name, bclass *c, int type)
 {
     bfuncinfo finfo;
     bblockinfo binfo;
@@ -614,6 +615,14 @@ static bproto* funcbody(bparser *parser, bstring *name, int type)
         finfo.proto->varg |= BE_VA_METHOD;
     }
     func_varlist(parser); /* parse arg list */
+    if ((type & FUNC_STATIC) && (c != NULL)) { /* If static method, add an implicit local variable `_class` */
+        bexpdesc e1, e2;
+        new_var(parser, parser_newstr(parser, "_class"), &e1); /* new implicit variable '_class' */
+        init_exp(&e2, ETCONST, 0);
+        be_code_implicit_class(parser->finfo, &e2, c);
+        be_code_setvar(parser->finfo, &e1, &e2);
+        finfo.proto->varg |= BE_VA_STATICMETHOD;
+    }
     stmtlist(parser); /* parse statement without final `end` */
     end_func(parser); /* close function context */
     match_token(parser, KeyEnd); /* skip 'end' */
@@ -628,7 +637,7 @@ static void anon_func(bparser *parser, bexpdesc *e)
     bstring *name = parser_newstr(parser, "_anonymous_");
     /* 'def' ID '(' varlist ')' block 'end' */
     scan_next_token(parser); /* skip 'def' */
-    proto = funcbody(parser, name, FUNC_ANONYMOUS);
+    proto = funcbody(parser, name, NULL, FUNC_ANONYMOUS);
     init_exp(e, ETPROTO, be_code_proto(parser->finfo, proto));
     be_stackpop(parser->vm, 1);
 }
@@ -1364,7 +1373,7 @@ static void def_stmt(bparser *parser)
     bfuncinfo *finfo = parser->finfo;
     /* 'def' ID '(' varlist ')' block 'end' */
     scan_next_token(parser); /* skip 'def' */
-    proto = funcbody(parser, func_name(parser, &e, 0), 0);
+    proto = funcbody(parser, func_name(parser, &e, 0), NULL, 0);
     be_code_closure(finfo, &e, be_code_proto(finfo, proto));
     be_stackpop(parser->vm, 1);
 }
@@ -1436,10 +1445,12 @@ static void classdef_stmt(bparser *parser, bclass *c, bbool is_static)
     scan_next_token(parser); /* skip 'def' */
     name = func_name(parser, &e, 1);
     check_class_attr(parser, c, name);
-    proto = funcbody(parser, name, is_static ? 0 : FUNC_METHOD);
+    proto = funcbody(parser, name, c, is_static ? FUNC_STATIC : FUNC_METHOD);
     be_class_method_bind(parser->vm, c, proto->name, proto, is_static);
     be_stackpop(parser->vm, 1);
 }
+
+static void classstaticclass_stmt(bparser *parser, bclass *c_out, bexpdesc *e_out);
 
 static void classstatic_stmt(bparser *parser, bclass *c, bexpdesc *e)
 {
@@ -1449,6 +1460,8 @@ static void classstatic_stmt(bparser *parser, bclass *c, bexpdesc *e)
     scan_next_token(parser); /* skip 'static' */
     if (next_type(parser) == KeyDef) {  /* 'static' 'def' ... */
         classdef_stmt(parser, c, btrue);
+    } else if (next_type(parser) == KeyClass) {  /* 'static' 'class' ... */
+        classstaticclass_stmt(parser, c, e);
     } else {
         if (next_type(parser) == KeyVar) {
             scan_next_token(parser); /* skip 'var' if any */
@@ -1514,6 +1527,36 @@ static void class_stmt(bparser *parser)
         class_block(parser, c, &e);
         be_class_compress(parser->vm, c); /* compress class size */
         match_token(parser, KeyEnd); /* skip 'end' */
+    } else {
+        parser_error(parser, "class name error");
+    }
+}
+
+static void classstaticclass_stmt(bparser *parser, bclass *c_out, bexpdesc *e_out)
+{
+    bstring *name;
+    /* [preceding 'static'] 'class' ID [':' ID] class_block 'end' */
+    scan_next_token(parser); /* skip 'class' */
+    if (match_id(parser, name) != NULL) {
+        bexpdesc e_class;         /* new class object */
+        check_class_attr(parser, c_out, name);      /* check that the class names does not collide with another member */
+        be_class_member_bind(parser->vm, c_out, name, bfalse);  /* add the member slot as static */
+        /* create the class object */
+        bclass *c = be_newclass(parser->vm, name, NULL);
+        new_var(parser, name, &e_class);    /* add a local var to the static initialization code for static members */
+        be_code_class(parser->finfo, &e_class, c);
+        class_inherit(parser, &e_class);
+        class_block(parser, c, &e_class);
+        be_class_compress(parser->vm, c); /* compress class size */
+        match_token(parser, KeyEnd); /* skip 'end' */
+        /* add the code to copy the class object to the static member */
+        bexpdesc e1 = *e_out;        /* copy the class description */
+        bexpdesc key;   /* build the member key */
+        init_exp(&key, ETSTRING, 0);
+        key.v.s = name;
+        /* assign the class to the static member */
+        be_code_member(parser->finfo, &e1, &key);   /* compute member accessor */
+        be_code_setvar(parser->finfo, &e1, &e_class);    /* set member */
     } else {
         parser_error(parser, "class name error");
     }

--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -283,8 +283,12 @@ static void m_solidify_proto_inner_class(bvm *vm, bbool str_literal, bproto *pr,
     if (pr->nconst > 0) {
         for (int k = 0; k < pr->nconst; k++) {
             if (var_type(&pr->ktab[k]) == BE_CLASS) {
-                // output the class
-                m_solidify_subclass(vm, str_literal, (bclass*) var_toobj(&pr->ktab[k]), fout);
+                if ((k == 0) && (pr->varg & BE_VA_STATICMETHOD)) {
+                    // it is the implicit '_class' variable from a static method, don't dump the class
+                } else {
+                    // output the class
+                    m_solidify_subclass(vm, str_literal, (bclass*) var_toobj(&pr->ktab[k]), fout);
+                }
             }
         }
     }
@@ -416,6 +420,9 @@ static void m_solidify_closure(bvm *vm, bbool str_literal, bclosure *cl, const c
 static void m_solidify_subclass(bvm *vm, bbool str_literal, bclass *cl, void* fout)
 {
     const char * class_name = str(cl->name);
+
+    /* pre-declare class to support '_class' implicit variable */
+    logfmt("\nextern const bclass be_class_%s;\n", class_name);
 
     /* iterate on members to dump closures */
     if (cl->members) {

--- a/tests/class_static.be
+++ b/tests/class_static.be
@@ -120,3 +120,24 @@ assert(A.a == 1)
 assert(B.a == A)
 assert(B.b == 1)
 assert(B.c == A)
+
+#- static class get an implicit `_class` variable -#
+class A
+    static def f(x) return _class end
+end
+assert(A.f() == A)
+
+#- static class within a class -#
+class A
+    static class B
+        static def f() return 1 end
+        def g() return 2 end
+    end
+end
+a = A()
+b = A.B()
+assert(classname(a) == 'A')
+assert(classname(b) == 'B')
+assert(A.B.f() == 1)
+assert(b.g() == 2)
+assert(super(B) == nil)


### PR DESCRIPTION
Add an implicit `_class` variable whenever a static method (class method) is called. This allows to reference automatically the class since there is no `self`.

Example:
```berry
class my_class
  static def f(x)
    print(x)
    print(_class)        # `_class` contains a reference to the class object
  end
end

# output:
# > A.f(42)
# 42
# <class: my_class>
```

Add a `static class` construct to store private classes within classes. This allows classes to work similarly to modules and contain private classes.

```berry
class A
    static class B
        def f() return 1 end
    end
end

b = A.B()  # create an instance of B() although B is not in the global namespace
```