### PR TITLE
Allow 'call()' to work with class constructors

### DIFF
--- a/src/be_baselib.c
+++ b/src/be_baselib.c
@@ -319,7 +319,7 @@ int be_baselib_iterator(bvm *vm)
 static int l_call(bvm *vm)
 {
     int top = be_top(vm);
-    if (top >= 1 && be_isfunction(vm, 1)) {
+    if (top >= 1 && (be_isfunction(vm, 1) || be_isclass(vm, 1))) {
         size_t arg_count = top - 1;  /* we have at least 'top - 1' arguments */
         /* test if last argument is a list */
 
@@ -354,7 +354,7 @@ static int l_call(bvm *vm)
 
         be_return(vm);
     }
-    be_raise(vm, "value_error", "first argument must be a function");
+    be_raise(vm, "value_error", "first argument must be a function or a class");
     be_return_nil(vm);
 }
 

--- a/tests/call.be
+++ b/tests/call.be
@@ -100,3 +100,13 @@ for i:1..50 l50.push(i) end
 
 assert(call(g, l50) == [1, 2, 3])
 assert(call(c, l50) == 50)
+
+#- call should be working for a class constructor -#
+class A
+    var a
+    def init(x)
+        self.a = x
+    end
+end
+var inst = call(A, 5)
+assert(inst.a == 5)


### PR DESCRIPTION
Allow 'call()' to work with class constructors. Previously it would work only for functions, but a class constructor is also a callable function.