### PR TITLE
`format` is now global

### DIFF
--- a/src/be_baselib.c
+++ b/src/be_baselib.c
@@ -14,6 +14,7 @@
 #include "be_vector.h"
 #include "be_string.h"
 #include "be_map.h"
+#include "be_strlib.h"
 #include <string.h>
 
 #define READLINE_STEP       100
@@ -504,6 +505,7 @@ void be_load_baselib_next(bvm *vm)
 {
     be_regfunc(vm, "call", l_call);
     be_regfunc(vm, "bool", l_bool);
+    be_regfunc(vm, "format", be_str_format);
 }
 #else
 extern const bclass be_class_list;
@@ -537,6 +539,7 @@ vartab m_builtin (scope: local) {
     bytes, class(be_class_bytes)
     call, func(l_call)
     bool, func(l_bool)
+    format, func(be_str_format)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_m_builtin.h"

--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -601,7 +601,7 @@ static bbool convert_to_real(bvm *vm, int index, breal *val)
     return converted;
 }
 
-static int str_format(bvm *vm)
+int be_str_format(bvm *vm)
 {
     int top = be_top(vm);
     if (top > 0 && be_isstring(vm, 1)) {
@@ -942,7 +942,7 @@ static int str_escape(bvm *vm)
 
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(string) {
-    be_native_module_function("format", str_format),
+    be_native_module_function("format", be_str_format),
     be_native_module_function("count", str_count),
     be_native_module_function("split", str_split),
     be_native_module_function("find", str_find),
@@ -960,7 +960,7 @@ be_define_native_module(string, NULL);
 #else
 /* @const_object_info_begin
 module string (scope: global, depend: BE_USE_STRING_MODULE) {
-    format, func(str_format)
+    format, func(be_str_format)
     count, func(str_count)
     split, func(str_split)
     find, func(str_find)

--- a/src/be_strlib.h
+++ b/src/be_strlib.h
@@ -25,6 +25,7 @@ const char* be_splitpath(const char *path);
 const char* be_splitname(const char *path);
 const char* be_pushvfstr(bvm *vm, const char *format, va_list arg);
 bstring* be_strindex(bvm *vm, bstring *str, bvalue *idx);
+int be_str_format(bvm *vm);
 
 #ifdef __cplusplus
 }

--- a/tests/string.be
+++ b/tests/string.be
@@ -147,3 +147,6 @@ assert(string.format("%s", nil) == 'nil')
 assert(string.format("%s", true) == 'true')
 assert(string.format("%s", false) == 'false')
 
+# format is now synonym to string.format
+assert(format == string.format)
+assert(format("%.1f", 3) == '3.0')


### PR DESCRIPTION
`string.format` is used so often that it is now accessible directly as a global `format`. This saves a lot of flash space in Tasmota matter.

```
> format("i = %i", 42)
'i = 42'
```