### PR TITLE
CLI allow script and file

### DIFF
--- a/default/berry.c
+++ b/default/berry.c
@@ -103,6 +103,7 @@ struct arg_opts {
     const char *src;
     const char *dst;
     const char *modulepath;
+    const char *execute;
 };
 
 /* check if the character is a letter */
@@ -210,9 +211,7 @@ static int handle_result(bvm *vm, int res)
 /* execute a script source or file and output a result or error */
 static int doscript(bvm *vm, const char *name, int args)
 {
-    /* load string, bytecode file or compile script file */
-    int res = args & arg_e ? /* check script source string */
-        be_loadstring(vm, name) : be_loadmode(vm, name, args & arg_l);
+    int res = be_loadmode(vm, name, args & arg_l);
     if (res == BE_OK) { /* parsing succeeded */
         res = be_pcall(vm, 0); /* execute */
     }
@@ -222,17 +221,25 @@ static int doscript(bvm *vm, const char *name, int args)
 /* load a Berry script string or file and execute
  * args: the enabled options mask
  * */
-static int load_script(bvm *vm, int argc, char *argv[], int args)
+static int load_script(bvm *vm, int argc, char *argv[], int args, const char * script)
 {
     int res = 0;
     int repl_mode = args & arg_i || (args == 0 && argc == 0);
     if (repl_mode) { /* enter the REPL mode after executing the script file */
         be_writestring(repl_prelude);
     }
-    if (argc > 0) { /* check file path or source string argument */
+    /* compile script file */
+    if (script) {
+        res = be_loadstring(vm, script);
+        if (res == BE_OK) { /* parsing succeeded */
+            res = be_pcall(vm, 0); /* execute */
+        }
+        res = handle_result(vm, res);
+    }
+    if (res == BE_OK && argc > 0) { /* check file path or source string argument */
         res = doscript(vm, argv[0], args);
     }
-    if (repl_mode) { /* enter the REPL mode */
+    if (res == BE_OK && repl_mode) { /* enter the REPL mode */
         res = be_repl(vm, get_line, free_line);
         if (res == -BE_MALLOC_FAIL) {
             be_writestring("error: memory allocation failed.\n");
@@ -262,9 +269,12 @@ static int parse_arg(struct arg_opts *opt, int argc, char *argv[])
         case 'v': args |= arg_v; break;
         case 'i': args |= arg_i; break;
         case 'l': args |= arg_l; break;
-        case 'e': args |= arg_e; break;
         case 'g': args |= arg_g; break;
         case 's': args |= arg_s; break;
+        case 'e':
+            args |= arg_e;
+            opt->execute = opt->optarg;
+            break;
         case 'm':
             args |= arg_m;
             opt->modulepath = opt->optarg;
@@ -352,7 +362,7 @@ static int analysis_args(bvm *vm, int argc, char *argv[])
 {
     int args = 0;
     struct arg_opts opt = { 0 };
-    opt.pattern = "m?vhilegsc?o?";
+    opt.pattern = "m?vhile?gsc?o?";
     args = parse_arg(&opt, argc, argv);
     argc -= opt.idx;
     argv += opt.idx;
@@ -393,7 +403,7 @@ static int analysis_args(bvm *vm, int argc, char *argv[])
         }
         return build_file(vm, opt.dst, opt.src, args);
     }
-    return load_script(vm, argc, argv, args);
+    return load_script(vm, argc, argv, args, opt.execute);
 }
 
 


### PR DESCRIPTION
Allow the command line version of `berry` to accept both an inline script (ran first) and a file:

```
./berry -e "import global" myscript.be
```

This is handy to force imports before running the script