### PR TITLE
Added strnlen implementation for sytems that don't have it defined

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -20,6 +20,14 @@
 
 static const char * hex = "0123456789ABCDEF";
 
+size_t strnlength (const char* s, size_t n) {
+  if (strnlen){
+      return strnlen(s, n);
+  }
+  const char* found = memchr(s, '\0', n);
+  return found ? (size_t)(found-s) : n;
+}
+
 /********************************************************************
 ** Base64 lib from https://github.com/Densaugeo/base64_arduino
 **

--- a/src/be_byteslib.h
+++ b/src/be_byteslib.h
@@ -36,6 +36,10 @@ typedef struct buf_impl {
 } buf_impl;
 
 size_t be_bytes_tohex(char * out, size_t outsz, const uint8_t * in, size_t insz);
+/*
+ * Not all systems have strnlen defined, so we'll use a wrapper
+ */
+size_t strnlen(const char* s, size_t n) __attribute__((weak));
 
 #if BE_USE_PRECOMPILED_OBJECT
 #include "../generate/be_const_bytes.h"


### PR DESCRIPTION
Some systems don't have `strnlen` defined. Where it is this code should still work and use it preferentially, and where it's not it will use this implementation.