### PR TITLE
fix: raise exception when doing modulo ('%') by zero, instead of crashing with SIGFPE

### DIFF
--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -707,8 +707,9 @@ newframe: /* a new call frame */
                 breal x = var2real(a), y = var2real(b);
                 if (y == cast(breal, 0)) {
                     vm_error(vm, "divzero_error", "division by zero");
+                } else {
+                    var_setreal(dst, x / y);
                 }
-                var_setreal(dst, x / y);
             } else if (var_isinstance(a)) {
                 ins_binop(vm, "/", ins);
             } else {
@@ -719,9 +720,19 @@ newframe: /* a new call frame */
         opcase(MOD): {
             bvalue *dst = RA(), *a = RKB(), *b = RKC();
             if (var_isint(a) && var_isint(b)) {
-                var_setint(dst, ibinop(%, a, b));
+                bint x = var_toint(a), y = var_toint(b);
+                if (y == 0) {
+                    vm_error(vm, "divzero_error", "division by zero");
+                } else {
+                    var_setint(dst, x % y);
+                }
             } else if (var_isnumber(a) && var_isnumber(b)) {
-                var_setreal(dst, mathfunc(fmod)(var_toreal(a), var_toreal(b)));
+                breal x = var2real(a), y = var2real(b);
+                if (y == cast(breal, 0)) {
+                    vm_error(vm, "divzero_error", "division by zero");
+                } else {
+                    var_setreal(dst, mathfunc(fmod)(x, y));
+                }
             } else if (var_isinstance(a)) {
                 ins_binop(vm, "%", ins);
             } else {

--- a/tests/division_by_zero.be
+++ b/tests/division_by_zero.be
@@ -1,0 +1,47 @@
+
+try
+    # Test integer division
+    var div = 1/0
+    assert(false) # Should not reach this point
+except .. as e,m
+    
+    assert(e == "divzero_error")
+    assert(m == "division by zero")
+end
+
+
+try
+    # Test integer modulo
+    var div = 1%0
+    assert(false)
+except .. as e,m
+    assert(e == "divzero_error")
+    assert(m == "division by zero")
+end
+
+try
+    # Test float division
+    var div = 1.1/0.0
+    assert(false)
+except .. as e,m
+    assert(e == "divzero_error")
+    assert(m == "division by zero")
+end
+
+try
+    # Test float modulo
+    var div = 1.1%0.0
+    assert(false)
+except .. as e,m
+    assert(e == "divzero_error")
+    assert(m == "division by zero")
+end
+
+
+# Check normal division & modulo
+assert(1/2 == 0)
+assert(1%2 == 1)
+assert(1.0/2.0 == 0.5)
+assert(1.0%2.0 == 1.0)
+assert(4/2 == 2)
+assert(4%2 == 0)


### PR DESCRIPTION
Makes the behavior consistent with division ('/' operator), prevents full VM crash. Similar behavior is observed in Python (v. 3.11.8).

Additionally I have moved the actual  float modulo and division into the `else` branch of the check, to prevent UB even when the division by zero was caught.

Added testcase to check this behavior.