### PR TITLE
Add `debug.caller()`

### DIFF
--- a/src/be_debuglib.c
+++ b/src/be_debuglib.c
@@ -257,6 +257,7 @@ be_native_module_attr_table(debug) {
     be_native_module_function("varname", m_varname),
     be_native_module_function("upvname", m_upvname)
 #endif
+    be_native_module_function("caller", m_caller),
     be_native_module_function("gcdebug", m_gcdebug)
 };
 

--- a/tests/debug.be
+++ b/tests/debug.be
@@ -2,3 +2,28 @@ import debug
 
 class A end
 debug.attrdump(A)   #- should not crash -#
+
+# debug.caller()
+def caller_name_chain()
+    import debug
+    import introspect
+    var i = 1
+    var ret = []
+    var caller = debug.caller(i)
+    while caller
+        ret.push(introspect.name(caller))
+        i += 1
+        caller = debug.caller(i)
+    end
+    return ret
+end
+var chain = caller_name_chain()
+assert(chain[0] == 'caller_name_chain')
+
+def guess_my_name__()
+    return caller_name_chain()
+end
+chain = guess_my_name__()
+print(chain)
+assert(chain[0] == 'caller_name_chain')
+assert(chain[1] == 'guess_my_name__')


### PR DESCRIPTION
Add `debug.caller()`with the following semantics:

- `debug.caller(nil) -> function or nil` return current function
- `debug.caller(int) -> function or nil` return the nth caller in chain (default is `1`).

One typical use-case is to get the name of the current function, or the name of the caller function. Note: use `introspect.name()` to get the name of a function.

Example:
```berry
def guess_my_name()
    import debug
    import introspect
    var func = debug.caller()
    var func_name = introspect.name(func)
    print(func_name)
end
guess_my_name()
# prints: guess_my_name
```