### PR TITLE
Raise an exception when file write fails

### DIFF
--- a/src/be_filelib.c
+++ b/src/be_filelib.c
@@ -26,7 +26,10 @@ static int i_write(bvm *vm)
         } else {
             data = be_tobytes(vm, 2, &size);
         }
-        be_fwrite(fh, data, size);
+        size_t bw = be_fwrite(fh, data, size);
+        if (bw != size) {
+            be_raise(vm, "io_error", "write failed");
+        }
     }
     be_return_nil(vm);
 }


### PR DESCRIPTION
`file.write()` does not return any value has no feedback mechanism when writes fails (like filesystem full).

This PR generates an exception when a call to `file.write()` internally resulted in a different number of bytes actually written to what was expected.