### PR TITLE
Fix wrong register when superclass is a member

### DIFF
--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -1571,15 +1571,11 @@ static void class_stmt(bparser *parser)
         begin_block(parser->finfo, &binfo, 0);
 
         bstring *class_str = parser_newstr(parser, "_class");   /* we always define `_class` local variable */
-        if (e.type == ETLOCAL) {
-            bexpdesc e1;                        /* if inline class, we add a second local variable for _class */
-            init_exp(&e1, ETLOCAL, 0);
-            e1.v.idx = new_localvar(parser, class_str);
-            be_code_setvar(parser->finfo, &e1, &e, 1);
-        } else {                                /* if global class, we just reuse the newly created class in the register */
-            init_exp(&e, ETLOCAL, 0);
-            e.v.idx = new_localvar(parser, class_str);
-        }
+        bexpdesc e1;                        /* if inline class, we add a second local variable for _class */
+        init_exp(&e1, ETLOCAL, 0);
+        e1.v.idx = new_localvar(parser, class_str);
+        be_code_setvar(parser->finfo, &e1, &e, 1);
+
         begin_varinfo(parser, class_str);
 
         class_block(parser, c, &e);

--- a/tests/class_static.be
+++ b/tests/class_static.be
@@ -155,3 +155,12 @@ assert(A.a == 1)
 assert(A.b == A)
 assert(A.c == [1, A])
 assert(A.f(1) == A)
+
+# bug when superclass is a member
+# the following would break with:
+#
+# attribute_error: class 'B' cannot assign to static attribute 'aa'
+# stack traceback:
+#     stdin:1: in function `main`
+class B end m = module('m') m.B = B
+class A : m.B static aa = 1 end


### PR DESCRIPTION
Fix a compilation bug when the superclass is a member, the code containing the static initialization code does not contain anymore the class in `R0`. This fix removes an optimization that would assume that `R0` has the class, and forces reading the class again into `R0`.

```berry
# the following would fail

> class B end m = module('m') m.B = B
> class A : m.B static aa = 1 end
attribute_error: class 'B' cannot assign to static attribute 'aa'
stack traceback:
	stdin:1: in function `main`
```

Showing the problem:

```
> class B end m = module('m') m.B = B
> f = compile("class A : m.B static aa = 1 end") import debug debug.codedump(f)
source 'string', function 'main':
; line 1
  0000  LDCONST	R0	K1
  0001  SETNGBL	R0	K0
  0002  CLASS	K1
  0003  GETNGBL	R0	K2
  0004  GETNGBL	R1	K0
  0005  GETMBR	R0	R0	K3     <- R0 contains `m.B`
  0006  SETSUPER	R1	R0
  0007  SETMBR	R0	K4	K5     <- R0 does not contain `A`
  0008  RET	0
```

After the fix:
```
> class B end m = module('m') m.B = B
> f = compile("class A : m.B static aa = 1 end") import debug debug.codedump(f)
source 'string', function 'main':
; line 1
  0000  LDCONST	R0	K1
  0001  SETNGBL	R0	K0
  0002  CLASS	K1
  0003  GETNGBL	R0	K2
  0004  GETNGBL	R1	K0
  0005  GETMBR	R0	R0	K3
  0006  SETSUPER	R1	R0
  0007  GETNGBL	R0	K0             <- force loading class in R0
  0008  SETMBR	R0	K4	K5
  0009  RET	0
```