### PR TITLE
Reduce size of bproto

### DIFF
--- a/src/be_object.h
+++ b/src/be_object.h
@@ -151,15 +151,15 @@ typedef struct bproto {
     bbyte nupvals; /* upvalue count */
     bbyte argc; /* argument count */
     bbyte varg; /* variable argument position + 1 */
+    int16_t codesize; /* code size */
+    int16_t nconst; /* constants count */
+    int16_t nproto; /* proto count */
     bgcobject *gray; /* for gc gray list */
     bupvaldesc *upvals;
     bvalue *ktab; /* constants table */
     struct bproto **ptab; /* proto table */
     binstruction *code; /* instructions sequence */
     bstring *name; /* function name */
-    int codesize; /* code size */
-    int nconst; /* constants count */
-    int nproto; /* proto count */
 #if BE_DEBUG_SOURCE_FILE
     bstring *source; /* source file name */
 #endif

--- a/src/berry.h
+++ b/src/berry.h
@@ -532,15 +532,15 @@ typedef bclass_ptr bclass_array[];
     BE_IIF(_is_upval)(sizeof(_name##_upvals)/sizeof(bupvaldesc),0),   /**< nupvals */              \
     (_argc),                                                          /**< argc */                 \
     0,                                                                /**< varg */                 \
+    sizeof(_name##_code)/sizeof(uint32_t),                            /**< codesize */             \
+    BE_IIF(_is_const)(sizeof(_name##_ktab)/sizeof(bvalue),0),         /**< nconst */               \
+    BE_IIF(_is_subproto)(sizeof(_name##_subproto)/sizeof(bproto*),0), /**< proto */                \
     NULL,                                                             /**< bgcobject *gray */      \
     BE_IIF(_is_upval)((bupvaldesc*)&_name##_upvals,NULL),             /**< bupvaldesc *upvals */   \
     BE_IIF(_is_const)((bvalue*)&_name##_ktab,NULL),                   /**< ktab */                 \
     BE_IIF(_is_subproto)((struct bproto**)&_name##_subproto,NULL),    /**< bproto **ptab */        \
     (binstruction*) &_name##_code,                                    /**< code */                 \
     be_local_const_str(_name##_str_name),                             /**< name */                 \
-    sizeof(_name##_code)/sizeof(uint32_t),                            /**< codesize */             \
-    BE_IIF(_is_const)(sizeof(_name##_ktab)/sizeof(bvalue),0),         /**< nconst */               \
-    BE_IIF(_is_subproto)(sizeof(_name##_subproto)/sizeof(bproto*),0), /**< proto */                \
     PROTO_SOURCE_FILE_STR(_name)                                      /**< source */               \
     PROTO_RUNTIME_BLOCK                                               /**< */                      \
     PROTO_VAR_INFO_BLOCK                                              /**< */                      \
@@ -560,15 +560,15 @@ typedef bclass_ptr bclass_array[];
     BE_IIF(_has_upval)(sizeof(*_upvals)/sizeof(bupvaldesc),0),  /**< nupvals */              \
     (_argc),                                                    /**< argc */                 \
     (_varg),                                                    /**< varg */                 \
+    sizeof(*_code)/sizeof(binstruction),                        /**< codesize */             \
+    BE_IIF(_has_const)(sizeof(*_ktab)/sizeof(bvalue),0),        /**< nconst */               \
+    BE_IIF(_has_subproto)(sizeof(*_protos)/sizeof(bproto*),0),  /**< proto */                \
     NULL,                                                       /**< bgcobject *gray */      \
     (bupvaldesc*) _upvals,                                      /**< bupvaldesc *upvals */   \
     (bvalue*) _ktab,                                            /**< ktab */                 \
     (struct bproto**) _protos,                                  /**< bproto **ptab */        \
     (binstruction*) _code,                                      /**< code */                 \
     ((bstring*) _fname),                                        /**< name */                 \
-    sizeof(*_code)/sizeof(binstruction),                        /**< codesize */             \
-    BE_IIF(_has_const)(sizeof(*_ktab)/sizeof(bvalue),0),        /**< nconst */               \
-    BE_IIF(_has_subproto)(sizeof(*_protos)/sizeof(bproto*),0),  /**< proto */                \
     PROTO_SOURCE_FILE(_source)                                  /**< source */               \
     PROTO_RUNTIME_BLOCK                                         /**< */                      \
     PROTO_VAR_INFO_BLOCK                                        /**< */                      \


### PR DESCRIPTION
Reduce size of `bproto` in Flash: encode codesize, number of sub-protos and constants with 16 bits integers, and relocate to compact the structure.

Saves 8 bytes per function on 32 bits systems.