### PR TITLE
Add `instrospect.contains()` and string to comptr

### DIFF
--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -122,7 +122,7 @@ static int m_toptr(bvm *vm)
     if (top >= 1) {
         bvalue *v = be_indexof(vm, 1);
         if (var_type(v) == BE_STRING) {
-            be_pushcomptr(vm, be_tostring(vm, 1));
+            be_pushcomptr(vm, (void*)be_tostring(vm, 1));
             be_return(vm);
         } else if (var_basetype(v) >= BE_FUNCTION || var_type(v) == BE_COMPTR) {
             be_pushcomptr(vm, var_toobj(v));

--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -93,6 +93,19 @@ static int m_findmember(bvm *vm)
     be_return_nil(vm);
 }
 
+static int m_contains(bvm *vm)
+{
+    bbool contains = bfalse;
+    int top = be_top(vm);
+    if (top >= 2 && be_isstring(vm, 2) && (be_isinstance(vm, 1) || be_ismodule(vm, 1) || be_isclass(vm, 1))) {
+        if (be_getmember(vm, 1, be_tostring(vm, 2))) {
+            contains = btrue;
+        }
+    }
+    be_pushbool(vm, contains);
+    be_return(vm);
+}
+
 static int m_setmember(bvm *vm)
 {
     int top = be_top(vm);
@@ -108,7 +121,10 @@ static int m_toptr(bvm *vm)
     int top = be_top(vm);
     if (top >= 1) {
         bvalue *v = be_indexof(vm, 1);
-        if (var_basetype(v) >= BE_FUNCTION || var_type(v) == BE_COMPTR) {
+        if (var_type(v) == BE_STRING) {
+            be_pushcomptr(vm, be_tostring(vm, 1));
+            be_return(vm);
+        } else if (var_basetype(v) >= BE_FUNCTION || var_type(v) == BE_COMPTR) {
             be_pushcomptr(vm, var_toobj(v));
             be_return(vm);
         } else if (var_type(v) == BE_INT) {
@@ -222,6 +238,7 @@ be_native_module_attr_table(introspect) {
 
     be_native_module_function("get", m_findmember),
     be_native_module_function("set", m_setmember),
+    be_native_module_function("contains", m_contains),
 
     be_native_module_function("module", m_getmodule),
     be_native_module_function("setmodule", m_setmodule),
@@ -242,6 +259,7 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     get, func(m_findmember)
     set, func(m_setmember)
+    contains, func(m_contains)
 
     module, func(m_getmodule)
     setmodule, func(m_setmodule)


### PR DESCRIPTION
Add two features to `import introspect`:
- `instrospect.contains( instance or module or class, name:string) -> bool`: returns `true` if the instance/class/module contains a member with `name`
- `introspect.toptr()` now works also for a `string` and returns a pointer to the `C` string (warning, the pointer is only valid until next GC)