### PR TITLE
Make source file optional

### DIFF
--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -51,6 +51,14 @@
  **/
 #define BE_USE_PRECOMPILED_OBJECT       1
 
+/* Macro: BE_DEBUG_SOURCE_FILE
+ * Indicate if each function remembers its source file name
+ * 0: do not keep the file name (saves 4 bytes per function)
+ * 1: keep the source file name
+ * Default: 1
+ **/
+#define BE_DEBUG_SOURCE_FILE            1
+
 /* Macro: BE_DEBUG_RUNTIME_INFO
  * Set runtime error debugging information.
  * 0: unable to output source file and line number at runtime.
@@ -168,7 +176,7 @@
  * Berry debug hook switch.
  * Default: 0
  **/
-#define BE_USE_DEBUG_HOOK               1
+#define BE_USE_DEBUG_HOOK               0
 
 /* Macro: BE_USE_DEBUG_GC
  * Enable GC debug mode. This causes an actual gc after each

--- a/src/be_bytecode.c
+++ b/src/be_bytecode.c
@@ -114,6 +114,8 @@ static void save_string(void *fp, bstring *s)
         const char *data = str(s);
         save_word(fp, length);
         be_fwrite(fp, data, length);
+    } else {
+        save_word(fp, 0);
     }
 }
 
@@ -247,7 +249,11 @@ static void save_proto(bvm *vm, void *fp, bproto *proto)
 {
     if (proto) {
         save_string(fp, proto->name); /* name */
+#if BE_DEBUG_SOURCE_FILE
         save_string(fp, proto->source); /* source */
+#else
+        save_string(fp, NULL); /* source */
+#endif
         save_byte(fp, proto->argc); /* argc */
         save_byte(fp, proto->nstack); /* nstack */
         save_byte(fp, proto->varg); /* varg */
@@ -551,7 +557,11 @@ static bbool load_proto(bvm *vm, void *fp, bproto **proto, int info, int version
     if (str_len(name)) {
         *proto = be_newproto(vm);
         (*proto)->name = name;
+#if BE_DEBUG_SOURCE_FILE
         (*proto)->source = load_string(vm, fp);
+#else
+        load_string(vm, fp);    /* discard name */
+#endif
         (*proto)->argc = load_byte(fp);
         (*proto)->nstack = load_byte(fp);
         if (version > 1) {

--- a/src/be_debug.c
+++ b/src/be_debug.c
@@ -156,7 +156,9 @@ void be_dumpclosure(bclosure *cl)
 #if BE_DEBUG_RUNTIME_INFO
     blineinfo *lineinfo = proto->lineinfo;
 #endif
+#if BE_DEBUG_SOURCE_FILE
     logfmt("source '%s', ", str(proto->source));
+#endif
     logfmt("function '%s':\n", str(proto->name));
 #if BE_DEBUG_RUNTIME_INFO
     if (lineinfo) { /* first line */
@@ -184,8 +186,10 @@ static void sourceinfo(bproto *proto, binstruction *ip)
         blineinfo *end = it + proto->nlineinfo;
         int pc = cast_int(ip - proto->code - 1); /* now vm->ip has been increased */
         for (; it < end && pc > it->endpc; ++it);
-        sprintf(buf, ":%d:", it->linenumber);
+        snprintf(buf, sizeof(buf), ":%d:", it->linenumber);
+#if BE_DEBUG_SOURCE_FILE
         be_writestring(str(proto->source));
+#endif
         be_writestring(buf);
     } else {
         be_writestring("<unknown source>:");
@@ -262,7 +266,9 @@ static void hook_callnative(bvm *vm, int mask)
     be_stack_require(vm, BE_STACK_FREE_MIN + 2);
     info.type = mask;
     info.line = cf->lineinfo->linenumber;
+#if BE_DEBUG_SOURCE_FILE
     info.source = str(cl->proto->source);
+#endif
     info.func_name = str(cl->proto->name);
     info.data = hb->data;
     hb->hook(vm, &info);

--- a/src/be_func.c
+++ b/src/be_func.c
@@ -108,7 +108,9 @@ bproto* be_newproto(bvm *vm)
         p->codesize = 0;
         p->argc = 0;
         p->varg = 0;
+#if BE_DEBUG_SOURCE_FILE
         p->source = NULL;
+#endif
 #if BE_DEBUG_RUNTIME_INFO
         p->lineinfo = NULL;
         p->nlineinfo = 0;

--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -231,7 +231,9 @@ static void mark_proto(bvm *vm, bgcobject *obj)
             mark_gray(vm, gc_object(*ptab));
         }
         gc_setdark_safe(p->name);
+#if BE_DEBUG_SOURCE_FILE
         gc_setdark_safe(p->source);
+#endif
 #if BE_DEBUG_VAR_INFO
         if (p->nvarinfo) {
             bvarinfo *vinfo = p->varinfo;

--- a/src/be_module.c
+++ b/src/be_module.c
@@ -126,6 +126,7 @@ static char* fixpath(bvm *vm, bstring *path, size_t *size)
 {
     char *buffer;
     const char *split, *base;
+#if BE_DEBUG_SOURCE_FILE
     bvalue *func = vm->cf->func;
     bclosure *cl = var_toobj(func);
     if (var_isclosure(func)) {
@@ -133,6 +134,9 @@ static char* fixpath(bvm *vm, bstring *path, size_t *size)
     } else {
         base = "/";
     }
+#else
+    base = "/";
+#endif
     split = be_splitpath(base);
     *size = split - base + (size_t)str_len(path) + SUFFIX_LEN;
     buffer = be_malloc(vm, *size);

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -160,7 +160,9 @@ typedef struct bproto {
     int codesize; /* code size */
     int nconst; /* constants count */
     int nproto; /* proto count */
+#if BE_DEBUG_SOURCE_FILE
     bstring *source; /* source file name */
+#endif
 #if BE_DEBUG_RUNTIME_INFO /* debug information */
     blineinfo *lineinfo;
     int nlineinfo;

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -224,6 +224,7 @@ static void end_block(bparser *parser)
     end_block_ex(parser, -1);
 }
 
+#if BE_DEBUG_SOURCE_FILE
 /* Return the name of the source for this parser, could be `string`,
    `stdin` or the name of the current function */
 static bstring* parser_source(bparser *parser)
@@ -233,6 +234,7 @@ static bstring* parser_source(bparser *parser)
     }
     return be_newstr(parser->vm, parser->lexer.fname);
 }
+#endif
 
 /* Initialize a function block and create a new `bprotoˋ */
 static void begin_func(bparser *parser, bfuncinfo *finfo, bblockinfo *binfo)
@@ -250,7 +252,9 @@ static void begin_func(bparser *parser, bfuncinfo *finfo, bblockinfo *binfo)
     be_vector_init(vm, &finfo->pvec, sizeof(bproto*)); /* vector for subprotos */
     proto->ptab = be_vector_data(&finfo->pvec);
     proto->nproto = be_vector_capacity(&finfo->pvec);
+#if BE_DEBUG_SOURCE_FILE
     proto->source = parser_source(parser); /* keep a copy of source for function */
+#endif
     finfo->local = be_list_new(vm); /* list for local variables */
     var_setlist(vm->top, finfo->local); /* push list of local variables on the stack (avoid gc) */
     be_stackpush(vm);

--- a/src/berry.h
+++ b/src/berry.h
@@ -478,14 +478,29 @@ typedef bclass_ptr bclass_array[];
 #endif
 
 /**
+ * @def BE_DEBUG_SOURCE_FILE
+ * @brief conditional block in bproto depending on compilation options
+ *
+ */
+#if BE_DEBUG_SOURCE_FILE
+  #define PROTO_SOURCE_FILE(n)   \
+    ((bstring*) n),                                         /**< source */
+  #define PROTO_SOURCE_FILE_STR(n)  \
+    be_local_const_str(n##_str_source),                     /**< source */
+#else
+  #define PROTO_SOURCE_FILE(n)
+  #define PROTO_SOURCE_FILE_STR(n)
+#endif
+
+/**
  * @def PROTO_RUNTIME_BLOCK
  * @brief conditional block in bproto depending on compilation options
  *
  */
 #if BE_DEBUG_RUNTIME_INFO
   #define PROTO_RUNTIME_BLOCK   \
-    NULL,     /**< varinfo */ \
-    0,        /**< nvarinfo */
+    NULL,     /**< lineinfo */ \
+    0,        /**< nlineinfo */
 #else
   #define PROTO_RUNTIME_BLOCK
 #endif
@@ -526,7 +541,7 @@ typedef bclass_ptr bclass_array[];
     sizeof(_name##_code)/sizeof(uint32_t),                            /**< codesize */             \
     BE_IIF(_is_const)(sizeof(_name##_ktab)/sizeof(bvalue),0),         /**< nconst */               \
     BE_IIF(_is_subproto)(sizeof(_name##_subproto)/sizeof(bproto*),0), /**< proto */                \
-    be_local_const_str(_name##_str_source),                           /**< source */               \
+    PROTO_SOURCE_FILE_STR(_name)                                      /**< source */               \
     PROTO_RUNTIME_BLOCK                                               /**< */                      \
     PROTO_VAR_INFO_BLOCK                                              /**< */                      \
   }
@@ -554,7 +569,7 @@ typedef bclass_ptr bclass_array[];
     sizeof(*_code)/sizeof(binstruction),                        /**< codesize */             \
     BE_IIF(_has_const)(sizeof(*_ktab)/sizeof(bvalue),0),        /**< nconst */               \
     BE_IIF(_has_subproto)(sizeof(*_protos)/sizeof(bproto*),0),  /**< proto */                \
-    ((bstring*) _source),                                       /**< source */               \
+    PROTO_SOURCE_FILE(_source)                                  /**< source */               \
     PROTO_RUNTIME_BLOCK                                         /**< */                      \
     PROTO_VAR_INFO_BLOCK                                        /**< */                      \
   }


### PR DESCRIPTION
Add `#define BE_DEBUG_SOURCE_FILE 1` selector to make source file name optional. Disabling source file in each function saves a lot of flash space for solidified code.