### PR TITLE
Protect `be_free(vm, NULL, ...)`

### DIFF
--- a/src/be_mem.c
+++ b/src/be_mem.c
@@ -66,6 +66,7 @@ BERRY_API void* be_realloc(bvm *vm, void *ptr, size_t old_size, size_t new_size)
     
         /* Case 2: deallocate */
         else if (new_size == 0) {
+            if (ptr == NULL) { return NULL;     }
 #if BE_USE_DEBUG_GC
             memset(ptr, 0xFF, old_size); /* fill the structure with invalid pointers */
 #endif


### PR DESCRIPTION
Protect memory against calling `be_free(vm, NULL, size)`. This call is not supposed to happen, but in case it does, the call does nothing and returns NULL.
See #338