### PR TITLE
Use 32 bits mem-aligned memory (ESP32)

### DIFF
--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -194,6 +194,14 @@
  **/
 #define BE_USE_DEBUG_STACK               0
 
+/* Macro: BE_USE_MEM_ALIGNED
+ * Some embedded processors have special memory areas
+ * with read/write constraints of being aligned to 32 bits boundaries.
+ * This options tries to move such memory areas to this region.
+ * Default: 0
+ **/
+#define BE_USE_MEM_ALIGNED               0
+
 /* Macro: BE_USE_XXX_MODULE
  * These macros control whether the related module is compiled.
  * When they are true, they will enable related modules. At this

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -325,10 +325,17 @@ static void end_func(bparser *parser)
     proto->nconst = be_vector_count(&finfo->kvec);
     proto->ptab = be_vector_release(vm, &finfo->pvec);
     proto->nproto = be_vector_count(&finfo->pvec);
+#if BE_USE_MEM_ALIGNED
+    proto->code = be_move_to_aligned(vm, proto->code, proto->codesize * sizeof(binstruction));     /* move `code` to 4-bytes aligned memory region */
+    proto->ktab = be_move_to_aligned(vm, proto->ktab, proto->nconst * sizeof(bvalue));     /* move `ktab` to 4-bytes aligned memory region */
+#endif /* BE_USE_MEM_ALIGNED */
 #if BE_DEBUG_RUNTIME_INFO
-    proto->lineinfo = be_vector_release(vm, &finfo->linevec);
+    proto->lineinfo = be_vector_release(vm, &finfo->linevec);     /* move `lineinfo` to 4-bytes aligned memory region */
     proto->nlineinfo = be_vector_count(&finfo->linevec);
-#endif
+#if BE_USE_MEM_ALIGNED
+    proto->lineinfo = be_move_to_aligned(vm, proto->lineinfo, proto->nlineinfo * sizeof(blineinfo));
+#endif /* BE_USE_MEM_ALIGNED */
+#endif /* BE_DEBUG_RUNTIME_INFO */
 #if BE_DEBUG_VAR_INFO
     proto->varinfo = be_vector_release(vm, &finfo->varvec);
     proto->nvarinfo = be_vector_count(&finfo->varvec);


### PR DESCRIPTION
ESP32 has some spare IRAM memory with the constraint of accepting only 32-bits aligned access.

Option `#define BE_USE_MEM_ALIGNED 1` tries to move "code" section and "constants" sections to such memory if it is available, or use normal memory.

This feature allows to use spare ~40Kb of memory in Tasmota.