### PR TITLE
File add `savecode` to save bytecode

### DIFF
--- a/src/be_bytecode.c
+++ b/src/be_bytecode.c
@@ -297,6 +297,13 @@ static void save_global_info(bvm *vm, void *fp)
     }
 }
 
+void be_bytecode_save_to_fs(bvm *vm, void *fp, bproto *proto)
+{
+    save_header(fp);
+    save_global_info(vm, fp);
+    save_proto(vm, fp, proto);
+}
+
 void be_bytecode_save(bvm *vm, const char *filename, bproto *proto)
 {
     void *fp = be_fopen(filename, "wb");
@@ -304,9 +311,7 @@ void be_bytecode_save(bvm *vm, const char *filename, bproto *proto)
         bytecode_error(vm, be_pushfstring(vm,
             "can not open file '%s'.", filename));
     } else {
-        save_header(fp);
-        save_global_info(vm, fp);
-        save_proto(vm, fp, proto);
+        be_bytecode_save_to_fs(vm, fp, proto);
         be_fclose(fp);
     }
 }

--- a/src/be_bytecode.h
+++ b/src/be_bytecode.h
@@ -11,6 +11,7 @@
 #include "be_object.h"
 
 void be_bytecode_save(bvm *vm, const char *filename, bproto *proto);
+void be_bytecode_save_to_fs(bvm *vm, void *fp, bproto *proto);
 bclosure* be_bytecode_load(bvm *vm, const char *filename);
 bclosure* be_bytecode_load_from_fs(bvm *vm, void *fp);
 bbool be_bytecode_check(const char *path);

--- a/src/be_filelib.c
+++ b/src/be_filelib.c
@@ -9,6 +9,7 @@
 #include "be_mem.h"
 #include "be_sys.h"
 #include "be_gc.h"
+#include "be_bytecode.h"
 #include <string.h>
 
 #define READLINE_STEP           100
@@ -176,6 +177,26 @@ static int i_close(bvm *vm)
     be_return_nil(vm);
 }
 
+static int i_savecode(bvm *vm)
+{
+    int argc = be_top(vm);
+    if (argc >= 2 && be_isclosure(vm, 2)) {
+        be_getmember(vm, 1, ".p");
+        if (be_iscomptr(vm, -1)) {
+            void *fh = be_tocomptr(vm, -1);
+            bvalue *v = be_indexof(vm, 2);
+            if (var_isclosure(v)) {
+                bclosure *cl = var_toobj(v);
+                bproto *pr = cl->proto;
+                be_bytecode_save_to_fs(vm, fh, pr);
+            }
+        }
+    } else {
+        be_raise(vm, "type_error", "closure expected");
+    }
+    be_return_nil(vm);
+}
+
 #if !BE_USE_PRECOMPILED_OBJECT
 static int m_open(bvm *vm)
 #else
@@ -196,6 +217,7 @@ int be_nfunc_open(bvm *vm)
         { "flush", i_flush },
         { "close", i_close },
         { "deinit", i_close },
+        { "savecode", i_savecode },
         { NULL, NULL }
     };
     fname = argc >= 1 && be_isstring(vm, 1) ? be_tostring(vm, 1) : NULL;


### PR DESCRIPTION
Add method `savecode()` to file object to save bytecode to a file. Currently there is no way to generate bytecode from Berry code, only from `C`.

```berry
pcode = compile("def func() return 42 end")

f = open("func.bec", "w")
f.savecode(pcode)
f.close()
```

Loading works as usual:
```berry
pcode = compile("func.bec", "file")
pcode()

func()
# returns 42
```