### PR TITLE
introspect.set for class attributes

### DIFF
--- a/src/be_api.c
+++ b/src/be_api.c
@@ -643,6 +643,10 @@ BERRY_API bbool be_setmember(bvm *vm, int index, const char *k)
         bstring *key = be_newstr(vm, k);
         bmodule *mod = var_toobj(o);
         return be_module_setmember(vm, mod, key, v);
+    } else if (var_isclass(o)) {
+        bstring *key = be_newstr(vm, k);
+        bclass *cl = var_toobj(o);
+        return be_class_setmember(vm, cl, key, v);
     }
     return bfalse;
 }

--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -96,7 +96,7 @@ static int m_findmember(bvm *vm)
 static int m_setmember(bvm *vm)
 {
     int top = be_top(vm);
-    if (top >= 3 && (be_isinstance(vm, 1) || be_ismodule(vm, 1)) && be_isstring(vm, 2)) {
+    if (top >= 3 && (be_isinstance(vm, 1) || be_ismodule(vm, 1) || be_isclass(vm, 1)) && be_isstring(vm, 2)) {
         be_setmember(vm, 1, be_tostring(vm, 2));
         be_return(vm);
     }

--- a/tests/introspect.be
+++ b/tests/introspect.be
@@ -42,3 +42,25 @@ assert(introspect.name(A) == 'A')
 assert(introspect.name(A.a) == 'a')
 assert(introspect.name(A.b) == 'b')
 assert(introspect.name(A.c) == nil)
+
+# test introspect get and set
+# class and instance
+class A
+    static var a
+    var b
+end
+
+a = A()
+introspect.set(A, "a", 10)
+assert(A.a == 10)
+assert(introspect.get(A, "a") == 10)
+
+introspect.set(a, "b", 20)
+assert(a.b == 20)
+assert(introspect.get(a, "b") == 20)
+
+# module
+m = module('m')
+introspect.set(m, 'c', 30)
+assert(m.c == 30)
+assert(introspect.get(m, 'c') == 30)


### PR DESCRIPTION
Make `introspect.set()` work with class attributes:

```berry
class A
    static var a
end

introspect.set(A, "a", 10)
# now A.a == 10
```
