### PR TITLE
Fix crash with solidified empty map

### DIFF
--- a/src/be_map.c
+++ b/src/be_map.c
@@ -178,6 +178,9 @@ static bmapnode* insert(bvm *vm, bmap *map, bvalue *key, uint32_t hash)
 
 static bmapnode* find(bvm *vm, bmap *map, bvalue *key, uint32_t hash)
 {
+    if (map->size == 0) {   /* this situation happens only for solidified empty maps that are compacted */
+        return NULL;
+    }
     bmapnode *slot = hash2slot(map, hash);
     if (isnil(slot)) {
         return NULL;


### PR DESCRIPTION
When created in memory, maps have always at least 1 slot, hence modulo computed on the number of slots work.

When solidified, maps are compacted, hence an empty map has 0 slot, and modulo would crash because of division by zero.