### PR TITLE
Fix ternary parser bug

### DIFF
--- a/src/be_code.c
+++ b/src/be_code.c
@@ -84,7 +84,7 @@ static int codeABx(bfuncinfo *finfo, bopcode op, int a, int bx)
 /* returns false if the move operation happened, or true if there was a register optimization and `b` should be replaced by `a` */
 static bbool code_move(bfuncinfo *finfo, int a, int b)
 {
-    if (finfo->pc) {  /* If not the first instruction of the function */
+    if (finfo->pc > finfo->binfo->lastjmp) {  /* If not the first instruction of the function */
         binstruction *i = be_vector_end(&finfo->code);  /* get the last instruction */
         bopcode op = IGET_OP(*i);
         if (op <= OP_LDNIL) { /* binop or unop */
@@ -171,6 +171,13 @@ static int get_jump(bfuncinfo *finfo, int pc)
 
 static void patchlistaux(bfuncinfo *finfo, int list, int vtarget, int dtarget)
 {
+    /* mark the last destination point of a jump to avoid false register optimization */
+    if (vtarget > finfo->binfo->lastjmp) {
+        finfo->binfo->lastjmp = vtarget;
+    }
+    if (dtarget > finfo->binfo->lastjmp) {
+        finfo->binfo->lastjmp = dtarget;
+    }
     while (list != NO_JUMP) {
         int next = get_jump(finfo, list);
         if (isjumpbool(finfo, list)) {

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -197,6 +197,7 @@ static void begin_block(bfuncinfo *finfo, bblockinfo *binfo, int type)
     binfo->type = (bbyte)type;
     binfo->hasupval = 0;
     binfo->sideeffect = 0;
+    binfo->lastjmp = 0;
     binfo->beginpc = finfo->pc; /* set starting pc for this block */
     binfo->nactlocals = (bbyte)be_list_count(finfo->local); /* count number of local variables in previous block */
     if (type & BLOCK_LOOP) {

--- a/src/be_parser.h
+++ b/src/be_parser.h
@@ -45,7 +45,7 @@ typedef struct {
     int t; /* patch list of 'exit when true' */
     int f; /* patch list of 'exit when false' */
     bbyte not; /* not mark */
-    bbyte type;
+    exptype_t type;
 } bexpdesc;
 
 typedef struct bblockinfo {
@@ -53,7 +53,8 @@ typedef struct bblockinfo {
     bbyte nactlocals; /* number of active local variables */
     bbyte type;       /* block type mask */
     bbyte hasupval;   /* has upvalue mark */
-    bbyte sideeffect; /* did the last expr/statement had a side effect */ 
+    bbyte sideeffect; /* did the last expr/statement had a side effect */
+    int lastjmp;      /* pc for the last jump, prevents false register optimizations */ 
     int breaklist;    /* break list */
     int beginpc;      /* begin pc */
     int continuelist; /* continue list */

--- a/tests/parser.be
+++ b/tests/parser.be
@@ -1,0 +1,11 @@
+# Test some sparser specific bugs
+
+# https://github.com/berry-lang/berry/issues/396
+def f()
+    if true
+        var a = 1
+        a = true ? a+1 : a+2
+        return a
+    end
+end
+assert(f() == 2)


### PR DESCRIPTION
Fix #396

Details:

The Berry parser does simple optimization in the following pattern:
```
def f() var a = 1 a = a + 2 end
```

The raw bytecode generated is:
```
0000  LDCONST	R0	K0
0001  ADD	R1	R0	K1
0002  MOVE	R0	R1
0002  RET	0
```
but the optimizer saves the `MOVE`:
```
0001  ADD	R1	R0	K1
0002  MOVE	R0	R1
# replaced by
0001  ADD	R0	R0	K1
```
storing directly the result in R0 instead of storing into a temporary R1 that is discarded right after.

In the case of the ternary operator, only the last `ADD` is patched, not the first one.

Fix: I added a `lastjmp` information which point to the further position in PC where a JMP lands. This optimization should not happen at the beginning of a new string of code starting from the target of a JMP.