### PR TITLE
Add missing math library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ endif ()
 
 file(MAKE_DIRECTORY generate)
 
+if(NOT WIN32)
+  find_library(MATH_LIBRARY m)
+else()
+  set(MATH_LIBRARY "")
+endif()
+
 # berry library
 file(GLOB SOURCES src/*.c)
 add_library(libberry ${SOURCES})
@@ -35,4 +41,4 @@ add_dependencies(libberry berry-coc)
 # berry default exe
 file(GLOB SOURCES_EXE default/*.c)
 add_executable(berry ${SOURCES_EXE})
-target_link_libraries(berry PUBLIC libberry)
+target_link_libraries(berry PUBLIC libberry ${MATH_LIBRARY})


### PR DESCRIPTION
Fixes the following linking error:

  [100%] Linking C executable bin/berry
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_ceil':
  be_mathlib.c:(.text+0x23d): undefined reference to `ceil'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_floor':
  be_mathlib.c:(.text+0x2d4): undefined reference to `floor'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_round':
  be_mathlib.c:(.text+0x36b): undefined reference to `round'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_sin':
  be_mathlib.c:(.text+0x402): undefined reference to `sin'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_cos':
  be_mathlib.c:(.text+0x499): undefined reference to `cos'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_tan':
  be_mathlib.c:(.text+0x530): undefined reference to `tan'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_asin':
  be_mathlib.c:(.text+0x5c7): undefined reference to `asin'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_acos':
  be_mathlib.c:(.text+0x65e): undefined reference to `acos'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_atan':
  be_mathlib.c:(.text+0x6f5): undefined reference to `atan'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_atan2':
  be_mathlib.c:(.text+0x7c9): undefined reference to `atan2'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_sinh':
  be_mathlib.c:(.text+0x860): undefined reference to `sinh'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_cosh':
  be_mathlib.c:(.text+0x8f7): undefined reference to `cosh'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_tanh':
  be_mathlib.c:(.text+0x98e): undefined reference to `tanh'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_sqrt':
  be_mathlib.c:(.text+0xa25): undefined reference to `sqrt'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_exp':
  be_mathlib.c:(.text+0xabc): undefined reference to `exp'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_log':
  be_mathlib.c:(.text+0xb53): undefined reference to `log'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_log10':
  be_mathlib.c:(.text+0xbea): undefined reference to `log10'
  /usr/bin/ld: lib/liblibberry.a(be_mathlib.c.o): in function `m_pow':
  be_mathlib.c:(.text+0xdf2): undefined reference to `pow'
  /usr/bin/ld: lib/liblibberry.a(be_vm.c.o): in function `vm_exec':
  be_vm.c:(.text+0x31e2): undefined reference to `fmod'
  collect2: error: ld returned 1 exit status
  make[2]: *** [CMakeFiles/berry.dir/build.make:130: bin/berry] Error 1
  make[1]: *** [CMakeFiles/Makefile2:138: CMakeFiles/berry.dir/all] Error 2
  make: *** [Makefile:91: all] Error 2

using recent gcc/ld compiler/linker available on Fedora 40:

  $ gcc --version | head -n 1
  gcc (GCC) 14.2.1 20240801 (Red Hat 14.2.1-1)

  $ ld --version | head -n1
  GNU ld version 2.41-37.fc40