### PR TITLE
Fix bytes.resize()

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -244,7 +244,7 @@ static unsigned int decode_base64(unsigned char input[], unsigned char output[])
 // shrink or increase. If increase, fill with zeores. Cannot go beyond `size`
 static void buf_set_len(buf_impl* attr, const size_t len)
 {
-    uint32_t old_len = attr->len;
+    int32_t old_len = attr->len;
     attr->len = ((int32_t)len <= attr->size) ? (int32_t)len : attr->size;
     if (old_len < attr->len) {
         memset((void*) &attr->bufptr[old_len], 0, attr->len - old_len);

--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -244,7 +244,7 @@ static unsigned int decode_base64(unsigned char input[], unsigned char output[])
 // shrink or increase. If increase, fill with zeores. Cannot go beyond `size`
 static void buf_set_len(buf_impl* attr, const size_t len)
 {
-    uint16_t old_len = attr->len;
+    uint32_t old_len = attr->len;
     attr->len = ((int32_t)len <= attr->size) ? (int32_t)len : attr->size;
     if (old_len < attr->len) {
         memset((void*) &attr->bufptr[old_len], 0, attr->len - old_len);

--- a/src/be_filelib.c
+++ b/src/be_filelib.c
@@ -79,15 +79,17 @@ static int i_readbytes(bvm *vm)
             be_call(vm, 2); /* call b.resize(size) */
             be_pop(vm, 3);  /* bytes() instance is at top */
 
-            char *buffer = (char*) be_tobytes(vm, -1, NULL); /* we get the address of the internam buffer of size 'size' */
-            size = be_fread(fh, buffer, size);
+            char *buffer = (char*) be_tobytes(vm, -1, NULL); /* we get the address of the internal buffer of size 'size' */
+            size_t read_size = be_fread(fh, buffer, size);
 
-            /* resize if something went wrong */
-            be_getmember(vm, -1, "resize");
-            be_pushvalue(vm, -2);
-            be_pushint(vm, size);
-            be_call(vm, 2); /* call b.resize(size) */
-            be_pop(vm, 3);  /* bytes() instance is at top */
+            if (size != read_size) {
+                /* resize if something went wrong */
+                be_getmember(vm, -1, "resize");
+                be_pushvalue(vm, -2);
+                be_pushint(vm, read_size);
+                be_call(vm, 2); /* call b.resize(size) */
+                be_pop(vm, 3);  /* bytes() instance is at top */
+            }
         } else {
             be_pushbytes(vm, NULL, 0);
         }


### PR DESCRIPTION
Fix `bytes.resize()` that used `uint16_t` instead of `int32_t`.

Optimize `file.readbytes()` when size read has the correct lenght, avoid calling `resize()`