### PR TITLE
Allow comments in multi-line strings

### DIFF
--- a/src/be_lexer.c
+++ b/src/be_lexer.c
@@ -394,7 +394,9 @@ static int skip_delimiter(blexer *lexer) {
     int c = lgetc(lexer);
     int delimeter_present = 0;
     while (1) {
-        if (c == '\r' || c == '\n') {
+        if (c == '#') {
+            skip_comment(lexer);
+        } else if (c == '\r' || c == '\n') {
             skip_newline(lexer);
         } else if (c == ' ' || c == '\t' || c == '\f' || c ==  '\v') {
             next(lexer);

--- a/tests/string.be
+++ b/tests/string.be
@@ -88,3 +88,25 @@ assert(string.replace("hellollo", "aa", "xx") == "hellollo")
 assert(string.replace("hello", "ll", "") == "heo")
 assert(string.replace("hello", "", "xx") == "hello")
 assert(string.replace("hello", "", "") == "hello")
+
+# multi-line strings
+var s = "a" "b""c"
+assert(s == 'abc')
+
+s = 'a'"b"'''c'
+assert(s == 'abc')
+
+s = "a"
+'b'
+    ""
+    "c"
+assert(s == 'abc')
+
+s = "a" #- b -# "b"  #--# "c"
+assert(s == 'abc')
+
+s = "a"#
+    # "z"
+    "b"  # zz
+    "c"
+assert(s == 'abc')


### PR DESCRIPTION
Allow multi-line strings to have comments:

```berry
var s = "a"   # comment
        "b"  #- comment -# "c"

print(s)
#shows 'abc'
```