### PR TITLE
Fix walrus with member or index

### DIFF
--- a/src/be_code.c
+++ b/src/be_code.c
@@ -721,21 +721,13 @@ int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg)
         setsupvar(finfo, OP_SETUPV, e1, src);
         break;
     case ETMEMBER: /* store to member R(A).RK(B) <- RK(C) */
-        setsfxvar(finfo, OP_SETMBR, e1, src);
-        if (keep_reg && e2->type == ETREG) {
+    case ETINDEX: /* store to member R(A)[RK(B)] <- RK(C) */
+        setsfxvar(finfo, (e1->type == ETMEMBER) ? OP_SETMBR : OP_SETIDX, e1, src);
+        if (keep_reg && e2->type == ETREG && e1->v.ss.obj >= be_list_count(finfo->local)) {
             /* special case of walrus assignemnt when we need to recreate an ETREG */
             code_move(finfo, e1->v.ss.obj, src);    /* move from ETREG to MEMBER instance*/
             free_expreg(finfo, e2); /* free source (checks only ETREG) */
             e2->v.idx = e1->v.ss.obj; /* update to new register */
-        }
-        break;
-    case ETINDEX: /* store to member R(A)[RK(B)] <- RK(C) */
-        setsfxvar(finfo, OP_SETIDX, e1, src);
-        if (keep_reg && e2->type == ETREG) {
-            /* special case of walrus assignemnt when we need to recreate an ETREG */
-            code_move(finfo, e1->v.ss.obj, src);
-            free_expreg(finfo, e2); /* free source (checks only ETREG) */
-            e2->v.idx = e1->v.ss.obj;
         }
         break;
     default:

--- a/src/be_code.c
+++ b/src/be_code.c
@@ -722,9 +722,21 @@ int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg)
         break;
     case ETMEMBER: /* store to member R(A).RK(B) <- RK(C) */
         setsfxvar(finfo, OP_SETMBR, e1, src);
+        if (keep_reg && e2->type == ETREG) {
+            /* special case of walrus assignemnt when we need to recreate an ETREG */
+            code_move(finfo, e1->v.ss.obj, src);    /* move from ETREG to MEMBER instance*/
+            free_expreg(finfo, e2); /* free source (checks only ETREG) */
+            e2->v.idx = e1->v.ss.obj; /* update to new register */
+        }
         break;
     case ETINDEX: /* store to member R(A)[RK(B)] <- RK(C) */
         setsfxvar(finfo, OP_SETIDX, e1, src);
+        if (keep_reg && e2->type == ETREG) {
+            /* special case of walrus assignemnt when we need to recreate an ETREG */
+            code_move(finfo, e1->v.ss.obj, src);
+            free_expreg(finfo, e2); /* free source (checks only ETREG) */
+            e2->v.idx = e1->v.ss.obj;
+        }
         break;
     default:
         return 1;

--- a/tests/walrus.be
+++ b/tests/walrus.be
@@ -56,3 +56,17 @@ import global
 def f() return id(global.l[0] := 42) end
 assert(f() == 42)
 # bug: returns [42, 11]
+
+# bug when using member for self
+class confused_walrus
+    var b
+    def f()
+        var c = 1
+        if self.b := true
+            c = 2
+        end
+        return self
+    end
+end
+var ins = confused_walrus()
+assert(ins.f() == ins)

--- a/tests/walrus.be
+++ b/tests/walrus.be
@@ -33,3 +33,26 @@ assert_attribute_error("var a,b def f() a end")
 
 # while the following does have side effect
 def f() a := b end
+
+# bug when using walrus with member
+def id(x) return x end
+var a = 1
+import global
+def f() return id(global.a := 42) end
+assert(f() == 42)
+# bug: returns <module: global>
+
+def concat(x, y, z) return str(x)+str(y)+str(z) end
+var a = 1
+import global
+def f() return concat(global.a := 1, global.a := 42, global.a := 0) end
+assert(f() == "1420")
+# bug: returns '1<module: global>42'
+
+# same bug when using index
+def id(x) return x end
+l = [10,11]
+import global
+def f() return id(global.l[0] := 42) end
+assert(f() == 42)
+# bug: returns [42, 11]


### PR DESCRIPTION
Fix a bug when using walrus operator with SETMEMBER or SETINDEX:

```berry
a = 1 import global def f() print(global.a := 42) end
```

When dumping f:
```C

    ( &(const bvalue[ 2]) {     /* constants */
    /* K0   */  be_nested_str(global),
    /* K1   */  be_nested_str(a),
    }),
    &be_const_str_f,
    &be_const_str_solidified,
    ( &(const binstruction[ 6]) {  /* code */
      0x60000001,  //  0000  GETGBL	R0	G1
      0xB8060000,  //  0001  GETNGBL	R1	K0
      0x540A0029,  //  0002  LDINT	R2	42
      0x90060202,  //  0003  SETMBR	R1	K1	R2   <-- the result is in R2, and R1 contains `global`
      0x7C000200,  //  0004  CALL	R0	1
      0x80000000,  //  0005  RET	0
    })
```

With the fix, in such case an additional MOVE is added:
```C

    ( &(const bvalue[ 2]) {     /* constants */
    /* K0   */  be_nested_str(global),
    /* K1   */  be_nested_str(a),
    }),
    &be_const_str_f,
    &be_const_str_solidified,
    ( &(const binstruction[ 7]) {  /* code */
      0x60000001,  //  0000  GETGBL	R0	G1
      0xB8060000,  //  0001  GETNGBL	R1	K0
      0x540A0029,  //  0002  LDINT	R2	42
      0x90060202,  //  0003  SETMBR	R1	K1	R2
      0x5C040400,  //  0004  MOVE	R1	R2      <-- this brings back the result in R1
      0x7C000200,  //  0005  CALL	R0	1
      0x80000000,  //  0006  RET	0
    })
```