### PR TITLE
`bool( [] )` and `bool( {} )` now evaluate as `false`

### DIFF
--- a/src/be_listlib.c
+++ b/src/be_listlib.c
@@ -262,6 +262,14 @@ static int m_size(bvm *vm)
     be_return(vm);
 }
 
+static int m_tobool(bvm *vm)
+{
+    be_getmember(vm, 1, ".p");
+    list_check_data(vm, 1);
+    be_pushbool(vm, be_data_size(vm, -1) > 0);
+    be_return(vm);
+}
+
 static int m_resize(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
@@ -507,6 +515,7 @@ void be_load_listlib(bvm *vm)
         { "reverse", m_reverse },
         { "copy", m_copy },
         { "keys", m_keys },
+        { "tobool", m_tobool }
         { "..", m_connect },
         { "+", m_merge },
         { "==", m_equal },
@@ -536,6 +545,7 @@ class be_class_list (scope: global, name: list) {
     reverse, func(m_reverse)
     copy, func(m_copy)
     keys, func(m_keys)
+    tobool, func(m_tobool)
     .., func(m_connect)
     +, func(m_merge)
     ==, func(m_equal)

--- a/src/be_maplib.c
+++ b/src/be_maplib.c
@@ -150,6 +150,14 @@ static int m_size(bvm *vm)
     be_return(vm);
 }
 
+static int m_tobool(bvm *vm)
+{
+    be_getmember(vm, 1, ".p");
+    map_check_data(vm, 1);
+    be_pushbool(vm, be_data_size(vm, -1) > 0);
+    be_return(vm);
+}
+
 static int iter_closure(bvm *vm)
 {
     /* for better performance, we operate the upvalues
@@ -228,6 +236,7 @@ void be_load_maplib(bvm *vm)
         { "insert", m_insert },
         { "iter", m_iter },
         { "keys", m_keys },
+        { "tobool", m_tobool }
         { NULL, NULL }
     };
     be_regclass(vm, "map", members);
@@ -247,6 +256,7 @@ class be_class_map (scope: global, name: map) {
     insert, func(m_insert)
     iter, func(m_iter)
     keys, func(m_keys)
+    tobool, func(m_tobool)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_be_class_map.h"

--- a/tests/bool.be
+++ b/tests/bool.be
@@ -36,7 +36,13 @@ assert(bool(3.5) == true)
 assert(bool('') == false)       # changed behavior
 assert(bool('a') == true)
 assert(bool(list) == true)
-assert(bool(list()) == true)
+assert(bool(list()) == false)   # changed behavior
+assert(bool([]) == false)       # changed behavior
+assert(bool([0]) == true)
+assert(bool(map()) == false)    # changed behavior
+assert(bool({}) == false)       # changed behavior
+assert(bool({false:false}) == true)
+assert(bool({nil:nil}) == false)# changed behavior - `nil` key is ignored so the map is empty
 
 import introspect
 assert(bool(introspect.toptr(0x1000)) == true)


### PR DESCRIPTION
**Breaking change** (although impact is minimalistic)

Change how list() and map() evaluate as bool. They used to always evaluate as true. Now [] and {} evaluate as false when converted to boolean.