### PR TITLE
Fix compilation

### DIFF
--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -14,6 +14,7 @@
 #include "be_mem.h"
 #include "be_baselib.h"
 #include <string.h>
+#include <strings.h>
 #include <stdio.h>
 #include <ctype.h>
 


### PR DESCRIPTION
Fix compilation while compiling JS version with higher warnings.

`strncasecmp()` requires `#include <strings.h>`