### PR TITLE
Consolidate class constants for solidification

### DIFF
--- a/src/be_object.h
+++ b/src/be_object.h
@@ -46,6 +46,8 @@
 #define BE_VA_VARARG            (1 << 0)    /* function has variable number of arguments */
 #define BE_VA_METHOD            (1 << 1)    /* function is a method (this is only a hint) */
 #define BE_VA_STATICMETHOD      (1 << 2)    /* the function is a static method and has the class as implicit '_class' variable */
+#define BE_VA_SHARED_KTAB       (1 << 3)    /* the funciton has a shared consolidated ktab */
+#define BE_VA_NOCOMPACT         (1 << 4)    /* the funciton has a shared consolidated ktab */
 #define array_count(a)   (sizeof(a) / sizeof((a)[0]))
 
 #define bcommon_header          \

--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -17,6 +17,7 @@
 #include "be_decoder.h"
 #include "be_sys.h"
 #include "be_mem.h"
+#include "be_gc.h"
 #include <string.h>
 #include <stdio.h>
 #include <ctype.h>
@@ -112,9 +113,9 @@ static void toidentifier(char *to, const char *p)
     *to = 0;      // final NULL
 }
 
-static void m_solidify_bvalue(bvm *vm, bbool str_literal, bvalue * value, const char *classname, const char *key, void* fout);
+static void m_solidify_bvalue(bvm *vm, bbool str_literal, const bvalue * value, const char *prefix_name, const char *key, void* fout);
 
-static void m_solidify_map(bvm *vm, bbool str_literal, bmap * map, const char *class_name, void* fout)
+static void m_solidify_map(bvm *vm, bbool str_literal, bmap * map, const char *prefix_name, void* fout)
 {
     // compact first
     be_map_compact(vm, map);
@@ -142,14 +143,14 @@ static void m_solidify_map(bvm *vm, bbool str_literal, bmap * map, const char *c
             } else {
                 logfmt("        { be_const_key_weak(%s, %i), ", id_buf, key_next);
             }
-            m_solidify_bvalue(vm, str_literal, &node->value, class_name, str(node->key.v.s), fout);
+            m_solidify_bvalue(vm, str_literal, &node->value, prefix_name, str(node->key.v.s), fout);
         } else if (node->key.type == BE_INT) {
 #if BE_INTGER_TYPE == 2
             logfmt("        { be_const_key_int(%lli, %i), ", node->key.v.i, key_next);
 #else
             logfmt("        { be_const_key_int(%i, %i), ", node->key.v.i, key_next);
 #endif
-            m_solidify_bvalue(vm, str_literal, &node->value, class_name, NULL, fout);
+            m_solidify_bvalue(vm, str_literal, &node->value, prefix_name, NULL, fout);
         } else {
             char error[64];
             snprintf(error, sizeof(error), "Unsupported type in key: %i", node->key.type);
@@ -162,21 +163,21 @@ static void m_solidify_map(bvm *vm, bbool str_literal, bmap * map, const char *c
 
 }
 
-static void m_solidify_list(bvm *vm, bbool str_literal, blist * list, const char *class_name, void* fout)
+static void m_solidify_list(bvm *vm, bbool str_literal, const blist * list, const char *prefix_name, void* fout)
 {
     logfmt("    be_nested_list(%i,\n", list->count);
 
     logfmt("    ( (struct bvalue*) &(const bvalue[]) {\n");
     for (int i = 0; i < list->count; i++) {
         logfmt("        ");
-        m_solidify_bvalue(vm, str_literal, &list->data[i], class_name, "", fout);
+        m_solidify_bvalue(vm, str_literal, &list->data[i], prefix_name, "", fout);
         logfmt(",\n");
     }
     logfmt("    }))");        // TODO need terminal comma?
 }
 
 // pass key name in case of class, or NULL if none
-static void m_solidify_bvalue(bvm *vm, bbool str_literal, bvalue * value, const char *classname, const char *key, void* fout)
+static void m_solidify_bvalue(bvm *vm, bbool str_literal, const bvalue * value, const char *prefix_name, const char *key, void* fout)
 {
     int type = var_primetype(value);
     switch (type) {
@@ -238,13 +239,14 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, bvalue * value, const 
         break;
     case BE_CLOSURE:
         {
-            const char * func_name = str(((bclosure*) var_toobj(value))->proto->name);
+            bclosure *clo = (bclosure*) var_toobj(value);
+            const char * func_name = str(clo->proto->name);
             size_t id_len = toidentifier_length(func_name);
             char func_name_id[id_len];
             toidentifier(func_name_id, func_name);
             logfmt("be_const_%sclosure(%s%s%s_closure)",
                 var_isstatic(value) ? "static_" : "",
-                classname ? classname : "", classname ? "_" : "",
+                prefix_name ? prefix_name : "", prefix_name ? "_" : "",
                 func_name_id);
         }
         break;
@@ -252,12 +254,12 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, bvalue * value, const 
         logfmt("be_const_class(be_class_%s)", str(((bclass*) var_toobj(value))->name));
         break;
     case BE_COMPTR:
-        logfmt("be_const_comptr(&be_ntv_%s_%s)", classname ? classname : "unknown", key ? key : "unknown");
+        logfmt("be_const_comptr(&be_ntv_%s_%s)", prefix_name ? prefix_name : "unknown", key ? key : "unknown");
         break;
     case BE_NTVFUNC:
         logfmt("be_const_%sfunc(be_ntv_%s_%s)",
             var_isstatic(value) ? "static_" : "",
-            classname ? classname : "unknown", key ? key : "unknown");
+            prefix_name ? prefix_name : "unknown", key ? key : "unknown");
         break;
     case BE_INSTANCE:
     {
@@ -277,16 +279,16 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, bvalue * value, const 
             } else {
                 logfmt("        be_const_list( * ");
             }
-            m_solidify_bvalue(vm, str_literal, &ins->members[0], classname, key, fout);
+            m_solidify_bvalue(vm, str_literal, &ins->members[0], prefix_name, key, fout);
             logfmt("    ) } ))");
         }
     }
         break;
     case BE_MAP:
-        m_solidify_map(vm, str_literal, (bmap *) var_toobj(value), classname, fout);
+        m_solidify_map(vm, str_literal, (bmap *) var_toobj(value), prefix_name, fout);
         break;
     case BE_LIST:
-        m_solidify_list(vm, str_literal, (blist *) var_toobj(value), classname, fout);
+        m_solidify_list(vm, str_literal, (blist *) var_toobj(value), prefix_name, fout);
         break;
     default:
         {
@@ -297,13 +299,14 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, bvalue * value, const 
     }
 }
 
-static void m_solidify_subclass(bvm *vm, bbool str_literal, bclass *cl, void* fout);
+static void m_solidify_subclass(bvm *vm, bbool str_literal, const bclass *cl, void* fout);
 
 /* solidify any inner class */
-static void m_solidify_proto_inner_class(bvm *vm, bbool str_literal, bproto *pr, void* fout)
+static void m_solidify_closure_inner_class(bvm *vm, bbool str_literal, const bclosure *clo, void* fout)
 {
     // parse any class in constants to output it first
-    if (pr->nconst > 0) {
+    bproto *pr = clo->proto;
+    if ((!gc_isconst(clo)) && (pr->nconst > 0) && (!(pr->varg & BE_VA_SHARED_KTAB)) && (!(pr->varg & BE_VA_NOCOMPACT))) {        /* if shared ktab or nocompact, skip */
         for (int k = 0; k < pr->nconst; k++) {
             if (var_type(&pr->ktab[k]) == BE_CLASS) {
                 if ((k == 0) && (pr->varg & BE_VA_STATICMETHOD)) {
@@ -317,12 +320,8 @@ static void m_solidify_proto_inner_class(bvm *vm, bbool str_literal, bproto *pr,
     }
 }
 
-
-static void m_solidify_proto(bvm *vm, bbool str_literal, bproto *pr, const char * func_name, int indent, void* fout)
+static void m_solidify_proto(bvm *vm, bbool str_literal, const bproto *pr, const char * func_name, int indent, const char * prefix_name, void* fout)
 {
-    // const char * func_name = str(pr->name);
-    // const char * func_source = str(pr->source);
-
     logfmt("%*sbe_nested_proto(\n", indent, "");
     indent += 2;
 
@@ -348,7 +347,7 @@ static void m_solidify_proto(bvm *vm, bbool str_literal, bproto *pr, const char 
             size_t sub_len = strlen(func_name) + 10;
             char sub_name[sub_len];
             snprintf(sub_name, sizeof(sub_name), "%s_%"PRId32, func_name, i);
-            m_solidify_proto(vm, str_literal, pr->ptab[i], sub_name, indent+2, fout);
+            m_solidify_proto(vm, str_literal, pr->ptab[i], sub_name, indent+2, prefix_name, fout);
             logfmt(",\n");
         }
         logfmt("%*s}),\n", indent, "");
@@ -358,13 +357,18 @@ static void m_solidify_proto(bvm *vm, bbool str_literal, bproto *pr, const char 
 
     logfmt("%*s%d,                          /* has constants */\n", indent, "", (pr->nconst > 0) ? 1 : 0);
     if (pr->nconst > 0) {
-        logfmt("%*s( &(const bvalue[%2d]) {     /* constants */\n", indent, "", pr->nconst);
-        for (int k = 0; k < pr->nconst; k++) {
-            logfmt("%*s/* K%-3d */  ", indent, "", k);
-            m_solidify_bvalue(vm, str_literal, &pr->ktab[k], NULL, NULL, fout);
-            logfmt(",\n");
+        // we output the full table unless it's a shared ktab
+        if (pr->varg & BE_VA_SHARED_KTAB) {
+            logfmt("%*s&be_ktab_%s,     /* shared constants */\n", indent, "", prefix_name);
+        } else {
+            logfmt("%*s( &(const bvalue[%2d]) {     /* constants */\n", indent, "", pr->nconst);
+            for (int k = 0; k < pr->nconst; k++) {
+                logfmt("%*s/* K%-3d */  ", indent, "", k);
+                m_solidify_bvalue(vm, str_literal, &pr->ktab[k], NULL, NULL, fout);
+                logfmt(",\n");
+            }
+            logfmt("%*s}),\n", indent, "");
         }
-        logfmt("%*s}),\n", indent, "");
     } else {
         logfmt("%*sNULL,                       /* no const */\n", indent, "");
     }
@@ -404,19 +408,19 @@ static void m_solidify_proto(bvm *vm, bbool str_literal, bproto *pr, const char 
 
 }
 
-static void m_solidify_closure(bvm *vm, bbool str_literal, bclosure *cl, const char * classname, void* fout)
+static void m_solidify_closure(bvm *vm, bbool str_literal, const bclosure *clo, const char * prefix_name, void* fout)
 {   
-    bproto *pr = cl->proto;
+    bproto *pr = clo->proto;
     const char * func_name = str(pr->name);
 
-    if (cl->nupvals > 0) {
+    if (clo->nupvals > 0) {
         logfmt("--> Unsupported upvals in closure <---");
         // be_raise(vm, "internal_error", "Unsupported upvals in closure");
     }
 
     int indent = 2;
 
-    m_solidify_proto_inner_class(vm, str_literal, pr, fout);
+    m_solidify_closure_inner_class(vm, str_literal, clo, fout);
 
     logfmt("\n");
     logfmt("/********************************************************************\n");
@@ -428,11 +432,11 @@ static void m_solidify_closure(bvm *vm, bbool str_literal, bclosure *cl, const c
         char func_name_id[id_len];
         toidentifier(func_name_id, func_name);
         logfmt("be_local_closure(%s%s%s,   /* name */\n",
-            classname ? classname : "", classname ? "_" : "",
+            prefix_name ? prefix_name : "", prefix_name ? "_" : "",
             func_name_id);
     }
 
-    m_solidify_proto(vm, str_literal, pr, func_name, indent, fout);
+    m_solidify_proto(vm, str_literal, pr, func_name, indent, prefix_name, fout);
     logfmt("\n");
 
     // closure
@@ -440,21 +444,28 @@ static void m_solidify_closure(bvm *vm, bbool str_literal, bclosure *cl, const c
     logfmt("/*******************************************************************/\n\n");
 }
 
-static void m_solidify_subclass(bvm *vm, bbool str_literal, bclass *cl, void* fout)
-{
-    const char * class_name = str(cl->name);
+static void m_compact_class(bvm *vm, bbool str_literal, const bclass *cla, void* fout);
 
+static void m_solidify_subclass(bvm *vm, bbool str_literal, const bclass *cla, void* fout)
+{
+    const char * classname = str(cla->name);
+
+    /* TODO try compacting for now */
+    m_compact_class(vm, str_literal, cla, fout);
+
+    char prefix_name[strlen(classname) + 10];
+    snprintf(prefix_name, sizeof(prefix_name), "class_%s", classname);
     /* pre-declare class to support '_class' implicit variable */
-    logfmt("\nextern const bclass be_class_%s;\n", class_name);
+    logfmt("\nextern const bclass be_class_%s;\n", classname);
 
     /* iterate on members to dump closures */
-    if (cl->members) {
+    if (cla->members) {
         bmapnode *node;
         bmapiter iter = be_map_iter();
-        while ((node = be_map_next(cl->members, &iter)) != NULL) {
+        while ((node = be_map_next(cla->members, &iter)) != NULL) {
             if (var_isstr(&node->key) && var_isclosure(&node->value)) {
                 bclosure *f = var_toobj(&node->value);
-                m_solidify_closure(vm, str_literal, f, class_name, fout);
+                m_solidify_closure(vm, str_literal, f, prefix_name, fout);
             }
         }
     }
@@ -462,57 +473,50 @@ static void m_solidify_subclass(bvm *vm, bbool str_literal, bclass *cl, void* fo
 
     logfmt("\n");
     logfmt("/********************************************************************\n");
-    logfmt("** Solidified class: %s\n", class_name);
+    logfmt("** Solidified class: %s\n", classname);
     logfmt("********************************************************************/\n");
 
-    if (cl->super) {
-        logfmt("extern const bclass be_class_%s;\n", str(cl->super->name));
+    if (cla->super) {
+        logfmt("extern const bclass be_class_%s;\n", str(cla->super->name));
     }
 
-    logfmt("be_local_class(%s,\n", class_name);
-    logfmt("    %i,\n", cl->nvar);
-    if (cl->super) {
-        logfmt("    &be_class_%s,\n", str(cl->super->name));
+    logfmt("be_local_class(%s,\n", classname);
+    logfmt("    %i,\n", cla->nvar);
+    if (cla->super) {
+        logfmt("    &be_class_%s,\n", str(cla->super->name));
     } else {
         logfmt("    NULL,\n");
     }
 
-    if (cl->members) {
-        m_solidify_map(vm, str_literal, cl->members, class_name, fout);
+    if (cla->members) {
+        m_solidify_map(vm, str_literal, cla->members, prefix_name, fout);
         logfmt(",\n");
     } else {
         logfmt("    NULL,\n");
     }
 
-    size_t id_len = toidentifier_length(class_name);
+    size_t id_len = toidentifier_length(classname);
     char id_buf[id_len];
-    toidentifier(id_buf, class_name);
+    toidentifier(id_buf, classname);
     if (!str_literal) {
         logfmt("    (bstring*) &be_const_str_%s\n", id_buf);
     } else {
         logfmt("    be_str_weak(%s)\n", id_buf);
     }
     logfmt(");\n");
-
 }
 
 static void m_solidify_class(bvm *vm, bbool str_literal, bclass *cl, void* fout)
 {
-    const char * class_name = str(cl->name);
     m_solidify_subclass(vm, str_literal, cl, fout);
-    logfmt("/*******************************************************************/\n\n");
-
-    logfmt("void be_load_%s_class(bvm *vm) {\n", class_name);
-    logfmt("    be_pushntvclass(vm, &be_class_%s);\n", class_name);
-    logfmt("    be_setglobal(vm, \"%s\");\n", class_name);
-    logfmt("    be_pop(vm, 1);\n");
-    logfmt("}\n");
 }
 
 static void m_solidify_module(bvm *vm, bbool str_literal, bmodule *ml, void* fout)
 {
-    const char * module_name = be_module_name(ml);
-    if (!module_name) { module_name = ""; }
+    const char * modulename = be_module_name(ml);
+    if (!modulename) { modulename = ""; }
+    // char prefix_name[strlen(modulename) + 10];
+    // snprintf(prefix_name, sizeof(prefix_name), "module_%s", modulename);
 
     /* iterate on members to dump closures and classes */
     if (ml->table) {
@@ -521,7 +525,7 @@ static void m_solidify_module(bvm *vm, bbool str_literal, bmodule *ml, void* fou
         while ((node = be_map_next(ml->table, &iter)) != NULL) {
             if (var_isstr(&node->key) && var_isclosure(&node->value)) {
                 bclosure *f = var_toobj(&node->value);
-                m_solidify_closure(vm, str_literal, f, module_name, fout);
+                m_solidify_closure(vm, str_literal, f, NULL, fout);
             }
             if (var_isstr(&node->key) && var_isclass(&node->value)) {
                 bclass *cl = var_toobj(&node->value);
@@ -533,20 +537,20 @@ static void m_solidify_module(bvm *vm, bbool str_literal, bmodule *ml, void* fou
 
     logfmt("\n");
     logfmt("/********************************************************************\n");
-    logfmt("** Solidified module: %s\n", module_name);
+    logfmt("** Solidified module: %s\n", modulename);
     logfmt("********************************************************************/\n");
 
-    logfmt("be_local_module(%s,\n", module_name);
-    logfmt("    \"%s\",\n", module_name);
+    logfmt("be_local_module(%s,\n", modulename);
+    logfmt("    \"%s\",\n", modulename);
 
     if (ml->table) {
-        m_solidify_map(vm, str_literal, ml->table, module_name, fout);
+        m_solidify_map(vm, str_literal, ml->table, NULL, fout);
         logfmt("\n");
     } else {
         logfmt("    NULL,\n");
     }
     logfmt(");\n");
-    logfmt("BE_EXPORT_VARIABLE be_define_const_native_module(%s);\n", module_name);
+    logfmt("BE_EXPORT_VARIABLE be_define_const_native_module(%s);\n", modulename);
     logfmt("/********************************************************************/\n");
 
 }
@@ -568,12 +572,12 @@ static int m_dump(bvm *vm)
             }
             be_pop(vm, 1);
         }
-        const char *classname = NULL;  /* allow to specify an explicit prefix */
+        const char *prefix_name = NULL;  /* allow to specify an explicit prefix */
         if (top >= 4 && be_isstring(vm, 4)) {
-            classname = be_tostring(vm, 4);
+            prefix_name = be_tostring(vm, 4);
         }
         if (var_isclosure(v)) {
-            m_solidify_closure(vm, str_literal, var_toobj(v), classname, fout);
+            m_solidify_closure(vm, str_literal, var_toobj(v), prefix_name, fout);
         } else if (var_isclass(v)) {
             m_solidify_class(vm, str_literal, var_toobj(v), fout);
         } else if (var_ismodule(v)) {
@@ -585,9 +589,274 @@ static int m_dump(bvm *vm)
     be_return_nil(vm);
 }
 
+static void m_compact_class(bvm *vm, bbool str_literal, const bclass *cla, void* fout)
+{
+    const char * classname = str(cla->name);
+
+    /* reserve an array big enough for max size ktab (256) */
+    const int MAX_KTAB_SIZE = 256;
+    bvalue ktab[MAX_KTAB_SIZE];       /* size is 2048 byte for 32 bits, so fitting in ESP32, may need to be changed on smaller architectures */
+    int ktab_size = 0;
+
+    /* for statistics, keep the aggregate number of bvalues */
+    int ktab_total = 0;
+
+    /* iterate on members to dump closures */
+    if (cla->members) {
+        bmapnode *node;
+        bmapiter iter = be_map_iter();
+
+        /* first iteration to build the global ktab */
+        while ((node = be_map_next(cla->members, &iter)) != NULL) {
+            if (var_isstr(&node->key) && var_isclosure(&node->value)) {
+                bclosure *cl = var_toobj(&node->value);
+                bproto *pr = cl->proto;
+
+                if ((gc_isconst(cl)) || (pr->varg & BE_VA_SHARED_KTAB) || (pr->varg & BE_VA_NOCOMPACT)) { continue; }
+
+                // iterate on each bvalue in ktab
+                for (int i = 0; i < pr->nconst; i++) {
+                    // look if the bvalue pair is already in ktab
+                    int found = 0;
+                    for (int j = 0; j < ktab_size; j++) {
+                        // to avoid any size issue, we compare all bytes
+                        // berry_log_C("// p1=%p p2=%p sz=%i", &pr->ktab[i], &ktab[j], sizeof(bvalue));
+                        if ((pr->ktab[i].type == ktab[j].type) && (pr->ktab[i].v.i == ktab[j].v.i) && (pr->ktab[i].v.c == ktab[j].v.c)) {
+                        // if (memcmp(&pr->ktab[i], &ktab[j], sizeof(bvalue)) == 0) {
+                            found = 1;
+                            break;
+                        }
+                    }
+                    // if not already there, add it
+                    if (!found) {
+                        ktab[ktab_size++] = pr->ktab[i];
+                    }
+                    if (ktab_size >= MAX_KTAB_SIZE) {
+                        logfmt("// ktab too big for class '%s' - skipping\n", classname);
+                        return;
+                    }
+                }
+                ktab_total += pr->nconst;
+            }
+        }
+
+        if (ktab_size == ktab_total) {
+            return;         /* nothing to optimize, can happen for classes with zero or 1 method */
+        }
+        /* allocate a proper ktab */
+        bvalue *new_ktab = be_malloc(vm, sizeof(bvalue) * ktab_size);
+        memmove(new_ktab, ktab, sizeof(bvalue) * ktab_size);
+
+        /* second iteration to replace ktab and patch code */
+        iter = be_map_iter();
+        while ((node = be_map_next(cla->members, &iter)) != NULL) {
+            if (var_isstr(&node->key) && var_isclosure(&node->value)) {
+                bclosure *cl = var_toobj(&node->value);
+                bproto *pr = cl->proto;
+
+                if ((gc_isconst(cl)) || (pr->varg & BE_VA_SHARED_KTAB) || (pr->varg & BE_VA_NOCOMPACT)) { continue; }
+
+                uint8_t mapping_array[MAX_KTAB_SIZE];
+                // iterate in proto ktab to get the index in the global ktab
+                for (int i = 0; i < pr->nconst; i++) {
+                    for (int j = 0; j < ktab_size; j++) {
+                        // compare all bytes
+                        if ((pr->ktab[i].type == ktab[j].type) && (pr->ktab[i].v.i == ktab[j].v.i) && (pr->ktab[i].v.c == ktab[j].v.c)) {
+                        // if (memcmp(&pr->ktab[i], &ktab[j], sizeof(bvalue)) == 0) {
+                            mapping_array[i] = j;
+                            break;
+                        }
+                    }
+                }
+
+                // replace ktab
+                pr->ktab = new_ktab;
+                pr->nconst = ktab_size;
+                // flag as shared ktab
+                pr->varg |= BE_VA_SHARED_KTAB;
+                // parse code to replace any K<x> reference
+                for (int pc = 0; pc < pr->codesize; pc++) {
+                    uint32_t ins = pr->code[pc];
+                    bopcode op = IGET_OP(ins);
+
+                    /* handle all impacted opcodes */
+                    /* Possibilities: */
+                    /* "B" | "B and C" | "Bx" contain a constant code */
+                    /* special case for OP_RET where "B" may not contain anything */
+                    switch (op) {
+                    case OP_ADD: case OP_SUB: case OP_MUL: case OP_DIV:
+                    case OP_MOD: case OP_LT: case OP_LE: case OP_EQ:
+                    case OP_NE:  case OP_GT:  case OP_GE: case OP_CONNECT:
+                    case OP_GETMBR: case OP_SETMBR:  case OP_GETMET:
+                    case OP_GETIDX: case OP_SETIDX: case OP_AND:
+                    case OP_OR: case OP_XOR: case OP_SHL: case OP_SHR:
+                    case OP_RAISE:
+                        // B and C might contain 'K' constant
+                        if (isKB(ins)) {
+                            int kidx = IGET_RKB(ins) & KR_MASK;
+                            if (kidx >= ktab_size) {
+                                be_raise(vm, "value_error", "invalid ktab index");
+                            }
+                            ins = (ins & ~IRKB_MASK) | ISET_RKB(setK(mapping_array[kidx]));
+                        }
+                        if (isKC(ins)) {
+                            int kidx = IGET_RKC(ins) & KR_MASK;
+                            if (kidx >= ktab_size) {
+                                be_raise(vm, "value_error", "invalid ktab index");
+                            }
+                            ins = (ins & ~IRKC_MASK) | ISET_RKC(setK(mapping_array[kidx]));
+                        }
+                        pr->code[pc] = ins;
+                        break;
+                    case OP_MOVE: case OP_SETSUPER: case OP_NEG: case OP_FLIP: case OP_IMPORT:
+                    case OP_GETNGBL: case OP_SETNGBL:
+                        // Only B might contain 'K' constant
+                        if (isKB(ins)) {
+                            int kidx = IGET_RKB(ins) & KR_MASK;
+                            if (kidx >= ktab_size) {
+                                be_raise(vm, "value_error", "invalid ktab index");
+                            }
+                            ins = (ins & ~IRKB_MASK) | ISET_RKB(setK(mapping_array[kidx]));
+                        }
+                        pr->code[pc] = ins;
+                        break;
+                    case OP_CLASS:
+                    case OP_LDCONST:
+                        // Bx contains the K
+                        {
+                            int kidx = IGET_Bx(ins);
+                            if (kidx >= ktab_size) {
+                                be_raise(vm, "value_error", "invalid ktab index");
+                            }
+                            ins = (ins & ~IBx_MASK) | ISET_Bx(mapping_array[kidx]);
+                            pr->code[pc] = ins;
+                        }
+                        break;
+                    case OP_RET:
+                        if (IGET_RA(ins)) {
+                            // Only B might contain 'K' constant
+                            if (isKB(ins)) {
+                                int kidx = IGET_RKB(ins) & KR_MASK;
+                                if (kidx >= ktab_size) {
+                                    be_raise(vm, "value_error", "invalid ktab index");
+                                }
+                                ins = (ins & ~IRKB_MASK) | ISET_RKB(setK(mapping_array[kidx]));
+                            }
+                        }
+                        pr->code[pc] = ins;
+                        break;
+                    /* The following opcodes are not impacted by shared constant table
+                    case OP_GETUPV: case OP_SETUPV:
+                    case OP_LDCONST:
+                    case OP_CALL:
+                    case OP_CLOSURE:
+                    case OP_CLOSE: case OP_LDNIL:
+                    case OP_EXBLK:
+                    case OP_CATCH:
+                    case OP_GETGBL: case OP_SETGBL:
+                    case OP_JMP:
+                    case OP_JMPT: case OP_JMPF:
+                    case OP_LDINT:
+                    case OP_LDBOOL:     */
+                    default:
+                        break;
+                    }
+
+                }
+            }
+        }
+    }
+    // logfmt("extern const bclass be_class_%s;\n", classname);
+    // scan classes and generate extern statements for classes
+    for (int k = 0; k < ktab_size; k++) {
+        // if it's a class, print an extern statement
+        if (var_isclass(&ktab[k])) {
+            bclass *cl = var_toobj(&ktab[k]);
+            logfmt("extern const bclass be_class_%s;\n", str(cl->name));
+        }
+    }
+
+    // scan again to export all sub-classes
+    for (int k = 0; k < ktab_size; k++) {
+        // if it's a class, print an extern statement
+        if (var_isclass(&ktab[k])) {
+            bclass *cl = var_toobj(&ktab[k]);
+            if (cl != cla) {
+                m_solidify_subclass(vm, str_literal, cl, fout);
+            }
+        }
+    }
+
+    // output shared ktab
+    int indent = 0;
+    logfmt("// compact class '%s' ktab size: %d, total: %d (saved %i bytes)\n", classname, ktab_size, ktab_total, (ktab_total - ktab_size) * 8);
+    logfmt("static const bvalue be_ktab_class_%s[%i] = {\n", classname, ktab_size);
+    for (int k = 0; k < ktab_size; k++) {
+        logfmt("%*s/* K%-3d */  ", indent + 2, "", k);
+        m_solidify_bvalue(vm, str_literal, &ktab[k], NULL, NULL, fout);
+        logfmt(",\n");
+    }
+    logfmt("%*s};\n", indent, "");
+    logfmt("\n");
+}
+
+// takes a class or a module
+// scans all first level bproto
+// build a consolidated 'ktab' array
+// check that the array is not bigger than 256 (which is the max acceptable constants)
+// (for now) print the potential saving
+static int m_compact(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        bbool str_literal = bfalse;
+        if (top >= 2) {
+            str_literal = be_tobool(vm, 2);
+        }
+        void* fout = NULL;      /* output file */
+        if (top >= 3 && be_isinstance(vm, 3)) {
+            be_getmember(vm, 3, ".p");
+            if (be_iscomptr(vm, -1)) {
+                fout = be_tocomptr(vm, -1);
+            }
+            be_pop(vm, 1);
+        }
+        // const char *prefix_name = NULL;  /* allow to specify an explicit prefix */
+        // if (top >= 4 && be_isstring(vm, 4)) {
+        //     prefix_name = be_tostring(vm, 4);
+        // }
+        if (var_isclass(v)) {
+            m_compact_class(vm, str_literal, var_toobj(v), fout);
+        } else if (var_ismodule(v)) {
+            // TODO
+        } else {
+            be_raise(vm, "value_error", "unsupported type");
+        }
+    }
+    be_return_nil(vm);
+}
+
+static int m_nocompact(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        if (var_isclosure(v)) {
+            bclosure *cl = var_toobj(v);
+            bproto *pr = cl->proto;
+            pr->varg |= BE_VA_NOCOMPACT;
+        } else {
+            be_raise(vm, "value_error", "unsupported type");
+        }
+    }
+    be_return_nil(vm);
+}
+
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(solidify) {
     be_native_module_function("dump", m_dump),
+    be_native_module_function("compact", m_compact),
 };
 
 be_define_native_module(solidify, NULL);
@@ -595,6 +864,8 @@ be_define_native_module(solidify, NULL);
 /* @const_object_info_begin
 module solidify (scope: global, depend: BE_USE_SOLIDIFY_MODULE) {
     dump, func(m_dump)
+    compact, func(m_compact)
+    nocompact, func(m_nocompact)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_solidify.h"


### PR DESCRIPTION
This feature runs a compaction pass when solidifying a class or a module. This allowed huge savings if Flash size in Tasmota.

Each function in a class or a module has its own arrays of constants. However there is a high probabillity that constants are used in multiple functions or methods (method names by far).

When solidifying, all constants in all methods of the class/module are consolidated in a single array, this array is then used for all methods. Bytecode is parsed and patched to adjust to the new indices in the consolidated array (`Kxx` values).

Before:
```berry
> class A def f() return "foo" end def g() return "foo" end end
> import solidify
> solidify.dump(A)

extern const bclass be_class_A;

/********************************************************************
** Solidified function: g
********************************************************************/
be_local_closure(A_g,   /* name */
  be_nested_proto(
    1,                          /* nstack */
    1,                          /* argc */
    2,                          /* varg */
    0,                          /* has upvals */
    NULL,                       /* no upvals */
    0,                          /* has sup protos */
    NULL,                       /* no sub protos */
    1,                          /* has constants */
    ( &(const bvalue[ 1]) {     /* constants */
    /* K0   */  be_nested_str(foo),
    }),
    &be_const_str_g,
    &be_const_str_solidified,
    ( &(const binstruction[ 1]) {  /* code */
      0x80060000,  //  0000  RET	1	K0
    })
  )
);
/*******************************************************************/


/********************************************************************
** Solidified function: f
********************************************************************/
be_local_closure(A_f,   /* name */
  be_nested_proto(
    1,                          /* nstack */
    1,                          /* argc */
    2,                          /* varg */
    0,                          /* has upvals */
    NULL,                       /* no upvals */
    0,                          /* has sup protos */
    NULL,                       /* no sub protos */
    1,                          /* has constants */
    ( &(const bvalue[ 1]) {     /* constants */
    /* K0   */  be_nested_str(foo),
    }),
    &be_const_str_f,
    &be_const_str_solidified,
    ( &(const binstruction[ 1]) {  /* code */
      0x80060000,  //  0000  RET	1	K0
    })
  )
);
[...]
```

After:
```berry
> class A def f() return "foo" end def g() return "foo" end end
> import solidify
> solidify.dump(A)
// compact class 'A' ktab size: 1, total: 2 (saved 8 bytes)
static const bvalue be_ktab_class_A[1] = {
  /* K0   */  be_nested_str(foo),
};


extern const bclass be_class_A;

/********************************************************************
** Solidified function: g
********************************************************************/
be_local_closure(class_A_g,   /* name */
  be_nested_proto(
    1,                          /* nstack */
    1,                          /* argc */
    10,                          /* varg */
    0,                          /* has upvals */
    NULL,                       /* no upvals */
    0,                          /* has sup protos */
    NULL,                       /* no sub protos */
    1,                          /* has constants */
    &be_ktab_class_A,     /* shared constants */
    &be_const_str_g,
    &be_const_str_solidified,
    ( &(const binstruction[ 1]) {  /* code */
      0x80060000,  //  0000  RET	1	K0
    })
  )
);
/*******************************************************************/


/********************************************************************
** Solidified function: f
********************************************************************/
be_local_closure(class_A_f,   /* name */
  be_nested_proto(
    1,                          /* nstack */
    1,                          /* argc */
    10,                          /* varg */
    0,                          /* has upvals */
    NULL,                       /* no upvals */
    0,                          /* has sup protos */
    NULL,                       /* no sub protos */
    1,                          /* has constants */
    &be_ktab_class_A,     /* shared constants */
    &be_const_str_f,
    &be_const_str_solidified,
    ( &(const binstruction[ 1]) {  /* code */
      0x80060000,  //  0000  RET	1	K0
    })
  )
);
[...]
```

The solidified code indicates the savings done by compaction:
`// compact class 'A' ktab size: 1, total: 2 (saved 8 bytes)`