### PR TITLE
Avoid crash in item

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -1180,6 +1180,7 @@ static int m_item(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
+    check_ptr(vm, &attr);
     if (argc >=2 && be_isint(vm, 2)) {  /* single byte */
         int index = be_toint(vm,2);
         if (index < 0) {


### PR DESCRIPTION
Avoid crash in `bytes()` `item()` function when the buffer could not be allocated.