### PR TITLE
Add ability to solidify long strings

### DIFF
--- a/src/be_constobj.h
+++ b/src/be_constobj.h
@@ -262,6 +262,13 @@ const bntvmodule_t be_native_module(_module) = {                  \
     BE_STRING                                                   \
   }
 
+/* variant for long strings that does not trigger strtab */
+#define be_nested_str_long(_name_)                              \
+  {                                                             \
+    { .s=((bstring*)&be_const_str_##_name_) },                  \
+    BE_STRING                                                   \
+  }
+
 #define be_nested_str_literal(_name_)                           \
   {                                                             \
     { .s=(be_nested_const_str(_name_, _hash, sizeof(_name_)-1 ))\

--- a/src/be_string.c
+++ b/src/be_string.c
@@ -27,6 +27,17 @@
         .s = _s                                                    \
     }
 
+#define be_define_const_str_long(_name, _s, _len)                  \
+    BERRY_LOCAL const bclstring be_const_str_##_name = {           \
+        .next = (bgcobject *)NULL,                                 \
+        .type = BE_STRING,                                         \
+        .marked = GC_CONST,                                        \
+        .extra = 0,                                                \
+        .slen = 255,                                               \
+        .llen = _len,                                              \
+        .s = _s                                                    \
+    }
+
 /* const string table */
 struct bconststrtab {
     const bstring* const *table;
@@ -279,7 +290,7 @@ void be_gcstrtab(bvm *vm)
 
 uint32_t be_strhash(const bstring *s)
 {
-    if (gc_isconst(s)) {
+    if (gc_isconst(s) && (s->slen != 255)) {
         bcstring* cs = cast(bcstring*, s);
         if (cs->hash) {  /* if hash is null we need to compute it */
             return cs->hash;
@@ -298,11 +309,11 @@ uint32_t be_strhash(const bstring *s)
 const char* be_str2cstr(const bstring *s)
 {
     be_assert(cast_str(s) != NULL);
-    if (gc_isconst(s)) {
-        return cstr(s);
-    }
     if (s->slen == 255) {
         return lstr(s);
+    }
+    if (gc_isconst(s)) {
+        return cstr(s);
     }
     return sstr(s);
 }

--- a/src/be_string.h
+++ b/src/be_string.h
@@ -26,6 +26,12 @@ typedef struct {
     /* char s[]; */
 } blstring;
 
+typedef struct {        /* const long string */
+    bstring_header;
+    int llen;
+    char s[];
+} bclstring;
+
 typedef struct {
     bstring_header;
     uint32_t hash;


### PR DESCRIPTION
Solidification now works with long constant strings, i.e. strings longer than 255 bytes.