### PR TITLE
load bytecode from file pointer

### DIFF
--- a/src/be_bytecode.h
+++ b/src/be_bytecode.h
@@ -12,6 +12,7 @@
 
 void be_bytecode_save(bvm *vm, const char *filename, bproto *proto);
 bclosure* be_bytecode_load(bvm *vm, const char *filename);
+bclosure* be_bytecode_load_from_fs(bvm *vm, void *fp);
 bbool be_bytecode_check(const char *path);
 
 #endif


### PR DESCRIPTION
Add ability to load bytecode from a file pointer in addition to a filename. This allows to stream bytecode from a URL.

`bclosure* be_bytecode_load_from_fs(bvm *vm, void *fp);`