### PR TITLE
Fix parsing vulnerability in solidification

### DIFF
--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -69,7 +69,7 @@ static unsigned toidentifier_length(const char *s)
     unsigned len = 1;
     const char * p = s;
     while (*p) {
-        if (p[0] == '_' && p[1] == 'X') {
+        if (p[0] == '_' && p[1] != '\0' && p[1] == 'X') {
             len += 3;
             p += 2;
         } else if (isalnum(p[0]) || p[0] == '_') {


### PR DESCRIPTION
Fix potential vulnerability in parsing string in solidify. `toidentifier_length()` could crash is a string ends with '_'. I'm not sure this can actually happen during the solidification process, but it's always good to have safe code.