### PR TITLE
Fix compilation of GETIDX

### DIFF
--- a/src/be_code.c
+++ b/src/be_code.c
@@ -358,7 +358,7 @@ static int suffix_destreg(bfuncinfo *finfo, bexpdesc *e1, int dst, bbool no_reg_
         /* both are ETREG, we keep the lowest and discard the other */
         if (reg1 != reg2) {
             cand_dst = min(reg1, reg2);
-            be_code_freeregs(finfo, 1);  /* and free the other one */
+            be_code_freeregs(finfo, finfo->freereg - cand_dst);  /* and free the other one */
         } else {
             cand_dst = reg1;  /* both ETREG are equal, we return its value */
         }
@@ -726,8 +726,8 @@ int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg)
 /* if local or const, allocate a new register and copy value */
 int be_code_nextreg(bfuncinfo *finfo, bexpdesc *e)
 {
-    int dst = finfo->freereg;
     int src = exp2anyreg(finfo, e); /* get variable register index */
+    int dst = finfo->freereg;
     if ((e->type != ETREG) || (src < dst - 1)) { /* move local and const to new register, don't move if already top of stack */
         code_move(finfo, dst, src);
         be_code_allocregs(finfo, 1);
@@ -832,8 +832,8 @@ void be_code_ret(bfuncinfo *finfo, bexpdesc *e)
 /* Both expdesc are materialized in kregs */
 static void package_suffix(bfuncinfo *finfo, bexpdesc *c, bexpdesc *k)
 {
-    int key = exp2anyreg(finfo, k);
     c->v.ss.obj = exp2anyreg(finfo, c);
+    int key = exp2anyreg(finfo, k);
     c->v.ss.tt = c->type;
     c->v.ss.idx = key;
 }


### PR DESCRIPTION
Berry compilation problem:

```berry
def f(self) print(self.a[128]) end
```

Compilation assigns unwanted registers:
```
      0x60040001,  //  0000  GETGBL     R1      G1
      0x540A007F,  //  0001  LDINT      R2      128
      0x880C0100,  //  0002  GETMBR     R3      R0      K0
      0x94080602,  //  0003  GETIDX     R2      R3      R2
      0x5C100400,  //  0004  MOVE       R4      R2         <- PROBLEM
      0x7C040200,  //  0005  CALL       R1      1
      0x80000000,  //  0006  RET        0
```

With the fix, the integer is retrieved in second place, and erroneous register is not allocated:
```
      0x60040001,  //  0000  GETGBL	R1	G1
      0x88080100,  //  0001  GETMBR	R2	R0	K0
      0x540E007F,  //  0002  LDINT	R3	128
      0x94080403,  //  0003  GETIDX	R2	R2	R3
      0x7C040200,  //  0004  CALL	R1	1
      0x80000000,  //  0005  RET	0
```