### PR TITLE
Support for solidified long strings in coc compiler

### DIFF
--- a/tools/coc/block_builder.py
+++ b/tools/coc/block_builder.py
@@ -23,6 +23,7 @@ class block_builder:
         self.block = block()
         self.strtab = []
         self.strtab_weak = []
+        self.strtab_long = []
 
         self.block.name = obj.name
         if depend(obj, macro):
@@ -159,7 +160,7 @@ class block_builder:
     
     def writefile(self, filename, text):
         otext = "#include \"be_constobj.h\"\n\n" + text
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding='utf-8') as f:
             f.write(otext)
 
     def dumpfile(self, path):

--- a/tools/coc/coc
+++ b/tools/coc/coc
@@ -19,6 +19,7 @@ class builder:
         self.macro = None
         self.strmap = {}
         self.strmap_weak = {}
+        self.strmap_long = {}
 
         self.macro = macro_table()
         for path in self.config:
@@ -27,14 +28,14 @@ class builder:
         for d in self.input:
             self.scandir(d)
         
-        sb = str_build(self.strmap, self.strmap_weak)
+        sb = str_build(self.strmap, self.strmap_weak, self.strmap_long)
         sb.build(self.output)
     
     def parse_file(self, filename):
         if re.search(r"\.(h|c|cc|cpp)$", filename):
             # print(f"> parse {filename}")
             text = ""
-            with open(filename) as f:
+            with open(filename, encoding='utf-8') as f:
                 text = f.read()
             # print(f"> len(text)={len(text)}")
             parser = coc_parser(text)
@@ -42,12 +43,16 @@ class builder:
                 self.strmap[s] = 0
             for s in parser.strtab_weak:
                 self.strmap_weak[s] = 0
+            for s in parser.strtab_long:
+                self.strmap_long[s] = 0
             for obj in parser.objects:
                 builder = block_builder(obj, self.macro)
                 for s in builder.strtab:
                     self.strmap[s] = 0
                 for s in builder.strtab_weak:
                     self.strmap_weak[s] = 0
+                for s in builder.strtab_long:
+                    self.strmap_long[s] = 0
                 builder.dumpfile(self.output)
 
     def scandir(self, srcpath):

--- a/tools/coc/macro_table.py
+++ b/tools/coc/macro_table.py
@@ -22,7 +22,7 @@ class macro_table:
     
     def scan_file(self, filename):
         str = ""
-        with open(filename) as f:
+        with open(filename, encoding='utf-8') as f:
            str = f.read()
         r = macro_table.pat.findall(str)
         for it in r:


### PR DESCRIPTION
Follow up of #398, gives the ability for the `coc` compiler to handle long string literals solidified