### PR TITLE
Bytes add string

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -1768,6 +1768,7 @@ void be_load_byteslib(bvm *vm)
         { "clear", m_clear },
         { "reverse", m_reverse },
         { "copy", m_copy },
+        { "append", m_connect },
         { "+", m_merge },
         { "..", m_connect },
         { "==", m_equal },
@@ -1815,6 +1816,7 @@ class be_class_bytes (scope: global, name: bytes) {
     clear, func(m_clear)
     reverse, func(m_reverse)
     copy, func(m_copy)
+    append, func(m_connect)
     +, func(m_merge)
     .., func(m_connect)
     ==, func(m_equal)

--- a/tests/bytes.be
+++ b/tests/bytes.be
@@ -110,10 +110,17 @@ assert(str(b) == "bytes('AA')")
 b = b1 + '01'
 assert(str(b) == "bytes('AA3031')")
 
-#- .. -#
+#- .. and append as synonym-#
 b1 = bytes("1122")
 b2 = bytes("334455")
 b = b1..b2
+assert(str(b1) == "bytes('1122334455')")
+assert(str(b2) == "bytes('334455')")
+assert(str(b) == "bytes('1122334455')")
+#
+b1 = bytes("1122")
+b2 = bytes("334455")
+b = b1.append(b2)
 assert(str(b1) == "bytes('1122334455')")
 assert(str(b2) == "bytes('334455')")
 assert(str(b) == "bytes('1122334455')")
@@ -123,6 +130,12 @@ b1 = bytes("AA")
 b1 .. ''
 assert(str(b1) == "bytes('AA')")
 b1 .. '01'
+assert(str(b1) == "bytes('AA3031')")
+#
+b1 = bytes("AA")
+b1.append('')
+assert(str(b1) == "bytes('AA')")
+b1.append('01')
 assert(str(b1) == "bytes('AA3031')")
 
 #- item -#

--- a/tests/bytes.be
+++ b/tests/bytes.be
@@ -103,6 +103,13 @@ assert(str(b) == "bytes('1122334455')")
 b = b2 + b1
 assert(str(b) == "bytes('3344551122')")
 
+#- + for string -#
+b1 = bytes("AA")
+b = b1 + ''
+assert(str(b) == "bytes('AA')")
+b = b1 + '01'
+assert(str(b) == "bytes('AA3031')")
+
 #- .. -#
 b1 = bytes("1122")
 b2 = bytes("334455")
@@ -110,6 +117,13 @@ b = b1..b2
 assert(str(b1) == "bytes('1122334455')")
 assert(str(b2) == "bytes('334455')")
 assert(str(b) == "bytes('1122334455')")
+
+#- .. with string -#
+b1 = bytes("AA")
+b1 .. ''
+assert(str(b1) == "bytes('AA')")
+b1 .. '01'
+assert(str(b1) == "bytes('AA3031')")
 
 #- item -#
 b = bytes("334455")


### PR DESCRIPTION
Allow `bytes()` to add a `string`:

```berry
b = bytes()
b .. 'hello'
print(b)
# bytes('68656C6C6F')
```