### PR TITLE
Use be_assert() in be_module_setmember instead of assert()

### DIFF
--- a/src/be_module.c
+++ b/src/be_module.c
@@ -355,7 +355,7 @@ int be_module_attr(bvm *vm, bmodule *module, bstring *attr, bvalue *dst)
 
 bbool be_module_setmember(bvm *vm, bmodule *module, bstring *attr, bvalue *src)
 {
-    assert(src);
+    be_assert(src);
     bmap *attrs = module->table;
     if (!gc_isconst(attrs)) {
         bvalue *v = be_map_findstr(vm, attrs, attr);


### PR DESCRIPTION
when I was trying to port berry to my OS, I've noticed that the interpreter will not compile due to lack of assert() macro. I've fixed this by changing assert() to be_assert() in be_module.c on line 358. Now I only get linker errors due to unimplemented functions, but the C compiler no longer complains about missing assert().