### PR TITLE
global.undef to remove a global variable

### DIFF
--- a/src/be_api.c
+++ b/src/be_api.c
@@ -82,8 +82,8 @@ BERRY_API void be_regfunc(bvm *vm, const char *name, bntvfunc f)
     bstring *s = be_newstr(vm, name);
 #if !BE_USE_PRECOMPILED_OBJECT
     int idx = be_builtin_find(vm, s);
-    be_assert(idx == -1);
-    if (idx == -1) { /* new function */
+    be_assert(idx < 0);
+    if (idx < 0) { /* new function */
         idx = be_builtin_new(vm, s);
 #else
     int idx = be_global_find(vm, s);
@@ -102,8 +102,8 @@ BERRY_API void be_regclass(bvm *vm, const char *name, const bnfuncinfo *lib)
     bstring *s = be_newstr(vm, name);
 #if !BE_USE_PRECOMPILED_OBJECT
     int idx = be_builtin_find(vm, s);
-    be_assert(idx == -1);
-    if (idx == -1) { /* new function */
+    be_assert(idx < 0);
+    if (idx < 0) { /* new function */
         idx = be_builtin_new(vm, s);
 #else
     int idx = be_global_find(vm, s);
@@ -599,7 +599,7 @@ BERRY_API bbool be_getglobal(bvm *vm, const char *name)
 {
     int idx = be_global_find(vm, be_newstr(vm, name));
     bvalue *top = be_incrtop(vm);
-    if (idx > -1) {
+    if (idx >= 0) {
         *top = *be_global_var(vm, idx);
         return btrue;
     }

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -488,7 +488,10 @@ static void new_var(bparser *parser, bstring *name, bexpdesc *var)
         var->v.idx = new_localvar(parser, name); /* if local, contains the index in current local var list */
     } else {
         init_exp(var, ETGLOBAL, 0);
-        var->v.idx = be_global_new(parser->vm, name);
+        var->v.idx = be_global_find(parser->vm, name);
+        if (var->v.idx < 0) {
+            var->v.idx = be_global_new(parser->vm, name);
+        }
         if (var->v.idx > (int)IBx_MASK) {
             push_error(parser,
                 "too many global variables (in '%s')", str(name));

--- a/src/be_var.h
+++ b/src/be_var.h
@@ -20,6 +20,7 @@ void be_globalvar_init(bvm *vm);
 void be_globalvar_deinit(bvm *vm);
 int be_global_find(bvm *vm, bstring *name);
 int be_global_new(bvm *vm, bstring *name);
+bbool be_global_undef(bvm *vm, bstring *name);
 bvalue* be_global_var(bvm *vm, int index);
 void be_global_release_space(bvm *vm);
 int be_builtin_find(bvm *vm, bstring *name);

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -591,7 +591,7 @@ newframe: /* a new call frame */
             if (var_isstr(b)) {
                 bstring *name = var_tostr(b);
                 int idx = be_global_find(vm, name);
-                if (idx > -1) {
+                if (idx >= 0) {
                     *v = *be_global_var(vm, idx);
                 } else {
                     vm_error(vm, "attribute_error", "'%s' undeclared", str(name));

--- a/tests/global.be
+++ b/tests/global.be
@@ -41,3 +41,16 @@ assert(findinlist(global(), 'global_a') != nil)
 assert(findinlist(global(), 'global_b') != nil)
 assert(findinlist(global(), 'global_c') != nil)
 assert(findinlist(global(), 'global_d') == nil)
+
+# undef
+var a_global_var = 1
+assert(global.contains("a_global_var") == true)
+assert(global().find("a_global_var") != nil)
+
+global.undef("a_global_var")
+assert(global.contains("a_global_var") == false)
+assert(global().find("a_global_var") == nil)
+
+global.a_global_var = 1
+assert(global.contains("a_global_var") == true)
+global.undef("a_global_var")


### PR DESCRIPTION
Add an ability to remove a variable from the global scope. This is useful to avoid pollution of the global namespace and to uninstall some components.

Internally, when a global variable is "undef", its value is internally set to `nil` in `vlist` and the index in `vtab` is set to a negative value to "mask" it from the global scope. Since internally `-1` is used to indicate a variable not defined, we use the fonction `-index - 2` to generate a negative value. If later a new global variable with the same name is defined again, the original index is restored by applying again `-index - 2`.

Ex: index `15` becomes `-17`, and if defined again back to `15`

This feature is under test in Tasmota.

The name `global.undef()` may be reviewed.

Example:
```berry
> a
syntax_error: stdin:1: 'a' undeclared (first use in this function)
> var a = 1
> a
1
> import global
> global()
['_argv', 'a', 'global']

> global.undef("a")
> global()
['_argv', 'global']
> a
syntax_error: stdin:1: 'a' undeclared (first use in this function)
```