### PR TITLE
fix: Crash when overwriting builtin with walrus operator (fixes #416)

### DIFF
--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -1119,7 +1119,7 @@ static void walrus_expr(bparser *parser, bexpdesc *e)
         expr(parser, e);
         check_var(parser, e);
         if (check_newvar(parser, &e1)) { /* new variable */
-            new_var(parser, e1.v.s, e);
+            new_var(parser, e1.v.s, &e1);
         }
         if (be_code_setvar(parser->finfo, &e1, e, btrue /* do not release register */ )) {
             parser->lexer.linenumber = line;

--- a/tests/walrus.be
+++ b/tests/walrus.be
@@ -70,3 +70,12 @@ class confused_walrus
 end
 var ins = confused_walrus()
 assert(ins.f() == ins)
+
+# Check overwriting a builtin (https://github.com/berry-lang/berry/issues/416)
+
+def check_overwrite_builtin()
+    print := 1
+    assert(print == 1)
+end
+
+check_overwrite_builtin()


### PR DESCRIPTION
It appears that `check_newvar` was called with `&e1`,  but then `new_var` was mistakenly called with `e`, which caused the parser to generate garbage opcodes, leading to crashes.

Added test case to verify this behavior.