### PR TITLE
Truncate binary string to NULL char

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -786,7 +786,8 @@ static int m_asstring(bvm *vm)
 {
     buf_impl attr = bytes_check_data(vm, 0);
     check_ptr(vm, &attr);
-    be_pushnstring(vm, (const char*) attr.bufptr, attr.len);
+    size_t safe_len = strnlen((const char*) attr.bufptr, attr.len);
+    be_pushnstring(vm, (const char*) attr.bufptr, safe_len);
     be_return(vm);
 }
 


### PR DESCRIPTION
Make sure to truncate `bytes.asstring()` to a NULL char if any is present in the string.

Technically Berry accepts strings that contain NULL chars, although this leads to unpredictable behavior and potential crash or vulnerability.