### PR TITLE
Add observability hook when memory allocation failed

### DIFF
--- a/src/be_exec.c
+++ b/src/be_exec.c
@@ -79,6 +79,10 @@ void be_throw(bvm *vm, int errorcode)
 #if BE_USE_PERF_COUNTERS
     vm->counter_exc++;
 #endif
+    /* if BE_MALLOC_FAIL then call */
+    if (errorcode == BE_MALLOC_FAIL) {
+        if (vm->obshook != NULL) (*vm->obshook)(vm, BE_OBS_MALLOC_FAIL, vm->gc.usage);
+    }
     if (vm->errjmp) {
         vm->errjmp->status = errorcode;
         exec_throw(vm->errjmp);

--- a/src/berry.h
+++ b/src/berry.h
@@ -675,6 +675,7 @@ enum beobshookevents {
     BE_OBS_GC_END,              /**< end of GC, arg = allocated size */
     BE_OBS_VM_HEARTBEAT,        /**< VM heartbeat called every million instructions */
     BE_OBS_STACK_RESIZE_START,  /**< Berry stack resized */
+    BE_OBS_MALLOC_FAIL,         /**< Memory allocation failed */
 };
 
 typedef int (*bctypefunc)(bvm*, const void*); /**< bctypefunc */


### PR DESCRIPTION
This allows to add some additional logging when memory allocation fails, in case the exception is hidden somewhere in the code.