### PR TITLE
Removing 404 link to berry.readthedocs.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Berry has the following advantages:
 
 Reference Manual: [Wiki](https://github.com/berry-lang/berry/wiki/Reference)
 
-Reference Manual: [Read the docs](https://berry.readthedocs.io/)
-
 Short Manual (slightly outdated): [berry_short_manual.pdf](https://github.com/Skiars/berry_doc/releases/download/latest/berry_short_manual.pdf).
 
 Berry's EBNF grammar definition: [tools/grammar/berry.ebnf](./tools/grammar/berry.ebnf)


### PR DESCRIPTION
Site gone, and no quick find of a replacement, outside of the wiki already listed. Dead link also updated in Tasmota docs.