### PR TITLE
Add walrus operator `:=` to extend an assigment as an expression

### DIFF
--- a/src/be_lexer.c
+++ b/src/be_lexer.c
@@ -752,7 +752,9 @@ static btokentype lexer_next(blexer *lexer)
         case '}': next(lexer); return OptRBR;
         case ',': next(lexer); return OptComma;
         case ';': next(lexer); return OptSemic;
-        case ':': next(lexer); return OptColon;
+        case ':':
+            next(lexer);
+            return check_next(lexer, '=') ? OptWalrus : OptColon;
         case '?': next(lexer); return OptQuestion;
         case '^': return scan_assign(lexer, OptXorAssign, OptBitXor);
         case '~': next(lexer); return OptFlip;

--- a/src/be_lexer.h
+++ b/src/be_lexer.h
@@ -89,7 +89,9 @@ typedef enum {
     KeyTry,         /* keyword try */
     KeyExcept,      /* keyword except */
     KeyRaise,       /* keyword raise */
-    KeyStatic       /* keyword static */
+    KeyStatic,      /* keyword static */
+    /* Walrus operator */
+    OptWalrus,      /* operator, := */
 } btokentype;
 
 struct blexerreader {

--- a/src/be_parser.h
+++ b/src/be_parser.h
@@ -53,6 +53,7 @@ typedef struct bblockinfo {
     bbyte nactlocals; /* number of active local variables */
     bbyte type;       /* block type mask */
     bbyte hasupval;   /* has upvalue mark */
+    bbyte sideeffect; /* did the last expr/statement had a side effect */ 
     int breaklist;    /* break list */
     int beginpc;      /* begin pc */
     int continuelist; /* continue list */

--- a/tests/walrus.be
+++ b/tests/walrus.be
@@ -1,0 +1,35 @@
+# test for the walrus operator
+var a = 1
+assert((a := a + 1) == 2)
+assert((a := a + 1) == 3)
+
+def f()
+    var defer = 10
+    var ret = []
+    for i:0..100
+        if (defer := defer - 1) == 0
+            ret.push(i)
+            defer = 10
+        end
+    end
+    return ret
+end
+assert(f() == [9, 19, 29, 39, 49, 59, 69, 79, 89, 99])
+
+# test for expressions with no side effects
+def assert_attribute_error(c)
+  try
+      compile(c)()
+      assert(false, 'unexpected execution flow')
+  except 'syntax_error' as e, m
+  end
+end
+
+# below the expressions `a` or `a b` have no side effect and do not generate any code, this is an error when in strict mode
+import strict
+var a, b
+assert_attribute_error("var a,b def f() a b end")
+assert_attribute_error("var a,b def f() a end")
+
+# while the following does have side effect
+def f() a := b end


### PR DESCRIPTION
Add Berry Walrus operator, similar to Python3. This operator ':=' allows to do an assignment from within an expression:

```berry
[...]
    var sz
    if (sz := size(self.my_list)) > 0
        print(f"list size = {sz}")
    end
[...]
```

The parser is improved tests to detect if there are expressions without any side effects. When in `import strict` strict mode, expressions without side effects are considered as errors because they are very likely to be errors:

```berry
> var a, b
> import strict
> def f() a end       # the expression `a` has no effect and generates no code
syntax_error: stdin:1: strict: expression without side effect detected

> def f() print(a) a end
syntax_error: stdin:1: strict: expression without side effect detected

> def f() a := b end   # this is valid because `a := b` has some side effect, although `a = b` would be better here
> 
```