### PR TITLE
Disable filelib.savecode when BE_USE_BYTECODE_SAVER disabled

### DIFF
--- a/src/be_filelib.c
+++ b/src/be_filelib.c
@@ -234,7 +234,9 @@ int be_nfunc_open(bvm *vm)
         { "flush", i_flush },
         { "close", i_close },
         { "deinit", i_close },
+#if BE_USE_BYTECODE_SAVER
         { "savecode", i_savecode },
+#endif
         { NULL, NULL }
     };
     fname = argc >= 1 && be_isstring(vm, 1) ? be_tostring(vm, 1) : NULL;


### PR DESCRIPTION
I think this is an unnecessary link-time dependency, otherwise if I:
```
#define BE_USE_BYTECODE_SAVER           0
```

I'd get this link error:
```
[Linking...]                                                                                                                           
/nix/store/22p5nv7fbxhm06mfkwwnibv1nsz06x4b-binutils-2.40/bin/ld: src/be_filelib.o: in function `i_savecode':                          
be_filelib.c:(.text+0x9e): undefined reference to `be_bytecode_save_to_fs'                                                             
collect2: error: ld returned 1 exit status
```