### PR TITLE
Math support for inf, fix json dump

### DIFF
--- a/src/be_jsonlib.c
+++ b/src/be_jsonlib.c
@@ -8,6 +8,7 @@
 #include "be_object.h"
 #include "be_mem.h"
 #include <string.h>
+#include <math.h>
 
 #if BE_USE_JSON_MODULE
 
@@ -515,6 +516,15 @@ static void value_dump(bvm *vm, int *indent, int idx, int fmt)
     } else if (be_isnil(vm, idx)) { /* convert to json null */
         be_stack_require(vm, 1 + BE_STACK_FREE_MIN); 
         be_pushstring(vm, "null");
+    } else if (be_isreal(vm, idx)) {
+        be_stack_require(vm, 1 + BE_STACK_FREE_MIN);
+        breal v = be_toreal(vm, idx);
+        if (isnan(v) || isinf(v)) {
+            be_pushstring(vm, "null");
+        } else {
+            be_tostring(vm, idx);
+            be_pushvalue(vm, idx); /* push to top */
+        };
     } else if (be_isnumber(vm, idx) || be_isbool(vm, idx)) { /* convert to json number and boolean */
         be_stack_require(vm, 1 + BE_STACK_FREE_MIN); 
         be_tostring(vm, idx);

--- a/src/be_mathlib.c
+++ b/src/be_mathlib.c
@@ -45,6 +45,17 @@ static int m_isnan(bvm *vm)
     be_return(vm);
 }
 
+static int m_isinf(bvm *vm)
+{
+    if (be_top(vm) >= 1 && be_isreal(vm, 1)) {
+        breal x = be_toreal(vm, 1);
+        be_pushbool(vm, isinf(x));
+    } else {
+        be_pushbool(vm, bfalse);
+    }
+    be_return(vm);
+}
+
 static int m_abs(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
@@ -284,6 +295,7 @@ static int m_rand(bvm *vm)
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(math) {
     be_native_module_function("isnan", m_isnan),
+    be_native_module_function("isinf", m_isinf),
     be_native_module_function("abs", m_abs),
     be_native_module_function("ceil", m_ceil),
     be_native_module_function("floor", m_floor),
@@ -308,6 +320,7 @@ be_native_module_attr_table(math) {
     be_native_module_function("rand", m_rand),
     be_native_module_real("pi", M_PI),
     be_native_module_real("nan", NAN),
+    be_native_module_real("inf", INFINITY),
     be_native_module_int("imax", M_IMAX),
     be_native_module_int("imin", M_IMIN),
 };
@@ -317,6 +330,7 @@ be_define_native_module(math, NULL);
 /* @const_object_info_begin
 module math (scope: global, depend: BE_USE_MATH_MODULE) {
     isnan, func(m_isnan)
+    isinf, func(m_isinf)
     abs, func(m_abs)
     ceil, func(m_ceil)
     floor, func(m_floor)
@@ -341,6 +355,7 @@ module math (scope: global, depend: BE_USE_MATH_MODULE) {
     rand, func(m_rand)
     pi, real(M_PI)
     nan, real(NAN)
+    inf, real(INFINITY)
     imax, int(M_IMAX)
     imin, int(M_IMIN)
 }

--- a/tests/math.be
+++ b/tests/math.be
@@ -10,5 +10,37 @@ assert(math.isnan(n*0))
 
 assert(!math.isnan(0))
 assert(!math.isnan(1.5))
+assert(!math.isnan(math.inf))
 
 assert(n != n)      #- nan is never identical to itself -#
+
+#- inf -#
+i = math.inf
+assert(str(i) == 'inf')
+assert(str(-i) == '-inf')       # inf has a sign
+assert(math.isinf(i))
+assert(math.isinf(i+i))
+assert(math.isinf(i+1))
+# the following result in nan
+assert(math.isnan(i*0))
+assert(math.isnan(i-i))
+assert(math.isnan(i/i))
+
+assert(!math.isinf(0))
+assert(!math.isinf(1.5))
+assert(!math.isinf(math.nan))
+
+assert(i == i)      #- equality works for inf -#
+assert(i == i+1)
+
+#- nan and inf convert to null in json -#
+import json
+
+m_nan = {"v": math.nan}
+assert(json.dump(m_nan) == '{"v":null}')
+m_inf1 = {"v": math.inf}
+assert(json.dump(m_inf1) == '{"v":null}')
+m_inf2 = {"v": -math.inf}
+assert(json.dump(m_inf2) == '{"v":null}')
+m_v = {"v": 3.5}
+assert(json.dump(m_v) == '{"v":3.5}')


### PR DESCRIPTION
Add support for `math.inf` representing the normalized Infinity:
- `math.inf` is infinity (positive), can be set as negative with `-math.inf`
- `math.isinf()` to test if a value is infinity

For `json.dump`, values `inf`, `-inf` and `nan` now convert to `null` which is the best match since `inf` and `nan` are not valid json values.