### PR TITLE
Avoid using strnlen

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -806,7 +806,10 @@ static int m_asstring(bvm *vm)
 {
     buf_impl attr = bytes_check_data(vm, 0);
     check_ptr(vm, &attr);
-    size_t safe_len = strnlen((const char*) attr.bufptr, attr.len);
+    /* equivalent to strnlen() */
+    const char* str = (const char*) attr.bufptr;
+    const char* found = memchr(str, '\0', attr.len);
+    size_t safe_len = found ? (size_t)(found - str) : (size_t)attr.len;
     be_pushnstring(vm, (const char*) attr.bufptr, safe_len);
     be_return(vm);
 }


### PR DESCRIPTION
Implement an alternative to `strnlen()` which is not standard C++

Replaces #480