### PR TITLE
Add dynamic GC debug and counters

### DIFF
--- a/src/be_debuglib.c
+++ b/src/be_debuglib.c
@@ -84,6 +84,19 @@ static int m_codedump(bvm *vm)
     be_return_nil(vm);
 }
 
+static int m_gcdebug(bvm *vm) {
+    int argc = be_top(vm);
+    if (argc >= 1 && be_isbool(vm, 1)) {
+        if (be_tobool(vm, 1)) {
+            comp_set_gc_debug(vm);
+        } else {
+            comp_clear_gc_debug(vm);
+        }
+    }
+    be_pushbool(vm, comp_is_gc_debug(vm));
+    be_return(vm);
+}
+
 static int m_traceback(bvm *vm)
 {
     be_tracestack(vm);
@@ -171,10 +184,40 @@ static int m_counters(bvm *vm)
     map_insert(vm, "try", vm->counter_try);
     map_insert(vm, "raise", vm->counter_exc);
     map_insert(vm, "objects", vm->counter_gc_kept);
+    map_insert(vm, "mem_alloc", vm->counter_mem_alloc);
+    map_insert(vm, "mem_free", vm->counter_mem_free);
+    map_insert(vm, "mem_realloc", vm->counter_mem_realloc);
     be_pop(vm, 1);
     be_return(vm);
 }
 #endif
+
+static int m_allocs(bvm *vm) {
+#if BE_USE_PERF_COUNTERS
+    be_pushint(vm, vm->counter_mem_alloc);
+    be_return(vm);
+#else
+    be_return_nil(vm);
+#endif
+}
+
+static int m_frees(bvm *vm) {
+#if BE_USE_PERF_COUNTERS
+    be_pushint(vm, vm->counter_mem_free);
+    be_return(vm);
+#else
+    be_return_nil(vm);
+#endif
+}
+
+static int m_reallocs(bvm *vm) {
+#if BE_USE_PERF_COUNTERS
+    be_pushint(vm, vm->counter_mem_realloc);
+    be_return(vm);
+#else
+    be_return_nil(vm);
+#endif
+}
 
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(debug) {
@@ -193,6 +236,7 @@ be_native_module_attr_table(debug) {
     be_native_module_function("varname", m_varname),
     be_native_module_function("upvname", m_upvname)
 #endif
+    be_native_module_function("gcdebug", m_gcdebug)
 };
 
 be_define_native_module(debug, NULL);
@@ -208,6 +252,12 @@ module debug (scope: global, depend: BE_USE_DEBUG_MODULE) {
     top, func(m_top)
     varname, func(m_varname), BE_DEBUG_VAR_INFO
     upvname, func(m_upvname), BE_DEBUG_VAR_INFO
+    // individual counters
+    allocs, func(m_allocs)
+    frees, func(m_frees)
+    reallocs, func(m_reallocs)
+    // GC debug mode
+    gcdebug, func(m_gcdebug)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_debug.h"

--- a/src/be_gc.c
+++ b/src/be_gc.c
@@ -545,15 +545,9 @@ static void reset_fixedlist(bvm *vm)
 
 void be_gc_auto(bvm *vm)
 {
-#if BE_USE_DEBUG_GC
-    if (vm->gc.status & GC_PAUSE) { /* force gc each time it's possible */
+    if (vm->gc.status & GC_PAUSE && (BE_USE_DEBUG_GC || vm->gc.usage > vm->gc.threshold || comp_is_gc_debug(vm))) {
         be_gc_collect(vm);
     }
-#else
-    if (vm->gc.status & GC_PAUSE && vm->gc.usage > vm->gc.threshold) {
-        be_gc_collect(vm);
-    }
-#endif
 }
 
 size_t be_gc_memcount(bvm *vm)

--- a/src/be_mem.c
+++ b/src/be_mem.c
@@ -60,22 +60,31 @@ BERRY_API void* be_realloc(bvm *vm, void *ptr, size_t old_size, size_t new_size)
 
     while (1) {
         /* Case 1: new allocation */
+#if BE_USE_PERF_COUNTERS
+        vm->counter_mem_alloc++;
+#endif
         if (!ptr || (old_size == 0)) {
             block = malloc_from_pool(vm, new_size);
         }
     
         /* Case 2: deallocate */
         else if (new_size == 0) {
-            if (ptr == NULL) { return NULL; }   /* safeguard */
-#if BE_USE_DEBUG_GC
-            memset(ptr, 0xFF, old_size); /* fill the structure with invalid pointers */
+#if BE_USE_PERF_COUNTERS
+            vm->counter_mem_free++;
 #endif
+            if (ptr == NULL) { return NULL; }   /* safeguard */
+            if (BE_USE_DEBUG_GC || comp_is_gc_debug(vm)) {
+                memset(ptr, 0xFF, old_size); /* fill the structure with invalid pointers */
+            }
             free_from_pool(vm, ptr, old_size);
             break;    /* early exit */
         }
 
         /* Case 3: reallocate with a different size */
         else if (new_size && old_size) {        // TODO we already know they are not null TODO
+#if BE_USE_PERF_COUNTERS
+            vm->counter_mem_realloc++;
+#endif
             if (new_size <= POOL32_SIZE || old_size <=POOL32_SIZE) {
                 /* complex case with different pools */
                 if (new_size <= POOL16_SIZE && old_size <= POOL16_SIZE) {

--- a/src/be_string.c
+++ b/src/be_string.c
@@ -268,13 +268,13 @@ void be_gcstrtab(bvm *vm)
             }
         }
     }
-#if BE_USE_DEBUG_GC == 0
-    if (tab->count < size >> 2 && size > 8) {
-        resize(vm, size >> 1);
+    if (BE_USE_DEBUG_GC || comp_is_gc_debug(vm)) {
+        resize(vm, tab->count + 4);
+    } else {
+        if (tab->count < size >> 2 && size > 8) {
+            resize(vm, size >> 1);
+        }
     }
-#else
-    resize(vm, tab->count + 4);
-#endif
 }
 
 uint32_t be_strhash(const bstring *s)

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -512,6 +512,9 @@ BERRY_API bvm* be_vm_new(void)
     vm->counter_exc = 0;
     vm->counter_gc_kept = 0;
     vm->counter_gc_freed = 0;
+    vm->counter_mem_alloc = 0;
+    vm->counter_mem_free = 0;
+    vm->counter_mem_realloc = 0;
 #endif
     return vm;
 }

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -14,14 +14,19 @@
 #define comp_set_named_gbl(vm)      ((vm)->compopt |= (1<<COMP_NAMED_GBL))
 #define comp_clear_named_gbl(vm)    ((vm)->compopt &= ~(1<<COMP_NAMED_GBL))
 
-#define comp_is_strict(vm)       ((vm)->compopt & (1<<COMP_STRICT))
-#define comp_set_strict(vm)      ((vm)->compopt |= (1<<COMP_STRICT))
-#define comp_clear_strict(vm)    ((vm)->compopt &= ~(1<<COMP_STRICT))
+#define comp_is_strict(vm)          ((vm)->compopt & (1<<COMP_STRICT))
+#define comp_set_strict(vm)         ((vm)->compopt |= (1<<COMP_STRICT))
+#define comp_clear_strict(vm)       ((vm)->compopt &= ~(1<<COMP_STRICT))
+
+#define comp_is_gc_debug(vm)       ((vm)->compopt & (1<<COMP_GC_DEBUG))
+#define comp_set_gc_debug(vm)      ((vm)->compopt |= (1<<COMP_GC_DEBUG))
+#define comp_clear_gc_debug(vm)    ((vm)->compopt &= ~(1<<COMP_GC_DEBUG))
 
 /* Compilation options */
 typedef enum {
-    COMP_NAMED_GBL = 0x00, /* compile with named globals */
-    COMP_STRICT = 0x01, /* compile with named globals */
+    COMP_NAMED_GBL = 0x00,  /* compile with named globals */
+    COMP_STRICT = 0x01,     /* compile with named globals */
+    COMP_GC_DEBUG = 0x02,   /* compile with gc debug */
 } compoptmask;
 
 typedef struct {
@@ -118,6 +123,9 @@ struct bvm {
     uint32_t counter_exc; /* counter for raised exceptions */
     uint32_t counter_gc_kept; /* counter for objects scanned by last gc */
     uint32_t counter_gc_freed; /* counter for objects freed by last gc */
+    uint32_t counter_mem_alloc; /* counter for memory allocations */
+    uint32_t counter_mem_free; /* counter for memory frees */
+    uint32_t counter_mem_realloc; /* counter for memory reallocations */
 
     uint32_t gc_mark_string;
     uint32_t gc_mark_class;


### PR DESCRIPTION
Extend `debug` module:
- allow dynamic GC debug with `debug.gcdebug(<bool>) -> bool`, instead of only as a compile option
- add counters for allocs, reallocs, frees

```
> import debug
> print(1+1)
2

> print("allocs", debug.allocs(), "reallocs", debug.reallocs(), "frees", debug.frees())
allocs 181 reallocs 19 frees 60

> debug.gcdebug(true)
true

> print("allocs", debug.allocs(), "reallocs", debug.reallocs(), "frees", debug.frees())
allocs 309 reallocs 38 frees 123

> debug.gcdebug(false)
false

> debug.gcdebug()   # get current status
false
```
