### PR TITLE
string.format automatic conversion

### DIFF
--- a/tests/string.be
+++ b/tests/string.be
@@ -110,3 +110,40 @@ s = "a"#
     "b"  # zz
     "c"
 assert(s == 'abc')
+
+# string.format with automatic conversion
+import string
+
+assert(string.format("%i", 3) == '3')
+assert(string.format("%i", "3") == '3')
+assert(string.format("%i", "03") == '3')
+assert(string.format("%i", nil) == '')
+
+class A def toint() return 42 end end
+a=A()
+class B end
+b=B()
+
+assert(string.format("%i", a) == '42')
+assert(string.format("%i", b) == '')
+
+assert(string.format("%i", nil) == '')
+assert(string.format("%i", true) == '1')
+assert(string.format("%i", false) == '0')
+
+assert(string.format("%c", a) == '*')
+
+assert(string.format("%f", 3.5) == '3.500000')
+assert(string.format("%f", 3) == '3.000000')
+assert(string.format("%.1f", 3) == '3.0')
+assert(string.format("%.1f", nil) == '')
+assert(string.format("%.1f", true) == '')
+assert(string.format("%.1f", false) == '')
+assert(string.format("%.1f", a) == '')
+
+assert(string.format("%s", a) == '<instance: A()>')
+assert(string.format("%s", 0) == '0')
+assert(string.format("%s", nil) == 'nil')
+assert(string.format("%s", true) == 'true')
+assert(string.format("%s", false) == 'false')
+


### PR DESCRIPTION
`string.format()` now automatically tries to convert to int/real/string according to the format:
- if `%d/i/o/u/x/X/c`, an explicit call to `int()` is made to convert to int
- if `%e/E/f/g/G`, an explicit call to `real()` is made
- if `%s` an explicit call to `str()` is made

```berry
# Example:

string.format("%i", "3")  # now return '3' instead of ''
```