### PR TITLE
Add `bytes().addfloat()`

### DIFF
--- a/tests/bytes.be
+++ b/tests/bytes.be
@@ -219,6 +219,11 @@ b = bytes("0000C03F")
 assert(b.getfloat(0) == 1.5)
 b.addfloat(0.33)
 assert(b == bytes("0000C03FC3F5A83E"))
+b.addfloat(0.33, true)      #- Big Endian -#
+assert(b == bytes("0000C03FC3F5A83E3EA8F5C3"))
+b = bytes("")
+b.addfloat(42)      #- add integer -#
+assert(b == bytes("00002842"))
 
 #- fromhex -#
 b = bytes("112233")

--- a/tests/bytes.be
+++ b/tests/bytes.be
@@ -217,6 +217,8 @@ b.setfloat(0, 0.33)
 assert(b == bytes('C3F5A83E'))
 b = bytes("0000C03F")
 assert(b.getfloat(0) == 1.5)
+b.addfloat(0.33)
+assert(b == bytes("0000C03FC3F5A83E"))
 
 #- fromhex -#
 b = bytes("112233")


### PR DESCRIPTION
Add method to add a 32 bit float at the end of a bytes() object.

`bytes().addfloat( int or real [, big_endian: bool]) -> instance of bytes`