### PR TITLE
bytes() can be solidified

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -16,28 +16,7 @@
 #include "be_constobj.h"
 #include <string.h>
 #include <ctype.h>
-
-#define BYTES_DEFAULT_SIZE          28              // default pre-reserved size for buffer (keep 4 bytes for len/size)
-#define BYTES_OVERHEAD              4               // bytes overhead to be added when allocating (used to store len and size)
-#define BYTES_HEADROOM              8               // keep a natural headroom of 8 bytes when resizing
-
-#define BYTES_SIZE_FIXED            -1              // if size is -1, then the bytes object cannot be reized
-#define BYTES_SIZE_MAPPED           -2              // if size is -2, then the bytes object is mapped to a fixed memory region, i.e. cannot be resized
-
-#define BYTES_RESIZE_ERROR          "attribute_error"
-#define BYTES_RESIZE_MESSAGE        "bytes object size if fixed and cannot be resized"
-/* be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE); */
-
-typedef struct buf_impl {
-  int32_t size;               // size in bytes of the buffer
-  int32_t len;                // current size of the data in buffer. Invariant: len <= size
-  uint8_t *bufptr;            // the actual data
-  int32_t prev_size;          // previous value read from the instance
-  int32_t prev_len;           // previous value read from the instance
-  uint8_t *prev_bufptr;
-  bbool   fixed;              // is size fixed? (actually encoded as negative size)
-  bbool   mapped;
-} buf_impl;
+#include "be_byteslib.h"
 
 /********************************************************************
 ** Base64 lib from https://github.com/Densaugeo/base64_arduino
@@ -481,7 +460,16 @@ static void buf_add_hex(buf_impl* attr, const char *hex, size_t len)
 ********************************************************************/
 
 /* if the bufptr is null, don't try to dereference and raise an exception instead */
-static void check_ptr(bvm *vm, buf_impl* attr) {
+static void check_ptr(bvm *vm, const buf_impl* attr) {
+    if (!attr->bufptr) {
+        be_raise(vm, "value_error", "operation not allowed on <null> pointer");
+    }
+}
+
+static void check_ptr_modifiable(bvm *vm, const buf_impl* attr) {
+    if (attr->solidified) {
+     be_raise(vm, "value_error", BYTES_READ_ONLY_MESSAGE);
+    }
     if (!attr->bufptr) {
         be_raise(vm, "value_error", "operation not allowed on <null> pointer");
     }
@@ -504,9 +492,13 @@ buf_impl m_read_attributes(bvm *vm, int idx)
     int32_t signed_size = be_toint(vm, -1);
     attr.fixed = bfalse;
     attr.mapped = bfalse;
+    attr.solidified = bfalse;
     if (signed_size < 0) {
         if (signed_size == BYTES_SIZE_MAPPED) {
             attr.mapped = btrue;
+        }
+        if (signed_size == BYTES_SIZE_SOLIDIFIED) {
+            attr.solidified = btrue;
         }
         signed_size = attr.len;
         attr.fixed = btrue;
@@ -516,10 +508,18 @@ buf_impl m_read_attributes(bvm *vm, int idx)
     return attr;
 }
 
+static void m_assert_not_readlonly(bvm *vm, const buf_impl* attr)
+{
+    if (attr->solidified) {
+     be_raise(vm, "value_error", BYTES_READ_ONLY_MESSAGE);
+    }
+}
+
 /* Write back attributes to the bytes instance, only if values changed after loading */
 /* stack item 1 must contain the instance */
 void m_write_attributes(bvm *vm, int rel_idx, const buf_impl * attr)
 {
+    m_assert_not_readlonly(vm, attr);
     int idx = be_absindex(vm, rel_idx);
     if (attr->bufptr != attr->prev_bufptr) {
         be_pushcomptr(vm, attr->bufptr);
@@ -547,8 +547,9 @@ void m_write_attributes(bvm *vm, int rel_idx, const buf_impl * attr)
 }
 
 // buf_impl * bytes_realloc(bvm *vm, buf_impl *oldbuf, int32_t size)
-void bytes_realloc(bvm *vm, buf_impl * attr, int32_t size)
+void bytes_realloc(bvm *vm, buf_impl * attr, size_t size)
 {
+    m_assert_not_readlonly(vm, attr);
     if (!attr->fixed && size < 4) { size = 4; }
     if (size > vm->bytesmaxsize) { size = vm->bytesmaxsize; }
     size_t oldsize = attr->bufptr ? attr->size : 0;
@@ -590,7 +591,7 @@ static void bytes_new_object(bvm *vm, size_t size)
 static int m_init(bvm *vm)
 {
     int argc = be_top(vm);
-    buf_impl attr = { 0, 0, NULL, 0, -1, NULL, bfalse, bfalse }; /* initialize prev_values to invalid to force a write at the end */
+    buf_impl attr = { 0, 0, NULL, 0, -1, NULL, bfalse, bfalse, bfalse }; /* initialize prev_values to invalid to force a write at the end */
     /* size cannot be 0, len cannot be negative */
     const char * hex_in = NULL;
 
@@ -713,7 +714,7 @@ buf_impl bytes_check_data(bvm *vm, size_t add_size) {
     return attr;
 }
 
-static size_t tohex(char * out, size_t outsz, const uint8_t * in, size_t insz) {
+size_t be_bytes_tohex(char * out, size_t outsz, const uint8_t * in, size_t insz) {
   static const char * hex = "0123456789ABCDEF";
   const uint8_t * pin = in;
   char * pout = out;
@@ -745,7 +746,7 @@ static int m_tostring(bvm *vm)
 
         char * hex_out = be_pushbuffer(vm, hex_len);
         size_t l = be_strlcpy(hex_out, "bytes('", hex_len);
-        l += tohex(&hex_out[l], hex_len - l, attr.bufptr, len);
+        l += be_bytes_tohex(&hex_out[l], hex_len - l, attr.bufptr, len);
         if (truncated) {
             l += be_strlcpy(&hex_out[l], "...", hex_len - l);
         }
@@ -767,7 +768,7 @@ static int m_tohex(bvm *vm)
         size_t hex_len = len * 2 + 1;
 
         char * hex_out = be_pushbuffer(vm, hex_len);
-        size_t l = tohex(hex_out, hex_len, attr.bufptr, len);
+        size_t l = be_bytes_tohex(hex_out, hex_len, attr.bufptr, len);
 
         be_pushnstring(vm, hex_out, l); /* make escape string from buffer */
         be_remove(vm, -2); /* remove buffer */
@@ -795,7 +796,7 @@ static int m_fromstring(bvm *vm)
         const char *s = be_tostring(vm, 2);
         int32_t len = be_strlen(vm, 2);      /* calling be_strlen to support null chars in string */
         buf_impl attr = bytes_check_data(vm, 0);
-        check_ptr(vm, &attr);
+        check_ptr_modifiable(vm, &attr);
         if (attr.fixed && attr.len != len) {
             be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE);
         }
@@ -823,7 +824,7 @@ static int m_add(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 4); /* we reserve 4 bytes anyways */
-    check_ptr(vm, &attr);
+    check_ptr_modifiable(vm, &attr);
     if (attr.fixed) { be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE); }
     if (argc >= 2 && be_isint(vm, 2)) {
         int32_t v = be_toint(vm, 2);
@@ -957,7 +958,7 @@ static int m_set(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
-    check_ptr(vm, &attr);
+    check_ptr_modifiable(vm, &attr);
     if (argc >=3 && be_isint(vm, 2) && be_isint(vm, 3)) {
         int32_t idx = be_toint(vm, 2);
         int32_t value = be_toint(vm, 3);
@@ -999,7 +1000,7 @@ static int m_setfloat(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
-    check_ptr(vm, &attr);
+    check_ptr_modifiable(vm, &attr);
     if (argc >=3 && be_isint(vm, 2) && (be_isint(vm, 3) || be_isreal(vm, 3))) {
         int32_t idx = be_toint(vm, 2);
         if (idx < 0) {
@@ -1030,7 +1031,7 @@ static int m_addfloat(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 4); /* we reserve 4 bytes anyways */
-    check_ptr(vm, &attr);
+    check_ptr_modifiable(vm, &attr);
     if (attr.fixed) { be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE); }
     if (argc >=2 && (be_isint(vm, 2) || be_isreal(vm, 2))) {
         float val_f = (float) be_toreal(vm, 2);
@@ -1059,7 +1060,7 @@ static int m_setbytes(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
-    check_ptr(vm, &attr);
+    check_ptr_modifiable(vm, &attr);
     if (argc >=3 && be_isint(vm, 2) && (be_isbytes(vm, 3))) {
         int32_t idx = be_toint(vm, 2);
         size_t from_len_total;
@@ -1106,7 +1107,7 @@ static int m_reverse(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
-    check_ptr(vm, &attr);
+    check_ptr_modifiable(vm, &attr);
 
     int32_t idx = 0;            /* start from index 0 */
     int32_t len = attr.len;     /* entire len */
@@ -1158,7 +1159,7 @@ static int m_setitem(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
-    check_ptr(vm, &attr);
+    check_ptr_modifiable(vm, &attr);
     if (argc >=3 && be_isint(vm, 2) && be_isint(vm, 3)) {
         int index = be_toint(vm, 2);
         int val = be_toint(vm, 3);
@@ -1179,7 +1180,6 @@ static int m_item(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
-    check_ptr(vm, &attr);
     if (argc >=2 && be_isint(vm, 2)) {  /* single byte */
         int index = be_toint(vm,2);
         if (index < 0) {
@@ -1241,6 +1241,7 @@ static int m_resize(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = m_read_attributes(vm, 1);
+    check_ptr_modifiable(vm, &attr);
 
     if (argc <= 1 || !be_isint(vm, 2)) {
         be_raise(vm, "type_error", "size must be of type 'int'");
@@ -1263,6 +1264,7 @@ static int m_resize(bvm *vm)
 static int m_clear(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
+    check_ptr_modifiable(vm, &attr);
     if (attr.fixed) { be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE); }
     attr.len = 0;
     m_write_attributes(vm, 1, &attr);  /* update instance */
@@ -1319,7 +1321,7 @@ static int m_connect(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = m_read_attributes(vm, 1);
-    check_ptr(vm, &attr);
+    check_ptr_modifiable(vm, &attr);
     if (attr.fixed) { be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE); }
     if (argc >= 2 && (be_isbytes(vm, 2) || be_isint(vm, 2) || be_isstring(vm, 2))) {
         if (be_isint(vm, 2)) {
@@ -1416,7 +1418,7 @@ static int m_fromb64(bvm *vm)
         int32_t bin_len = decode_base64_length((unsigned char*)s);   /* do a first pass to calculate the buffer size */
 
         buf_impl attr = m_read_attributes(vm, 1);
-        check_ptr(vm, &attr);
+        check_ptr_modifiable(vm, &attr);
         if (attr.fixed && attr.len != bin_len) {
             be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE);
         }
@@ -1455,7 +1457,7 @@ static int m_fromhex(bvm *vm)
         int32_t bin_len = (s_len - from) / 2;
 
         buf_impl attr = m_read_attributes(vm, 1);
-        check_ptr(vm, &attr);
+        check_ptr_modifiable(vm, &attr);
         if (attr.fixed && attr.len != bin_len) {
             be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE);
         }
@@ -1510,6 +1512,18 @@ static int m_is_mapped(bvm *vm)
 }
 
 /*
+ * Returns `btrue` if the buffer is solidified and read only
+ * 
+ * `isreadonly() -> bool`
+ */
+static int m_is_readonly(bvm *vm)
+{
+    buf_impl attr = m_read_attributes(vm, 1);
+    be_pushbool(vm, attr.solidified);
+    be_return(vm);
+}
+
+/*
  * Change the pointer to a mapped buffer.
  * 
  * This call does nothing if the buffer is not mapped (i.e. memory is managed externally)
@@ -1523,6 +1537,9 @@ static int m_change_buffer(bvm *vm)
     int argc = be_top(vm);
     if (argc >= 2 && be_iscomptr(vm, 2)) {
         buf_impl attr = m_read_attributes(vm, 1);
+        if (attr.solidified) {
+            be_raise(vm, "value_error", BYTES_READ_ONLY_MESSAGE);
+        }
         if (!attr.mapped) {
             be_raise(vm, "type_error", "bytes() object must be mapped");
         }
@@ -1790,11 +1807,12 @@ void be_load_byteslib(bvm *vm)
 {
     static const bnfuncinfo members[] = {
         { ".p", NULL },
-        { ".size", NULL },
         { ".len", NULL },
+        { ".size", NULL },
         { "_buffer", m_buffer },
         { "_change_buffer", m_change_buffer },
         { "ismapped", m_is_mapped },
+        { "isreadonly", m_is_readonly },
         { "init", m_init },
         { "deinit", m_deinit },
         { "tostring", m_tostring },
@@ -1836,14 +1854,18 @@ void be_load_byteslib(bvm *vm)
     be_regclass(vm, "bytes", members);
 }
 #else
+
+#include "../generate/be_const_bytes_def.h"
+
 /* @const_object_info_begin
 class be_class_bytes (scope: global, name: bytes) {
     .p, var
-    .size, var
     .len, var
+    .size, var
     _buffer, func(m_buffer)
     _change_buffer, func(m_change_buffer)
     ismapped, func(m_is_mapped)
+    isreadonly, func(m_is_readonly)
     init, func(m_init)
     deinit, func(m_deinit)
     tostring, func(m_tostring)

--- a/src/be_byteslib.h
+++ b/src/be_byteslib.h
@@ -1,0 +1,44 @@
+/********************************************************************
+** Copyright (c) 2018-2020 Guan Wenliang - Stephan Hadinger
+** This file is part of the Berry default interpreter.
+** skiars@qq.com, https://github.com/Skiars/berry
+** See Copyright Notice in the LICENSE file or at
+** https://github.com/Skiars/berry/blob/master/LICENSE
+********************************************************************/
+#ifndef __BE_BYTESLIB_H
+#define __BE_BYTESLIB_H
+
+#include "be_object.h"
+
+#define BYTES_DEFAULT_SIZE          28              /* default pre-reserved size for buffer (keep 4 bytes for len/size) */
+#define BYTES_OVERHEAD              4               /* bytes overhead to be added when allocating (used to store len and size) */
+#define BYTES_HEADROOM              8               /* keep a natural headroom of 8 bytes when resizing */
+
+#define BYTES_SIZE_FIXED            -1              /* if size is -1, then the bytes object cannot be reized */
+#define BYTES_SIZE_MAPPED           -2              /* if size is -2, then the bytes object is mapped to a fixed memory region, i.e. cannot be resized */
+#define BYTES_SIZE_SOLIDIFIED       -3              /* is size is -3, then the bytes object is solidified and cannot be resized nor modified */
+
+#define BYTES_RESIZE_ERROR          "attribute_error"
+#define BYTES_RESIZE_MESSAGE        "bytes object size if fixed and cannot be resized"
+#define BYTES_READ_ONLY_MESSAGE     "bytes object is read only"
+/* be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE); */
+
+typedef struct buf_impl {
+  int32_t size;               // size in bytes of the buffer
+  int32_t len;                // current size of the data in buffer. Invariant: len <= size
+  uint8_t *bufptr;            // the actual data
+  int32_t prev_size;          // previous value read from the instance
+  int32_t prev_len;           // previous value read from the instance
+  uint8_t *prev_bufptr;
+  bbool   fixed;              // is size fixed? (actually encoded as negative size)
+  bbool   mapped;
+  bbool   solidified;
+} buf_impl;
+
+size_t be_bytes_tohex(char * out, size_t outsz, const uint8_t * in, size_t insz);
+
+#if BE_USE_PRECOMPILED_OBJECT
+#include "../generate/be_const_bytes.h"
+#endif
+
+#endif

--- a/src/be_class.h
+++ b/src/be_class.h
@@ -49,6 +49,16 @@ struct binstance {
     bvalue members[1]; /* members variable data field */
 };
 
+/* special structure accepting 3 instance variables used only for bytes() solidification */
+struct binstance_arg3 {
+    bcommon_header;
+    struct binstance *super;
+    struct binstance *sub;
+    bclass *_class;
+    bgcobject *gray; /* for gc gray list */
+    bvalue members[3]; /* members variable data field */
+};
+
 bclass* be_newclass(bvm *vm, bstring *name, bclass *super);
 void be_class_compress(bvm *vm, bclass *c);
 int be_class_attribute(bvm *vm, bclass *c, bstring *attr);

--- a/src/be_code.c
+++ b/src/be_code.c
@@ -307,7 +307,7 @@ static int exp2const(bfuncinfo *finfo, bexpdesc *e)
 {
     int idx = findconst(finfo, e); /* does the constant already exist? */
     if (idx == -1) { /* if not add it */
-        bvalue k;
+        bvalue k = {0};
         switch (e->type) {
         case ETINT:
             k.type = BE_INT;
@@ -882,7 +882,7 @@ void be_code_index(bfuncinfo *finfo, bexpdesc *c, bexpdesc *k)
 void be_code_class(bfuncinfo *finfo, bexpdesc *dst, bclass *c)
 {
     int src;
-    bvalue var;
+    bvalue var = {0};
     var_setclass(&var, c);  /* new var of CLASS type */
     src = newconst(finfo, &var);  /* allocate a new constant and return kreg */
     if (dst->type == ETLOCAL) {  /* if target is a local variable, just assign */
@@ -965,7 +965,7 @@ void be_code_raise(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2)
 
 void be_code_implicit_class(bfuncinfo *finfo, bexpdesc *e, bclass *c)
 {
-    bvalue k;
+    bvalue k = {0};
     k.type = BE_CLASS;
     k.v.p = c;
     int idx = newconst(finfo, &k);  /* create new constant */

--- a/src/be_constobj.h
+++ b/src/be_constobj.h
@@ -19,6 +19,7 @@ extern "C" {
 #include "be_class.h"
 #include "be_string.h"
 #include "be_module.h"
+#include "be_byteslib.h"
 
 #ifndef __cplusplus
 
@@ -26,6 +27,40 @@ extern "C" {
     .next = NULL,                                               \
     .type = (_t),                                               \
     .marked = GC_CONST
+
+#define be_define_const_bytes(_name, ...)                               \
+    const binstance_arg3 be_const_instance_##_name = {                  \
+        be_const_header(BE_INSTANCE),                                   \
+        .super = NULL,                                                  \
+        .sub = NULL,                                                    \
+        ._class = (bclass*) &be_class_bytes,                            \
+        .members = {                                                    \
+            {.v.c = (const void*) & (const uint8_t[]) { __VA_ARGS__ },  \
+            .type = BE_COMPTR },                                        \
+            be_const_int(sizeof(#_name) / 2),                           \
+            be_const_int(BYTES_SIZE_SOLIDIFIED)                         \
+        }                                                               \
+    }
+
+/* special version to define a default empty bytes */
+#define be_define_const_bytes_empty()                                   \
+    const binstance_arg3 be_const_instance_ = {                         \
+        be_const_header(BE_INSTANCE),                                   \
+        .super = NULL,                                                  \
+        .sub = NULL,                                                    \
+        ._class = (bclass*) &be_class_bytes,                            \
+        .members = {                                                    \
+            {.v.c = (const void*) & (const uint8_t[]) { 0x00 },         \
+            .type = BE_COMPTR },                                        \
+            be_const_int(0),                                            \
+            be_const_int(BYTES_SIZE_SOLIDIFIED)                         \
+        }                                                               \
+    }
+
+#define be_const_bytes_instance(_bytes) {                               \
+    .v.c = &be_const_instance_##_bytes,                                 \
+    .type = BE_INSTANCE                                                 \
+}
 
 #define be_define_const_str_weak(_name, _s, _len)               \
     const bcstring be_const_str_##_name = {                     \
@@ -230,6 +265,27 @@ const bntvmodule_t be_native_module(_module) = {                  \
     .sub = NULL,                                                \
     ._class = (bclass*) _class_ptr,                             \
     .members = _members                                         \
+  }
+
+#define be_nested_simple_instance_1_arg(_class_ptr, arg0) \
+  & (const binstance)  {                                        \
+    be_const_header(BE_INSTANCE),                               \
+    .super = NULL,                                              \
+    .sub = NULL,                                                \
+    ._class = (bclass*) _class_ptr,                             \
+    .members = { arg0 }                                         \
+  }
+
+
+/* only instances with no super and no sub instance are supported */
+/* primarily for `list` and `map`*/
+#define be_nested_simple_instance_3_args(_class_ptr, arg0, arg1, arg2) \
+  & (const binstance_arg3)  {                                   \
+    be_const_header(BE_INSTANCE),                               \
+    .super = NULL,                                              \
+    .sub = NULL,                                                \
+    ._class = (bclass*) _class_ptr,                             \
+    .members = { arg0, arg1, arg2 }                             \
   }
 
 #define be_nested_map(_size, _slots)                            \
@@ -440,6 +496,7 @@ const bntvmodule_t be_native_module_##_module = {               \
 /* provide pointers to map and list classes for solidified code */
 extern const bclass be_class_list;
 extern const bclass be_class_map;
+extern const bclass be_class_bytes;
 
 #ifdef __cplusplus
 }

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -21,7 +21,7 @@
 #define BE_FUNCTION     6
 
 #define BE_GCOBJECT     16      /* from this type can be gced */
-#define BE_GCOBJECT_MAX (3<<5)  /* from this type can't be gced */
+#define BE_GCOBJECT_MAX (3<<5)  /* 96 - from this type can't be gced */
 
 #define BE_STRING       16
 #define BE_CLASS        17
@@ -32,20 +32,18 @@
 #define BE_MODULE       22
 #define BE_COMOBJ       23      /* common object */
 
-#define BE_NTVFUNC      ((0 << 5) | BE_FUNCTION)
-#define BE_CLOSURE      ((1 << 5) | BE_FUNCTION)
-#define BE_NTVCLOS      ((2 << 5) | BE_FUNCTION)
-#define BE_CTYPE_FUNC   ((3 << 5) | BE_FUNCTION)
-#define BE_STATIC       (1 << 7)
-
-#define func_isstatic(o)       (((o)->type & BE_STATIC) != 0)
-#define func_setstatic(o)      ((o)->type |= BE_STATIC)
-#define func_clearstatic(o)    ((o)->type &= ~BE_STATIC)
+#define BE_NTVFUNC      ((0 << 5) | BE_FUNCTION)    /* 6 - cannot be gced */
+#define BE_CLOSURE      ((1 << 5) | BE_FUNCTION)    /* 38 - can be gced */
+#define BE_NTVCLOS      ((2 << 5) | BE_FUNCTION)    /* 70 - can be gced*/
+#define BE_CTYPE_FUNC   ((3 << 5) | BE_FUNCTION)    /* 102 - cannot be gced */
+#define BE_STATIC       (1 << 7)                    /* 128 */
 
 /* values for bproto.varg */
 #define BE_VA_VARARG            (1 << 0)    /* function has variable number of arguments */
 #define BE_VA_METHOD            (1 << 1)    /* function is a method (this is only a hint) */
 #define BE_VA_STATICMETHOD      (1 << 2)    /* the function is a static method and has the class as implicit '_class' variable */
+#define BE_VA_SHARED_KTAB       (1 << 3)    /* the funciton has a shared consolidated ktab */
+#define BE_VA_NOCOMPACT         (1 << 4)    /* the funciton has a shared consolidated ktab */
 #define array_count(a)   (sizeof(a) / sizeof((a)[0]))
 
 #define bcommon_header          \
@@ -66,6 +64,7 @@ typedef struct bclosure bclosure;
 typedef struct bntvclos bntvclos;
 typedef struct bclass bclass;
 typedef struct binstance binstance;
+typedef struct binstance_arg3 binstance_arg3;
 typedef struct blist blist;
 typedef struct bmap bmap;
 typedef struct bupval bupval;

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -42,8 +42,6 @@
 #define BE_VA_VARARG            (1 << 0)    /* function has variable number of arguments */
 #define BE_VA_METHOD            (1 << 1)    /* function is a method (this is only a hint) */
 #define BE_VA_STATICMETHOD      (1 << 2)    /* the function is a static method and has the class as implicit '_class' variable */
-#define BE_VA_SHARED_KTAB       (1 << 3)    /* the funciton has a shared consolidated ktab */
-#define BE_VA_NOCOMPACT         (1 << 4)    /* the funciton has a shared consolidated ktab */
 #define array_count(a)   (sizeof(a) / sizeof((a)[0]))
 
 #define bcommon_header          \

--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -17,6 +17,8 @@
 #include "be_decoder.h"
 #include "be_sys.h"
 #include "be_mem.h"
+#include "be_byteslib.h"
+#include "be_gc.h"
 #include <string.h>
 #include <stdio.h>
 #include <ctype.h>
@@ -24,6 +26,7 @@
 
 extern const bclass be_class_list;
 extern const bclass be_class_map;
+extern const bclass be_class_bytes;
 
 #if BE_USE_SOLIDIFY_MODULE
 #include <inttypes.h>
@@ -263,14 +266,24 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, bvalue * value, const 
     {
         binstance * ins = (binstance *) var_toobj(value);
         bclass * cl = ins->_class;
-        if (ins->super || ins->sub) {
+
+        if (cl ==  &be_class_bytes) {
+            const void * bufptr = var_toobj(&ins->members[0]);
+            int32_t len = var_toint(&ins->members[1]);
+            size_t hex_len = len * 2 + 1;
+
+            char * hex_out = be_pushbuffer(vm, hex_len);
+            be_bytes_tohex(hex_out, hex_len, bufptr, len);
+            logfmt("be_const_bytes_instance(%s)", hex_out);
+            be_pop(vm, 1);
+        } else if (ins->super || ins->sub) {
             be_raise(vm, "internal_error", "instance must not have a super/sub class");
-        } else if (cl->nvar != 1) {
-            be_raise(vm, "internal_error", "instance must have only one instance variable");
-        } else if ((cl != &be_class_map && cl != &be_class_list) || 1) {   // TODO
+        } else {
             const char * cl_ptr = "";
             if (cl == &be_class_map) { cl_ptr = "map"; }
-            if (cl == &be_class_list) { cl_ptr = "list"; }
+            else if (cl == &be_class_list) { cl_ptr = "list"; }
+            else { be_raise(vm, "internal_error", "unsupported class"); }
+
             logfmt("be_const_simple_instance(be_nested_simple_instance(&be_class_%s, {\n", cl_ptr);
             if (cl == &be_class_map) {
                 logfmt("        be_const_map( * ");

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -110,7 +110,7 @@ struct bvm {
     struct bgc gc;
     bctypefunc ctypefunc; /* handler to ctype_func */
     bbyte compopt; /* compilation options */
-    int32_t bytesmaxsize; /* max allowed size for bytes() object, default 32kb but can be increased */
+    size_t bytesmaxsize; /* max allowed size for bytes() object, default 32kb but can be increased */
     bobshook obshook;
 #if BE_USE_PERF_COUNTERS
     uint32_t counter_ins; /* instructions counter */

--- a/tools/coc/bytes_build.py
+++ b/tools/coc/bytes_build.py
@@ -1,0 +1,41 @@
+import json
+
+class bytes_build:
+    def __init__(self, map):
+        self.map = map.copy()
+
+    def build(self, path):
+        prefix = path + "/be_const_bytes"
+        self.writefile(prefix + "_def.h", self.build_bytes_def())
+        self.writefile(prefix + ".h", self.build_bytes_ext())
+    
+    def writefile(self, filename, text):
+        buf = ""
+        try:
+            with open(filename) as f:
+                buf = f.read()
+        except FileNotFoundError:
+            pass
+        if buf != text:
+            with open(filename, "w") as f:
+                f.write(text)
+    
+    def build_bytes_def(self):
+        ostr = ""
+        ostr += "/* binary arrays */\n"
+        ostr += "be_define_const_bytes_empty();\n"
+        for k in self.map:
+            ostr += "be_define_const_bytes("
+            ostr += k + ", " + ", ".join( [ "0x" + k[i:i+2] for i in range(0, len(k), 2)] )
+            ostr += ");\n"
+
+        return ostr
+
+    def build_bytes_ext(self):
+        ostr = ""
+        ostr += "/* extern binary arrays */\n"
+        ostr += "extern const binstance_arg3 be_const_instance_;\n"
+        for k in self.map:
+            ostr += "extern const binstance_arg3 be_const_instance_" + k + ";\n"
+
+        return ostr

--- a/tools/coc/coc
+++ b/tools/coc/coc
@@ -4,6 +4,7 @@ import re
 import os
 from coc_parser import *
 from str_build import *
+from bytes_build import *
 from block_builder import *
 from macro_table import *
 
@@ -20,6 +21,7 @@ class builder:
         self.strmap = {}
         self.strmap_weak = {}
         self.strmap_long = {}
+        self.bytesmap = {}
 
         self.macro = macro_table()
         for path in self.config:
@@ -30,6 +32,9 @@ class builder:
         
         sb = str_build(self.strmap, self.strmap_weak, self.strmap_long)
         sb.build(self.output)
+
+        sbytes = bytes_build(self.bytesmap)
+        sbytes.build(self.output)
     
     def parse_file(self, filename):
         if re.search(r"\.(h|c|cc|cpp)$", filename):
@@ -45,6 +50,8 @@ class builder:
                 self.strmap_weak[s] = 0
             for s in parser.strtab_long:
                 self.strmap_long[s] = 0
+            for s in parser.bintab:
+                self.bytesmap[s] = 0
             for obj in parser.objects:
                 builder = block_builder(obj, self.macro)
                 for s in builder.strtab:

--- a/tools/coc/coc_parser.py
+++ b/tools/coc/coc_parser.py
@@ -23,10 +23,12 @@ class coc_parser:
         self.strtab = set()
         self.strtab_weak = set()
         self.strtab_long = set()
+        self.bintab = set()
         self.text = text
         self.parsers = {
             "@const_object_info_begin": self.parse_object,
             "be_const_str_": self.parse_string,
+            "be_const_bytes_instance(": self.parse_bin,
             "be_const_key(": self.parse_string,
             "be_nested_str(": self.parse_string,
             "be_const_key_weak(": self.parse_string_weak,

--- a/tools/coc/hash_map.py
+++ b/tools/coc/hash_map.py
@@ -27,6 +27,13 @@ class hash_map:
         self.bucket = []
 
         self.resize(2)
+        var_count = 0
+        # replace any 'var' by its slot number
+        for (key, value) in map.items():
+            if value == "var":
+                map[key] = var_count
+                var_count += 1
+
         for key in sorted(map.keys()):
             self.insert(key, map[key])
     
@@ -115,27 +122,21 @@ class hash_map:
     # Compute entries in the hash for modules or classes
     #################################################################################
     # return a list (entiry, var_count)
-    def entry_modify(self, ent, var_count):
+    def entry_modify(self, ent):
         ent.key = escape_operator(ent.key)
-        if ent.value == "var":
-            ent.value = "be_const_var(" + str(var_count) + ")"
-            var_count += 1
+        if isinstance(ent.value, int):
+            ent.value = "be_const_var(" + str(ent.value) + ")"
         else:
             ent.value = "be_const_" + ent.value
-        return (ent, var_count)
+        return ent
     
     #  generate the final map
     def entry_list(self):
         l = []
-        var_count = 0
         
         self.resize(self.count)
         for it in self.bucket:
-            (ent, var_count) = self.entry_modify(it, var_count)
-            # print(f"ent={ent} var_count={var_count}")
-            # # ex: ent=<entry object; key='arg', value='be_const_func(w_webserver_arg)', next=-1> var_count=0
-            # # ex: ent=<entry object; key='check_privileged_access2', value='be_const_func(w_webserver_check_privileged_access_ntv, "b", "")', next=-1> var_count=0
-            l.append(ent)
+            l.append(self.entry_modify(it))
         return l
     
     def var_count(self):
@@ -143,7 +144,7 @@ class hash_map:
 
         self.resize(self.count)
         for it in self.bucket:
-            if it.value == "var": count += 1
+            if isinstance(it.value, int): count += 1
         return count
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add ability to solidify `bytes()` literals. This allows to solidify raw bytes buffers. `coc` tools is modified to scan and include all bytes buffers, and deduplicate values.

Example:
```berry
> class A static var a = bytes("deadbeef") end
> import solidify
> solidify.dump(A)

extern const bclass be_class_A;

/********************************************************************
** Solidified class: A
********************************************************************/
be_local_class(A,
    0,
    NULL,
    be_nested_map(1,
    ( (struct bmapnode*) &(const bmapnode[]) {
        { be_const_key(a, -1), be_const_bytes_instance(DEADBEEF) },
    })),
    (bstring*) &be_const_str_A
);
/*******************************************************************/

void be_load_A_class(bvm *vm) {
    be_pushntvclass(vm, &be_class_A);
    be_setglobal(vm, "A");
    be_pop(vm, 1);
}
```

This feature is heavily used in Tasmota to encode Matter structures that are much more compact than solidified maps and lists.