### PR TITLE
Global `byte`

### DIFF
--- a/src/be_baselib.c
+++ b/src/be_baselib.c
@@ -506,6 +506,7 @@ void be_load_baselib_next(bvm *vm)
     be_regfunc(vm, "call", l_call);
     be_regfunc(vm, "bool", l_bool);
     be_regfunc(vm, "format", be_str_format);
+    be_regfunc(vm, "byte", be_str_byte);
 }
 #else
 extern const bclass be_class_list;
@@ -540,6 +541,7 @@ vartab m_builtin (scope: local) {
     call, func(l_call)
     bool, func(l_bool)
     format, func(be_str_format)
+    byte, func(be_str_byte)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_m_builtin.h"

--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -833,7 +833,7 @@ static int str_i2hex(bvm *vm)
     be_return_nil(vm);
 }
 
-static int str_byte(bvm *vm)
+int be_str_byte(bvm *vm)
 {
     if (be_top(vm) && be_isstring(vm, 1)) {
         const bbyte *s = (const bbyte *)be_tostring(vm, 1);
@@ -958,7 +958,7 @@ be_native_module_attr_table(string) {
     be_native_module_function("split", str_split),
     be_native_module_function("find", str_find),
     be_native_module_function("hex", str_i2hex),
-    be_native_module_function("byte", str_byte),
+    be_native_module_function("byte", be_str_byte),
     be_native_module_function("char", str_char),
     be_native_module_function("tolower", str_tolower),
     be_native_module_function("toupper", str_toupper),
@@ -976,7 +976,7 @@ module string (scope: global, depend: BE_USE_STRING_MODULE) {
     split, func(str_split)
     find, func(str_find)
     hex, func(str_i2hex)
-    byte, func(str_byte)
+    byte, func(be_str_byte)
     char, func(str_char)
     tolower, func(str_tolower)
     toupper, func(str_toupper)

--- a/src/be_strlib.h
+++ b/src/be_strlib.h
@@ -26,6 +26,7 @@ const char* be_splitname(const char *path);
 const char* be_pushvfstr(bvm *vm, const char *format, va_list arg);
 bstring* be_strindex(bvm *vm, bstring *str, bvalue *idx);
 int be_str_format(bvm *vm);
+int be_str_byte(bvm *vm);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Anytime the byte value of a character is needed, importing (and prefixing) `string` is needed. This can become tedious given how often this method is needed.

```berry
import string
assert(string.byte("ABC"[1]) == 66)
```
↓
```berry
assert(byte("ABC"[1]) == 66)
```