### PR TITLE
Fixing link to short manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ Berry has the following advantages:
 
 ## Documents
 
-Reference Manual: [Wiki](https://github.com/berry-lang/berry/wiki/Reference)
-
 Reference Manual: [Read the docs](https://berry.readthedocs.io/)
 
-Short Manual (slightly outdated): [berry_short_manual.pdf](https://github.com/Skiars/berry_doc/releases/download/latest/berry_short_manual.pdf).
+Short Manual: [berry_short_manual.pdf](https://github.com/berry-lang/berry_doc/blob/master/pdf/berry_short_manual.pdf).
 
 Berry's EBNF grammar definition: [tools/grammar/berry.ebnf](./tools/grammar/berry.ebnf)
 


### PR DESCRIPTION
Fixing broken link to the short manual, and no longer indicating "slightly outdated". Also removed link to the defunct wiki.