### PR TITLE
Provide details when trying to solidify upvals

### DIFF
--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -426,7 +426,8 @@ static void m_solidify_closure(bvm *vm, bbool str_literal, const bclosure *clo, 
     const char * func_name = str(pr->name);
 
     if (clo->nupvals > 0) {
-        logfmt("--> Unsupported upvals in closure <---");
+        const char *name = str(clo->proto->name);
+        logfmt("--> Unsupported upvals in closure in '%s' <---", name ? name : "<unkown>");
         // be_raise(vm, "internal_error", "Unsupported upvals in closure");
     }
 


### PR DESCRIPTION
Upvals are not supported by solidification. When trying to solidify upvals, the error message was `--> Unsupported upvals in closure <---`, now it gives the name of the function containing the faulty upvals to help identify quickly the location of the problem.