### PR TITLE
Add a binary_heap module

### DIFF
--- a/modules/binary_heap.be
+++ b/modules/binary_heap.be
@@ -1,0 +1,54 @@
+# https://en.wikipedia.org/wiki/Binary_heap
+# This allows to choose the M first elements of an N-sized array
+# with respect to a comparison predicate cmp that defines a total order.
+# This avoids the overhead of sorting the entire array and then picking
+# the first elements.  This is related to a priority queue.
+# We also define a binary heap based sort() of an entire array.
+
+var binary_heap = module("binary_heap")
+
+binary_heap._heapify = def(array, cmp, i)
+  var m = i, child, e, am, ac
+  while true
+    child = 2 * i + 1
+    if child >= array.size() return end
+    ac = array[child]
+    am = array[m]
+    if cmp(ac, am) m = child am = ac end
+    child += 1
+    if child < array.size()
+      ac = array[child]
+      if cmp(ac, am) m = child am = ac end
+    end
+    if m == i break end
+    array[m] = array[i]
+    array[i] = am
+    i = m
+  end
+end
+
+# similar to C++11 std::make_heap
+binary_heap.make_heap = def(array, cmp)
+  var i = size(array) / 2
+  while i >= 0 binary_heap._heapify(array, cmp, i) i -= 1 end
+end
+
+# similar to C++11 std::pop_heap, but removes and returns the element
+binary_heap.remove_heap = def(array, cmp)
+  var m = array.size()
+  if m < 2 return m == 1 ? array.pop() : nil end
+  m = array[0]
+  array[0] = array.pop()
+  binary_heap._heapify(array, cmp, 0)
+  return m
+end
+
+# https://en.wikipedia.org/wiki/Heapsort
+binary_heap.sort = def(array, cmp)
+  var i = array.size(), heap = array.copy()
+  binary_heap.make_heap(heap, cmp)
+  array.clear()
+  while i > 0 array.push(binary_heap.remove_heap(heap, cmp)) i -= 1 end
+end
+
+return binary_heap

--- a/modules/examples/binary_heap_sort.be
+++ b/modules/examples/binary_heap_sort.be
@@ -1,0 +1,34 @@
+import binary_heap
+
+var pi = [3,14,15,92,65,35,89,79,32,38,46,26,43,38,32,79,50,28,84,19,71,69,39]
+# Display the elements of pi[] in ascending order
+var h = pi.copy()
+var less = / a b -> a < b, sort = binary_heap.sort
+sort(h, less)
+print(h)
+
+# Display the 5 largest elements of pi[]
+var cmp = / a b -> a > b
+var max = []
+binary_heap.make_heap(h, cmp)
+var i = 5
+while i > 0 max.push(binary_heap.remove_heap(h, cmp)) i -= 1 end
+print(max)
+
+# Display the 7 largest elements of pi[] in ascending order of index
+h = []
+i = 1
+while i < pi.size() h.push(i - 1) i += 1 end
+cmp = / a b -> pi[a] > pi[b]
+if false # less efficient alternative: sort the entire array
+  sort(h, cmp)
+  max = h[0..6]
+  i = 0
+else # more efficient: only sort the minimum necessary subset
+  max = []
+  binary_heap.make_heap(h, cmp)
+  i = 7
+  while i > 0 max.push(binary_heap.remove_heap(h, cmp)) i -= 1 end
+end
+sort(max, less)
+while i < 7 print(f"{max[i]}: {pi[max[i]]}") i += 1 end


### PR DESCRIPTION
`binary_heap.make_heap(array,cmp)` transforms a Berry `list` into a binary heap where the heap property is defined by a comparison `cmp`.

`binary_heap.remove_heap(array,cmp)` removes and returns the first element of a binary heap and maintains the heap property for the remaining elements. By repeatedly invoking it, one can obtain the first few elements of a Berry list in a sorted order, without having to sort all elements.

`binary_heap.sort(array,cmp)` implements a heap sort of a Berry `list`.

The example program can be run as follows:
```sh
berry -m modules modules/examples/binary_heap_sort.be
```