### PR TITLE
Change 'bntvfunc' to return void instead of int

### DIFF
--- a/src/be_api.c
+++ b/src/be_api.c
@@ -1019,19 +1019,17 @@ BERRY_API void be_refpop(bvm *vm)
     }
 }
 
-BERRY_API int be_returnvalue(bvm *vm)
+BERRY_API void be_returnvalue(bvm *vm)
 {
     bvalue *src = vm->top - 1;
     bvalue *ret = retreg(vm);
     var_setval(ret, src);
-    return 0;
 }
 
-BERRY_API int be_returnnilvalue(bvm *vm)
+BERRY_API void be_returnnilvalue(bvm *vm)
 {
     bvalue *ret = retreg(vm);
     var_setnil(ret);
-    return 0;
 }
 
 BERRY_API void be_call(bvm *vm, int argc)
@@ -1087,7 +1085,7 @@ BERRY_API int be_getexcept(bvm *vm, int code)
     return code;
 }
 
-static int _dvfunc(bvm *vm, bbool esc)
+static void _dvfunc(bvm *vm, bbool esc)
 {
     const char* s = esc ?
         be_toescape(vm, 1, 'x') : be_tostring(vm, 1);
@@ -1095,14 +1093,14 @@ static int _dvfunc(bvm *vm, bbool esc)
     be_return_nil(vm);
 }
 
-static int _dumpesc(bvm *vm)
+static void _dumpesc(bvm *vm)
 {
-    return _dvfunc(vm, btrue);
+    _dvfunc(vm, btrue);
 }
 
-static int _dumpdir(bvm *vm)
+static void _dumpdir(bvm *vm)
 {
-    return _dvfunc(vm, bfalse);
+    _dvfunc(vm, bfalse);
 }
 
 static int dump_value(bvm *vm, int index, bbool esc)

--- a/src/be_baselib.c
+++ b/src/be_baselib.c
@@ -19,7 +19,7 @@
 
 #define READLINE_STEP       100
 
-int be_baselib_assert(bvm *vm)
+void be_baselib_assert(bvm *vm)
 {
     int argc = be_top(vm);
     /* assertion fails when there is no argument
@@ -34,7 +34,7 @@ int be_baselib_assert(bvm *vm)
     be_return_nil(vm);
 }
 
-int be_baselib_print(bvm *vm)
+void be_baselib_print(bvm *vm)
 {
     int i, argc = be_top(vm);
     for (i = 1; i <= argc; ++i) {
@@ -49,7 +49,7 @@ int be_baselib_print(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_readline(bvm *vm)
+static void m_readline(bvm *vm)
 {
     size_t pos = 0, size = READLINE_STEP;
     char *buffer = be_malloc(vm, size);
@@ -69,12 +69,12 @@ static int m_readline(bvm *vm)
     be_return(vm);
 }
 
-int be_baselib_input(bvm *vm)
+void be_baselib_input(bvm *vm)
 {
     if (be_top(vm) && be_isstring(vm, 1)) { /* echo prompt */
         be_writestring(be_tostring(vm, 1));
     }
-    return m_readline(vm);
+    m_readline(vm);
 }
 
 /* Look in the current class and all super classes for a method corresponding to a specific closure pointer */
@@ -119,7 +119,7 @@ static bbool obj2int(bvm *vm, bvalue *var, bint *val)
     return bfalse;
 }
 
-int be_baselib_super(bvm *vm)
+void be_baselib_super(bvm *vm)
 {
     int argc = be_top(vm);
 
@@ -198,7 +198,7 @@ int be_baselib_super(bvm *vm)
     be_return_nil(vm);
 }
 
-int be_baselib_type(bvm *vm)
+void be_baselib_type(bvm *vm)
 {
     if (be_top(vm)) {
         be_pushstring(vm, be_typename(vm, 1));
@@ -207,7 +207,7 @@ int be_baselib_type(bvm *vm)
     be_return_nil(vm);
 }
 
-int be_baselib_classname(bvm *vm)
+void be_baselib_classname(bvm *vm)
 {
     if (be_top(vm)) {
         const char *t = be_classname(vm, 1);
@@ -219,7 +219,7 @@ int be_baselib_classname(bvm *vm)
     be_return_nil(vm);
 }
 
-int be_baselib_classof(bvm *vm)
+void be_baselib_classof(bvm *vm)
 {
     if (be_top(vm) && be_classof(vm, 1)) {
         be_return(vm);
@@ -227,7 +227,7 @@ int be_baselib_classof(bvm *vm)
     be_return_nil(vm);
 }
 
-int be_baselib_number(bvm *vm)
+void be_baselib_number(bvm *vm)
 {
     if (be_top(vm)) {
         if (be_isstring(vm, 1)) {
@@ -241,7 +241,7 @@ int be_baselib_number(bvm *vm)
     be_return_nil(vm);
 }
 
-int be_baselib_int(bvm *vm)
+void be_baselib_int(bvm *vm)
 {
     if (be_top(vm)) {
         if (be_isstring(vm, 1)) {
@@ -273,7 +273,7 @@ int be_baselib_int(bvm *vm)
     be_return_nil(vm);
 }
 
-int be_baselib_real(bvm *vm)
+void be_baselib_real(bvm *vm)
 {
     if (be_top(vm)) {
         if (be_isstring(vm, 1)) {
@@ -297,7 +297,7 @@ static int check_method(bvm *vm, const char *attr)
         be_isinstance(vm, 1) && be_getmethod(vm, 1, attr);
 }
 
-int be_baselib_iterator(bvm *vm)
+void be_baselib_iterator(bvm *vm)
 {
     if (be_top(vm) && be_isfunction(vm, 1)) {
         be_return(vm); /* return the argument[0]::function */
@@ -316,7 +316,7 @@ int be_baselib_iterator(bvm *vm)
 /* then all subsequent arguments are pushed except the last one */
 /* If the last argument is a 'list', then all elements are pushed as arguments */
 /* otherwise the last argument is pushed as well */
-static int l_call(bvm *vm)
+static void l_call(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1 && (be_isfunction(vm, 1) || be_isclass(vm, 1))) {
@@ -358,7 +358,7 @@ static int l_call(bvm *vm)
     be_return_nil(vm);
 }
 
-int be_baselib_str(bvm *vm)
+void be_baselib_str(bvm *vm)
 {
     if (be_top(vm)) {
         be_tostring(vm, 1);
@@ -368,7 +368,7 @@ int be_baselib_str(bvm *vm)
     be_return(vm);
 }
 
-static int l_bool(bvm *vm)
+static void l_bool(bvm *vm)
 {
     if (be_top(vm)) {
         be_pushbool(vm, be_tobool(vm, 1));
@@ -379,7 +379,7 @@ static int l_bool(bvm *vm)
 }
 
 
-int be_baselib_size(bvm *vm)
+void be_baselib_size(bvm *vm)
 {
     if (be_top(vm) && be_isstring(vm, 1)) {
         be_pushint(vm, be_strlen(vm, 1));
@@ -394,7 +394,7 @@ int be_baselib_size(bvm *vm)
     be_return_nil(vm);
 }
 
-int be_baselib_module(bvm *vm)
+void be_baselib_module(bvm *vm)
 {
     int argc = be_top(vm);
     be_newmodule(vm);
@@ -405,14 +405,13 @@ int be_baselib_module(bvm *vm)
 }
 
 #if BE_USE_SCRIPT_COMPILER
-static int raise_compile_error(bvm *vm)
+static void raise_compile_error(bvm *vm)
 {
     be_pop(vm, 2); /* pop the exception value and message */
     be_throw(vm, BE_EXCEPTION);
-    return 0;
 }
 
-static int m_compile_str(bvm *vm)
+static void m_compile_str(bvm *vm)
 {
     int len = be_strlen(vm, 1);
     const char *src = be_tostring(vm, 1);
@@ -420,10 +419,10 @@ static int m_compile_str(bvm *vm)
     if (res == BE_OK) {
         be_return(vm);
     }
-    return raise_compile_error(vm);
+    raise_compile_error(vm);
 }
 
-static int m_compile_file(bvm *vm)
+static void m_compile_file(bvm *vm)
 {
     const char *fname = be_tostring(vm, 1);
     int res = be_loadfile(vm, fname);
@@ -433,31 +432,34 @@ static int m_compile_file(bvm *vm)
         be_pushstring(vm, "io_error");
         be_pushvalue(vm, -2);
     }
-    return raise_compile_error(vm);
+    raise_compile_error(vm);
 }
 #endif
 
-int be_baselib_compile(bvm *vm)
+void be_baselib_compile(bvm *vm)
 {
 #if BE_USE_SCRIPT_COMPILER
     if (be_top(vm) && be_isstring(vm, 1)) {
         if (be_top(vm) >= 2 && be_isstring(vm, 2)) {
             const char *s = be_tostring(vm, 2);
             if (!strcmp(s, "string")) {
-                return m_compile_str(vm);
+                m_compile_str(vm);
+                return;
             }
             if (!strcmp(s, "file")) {
-                return m_compile_file(vm);
+                m_compile_file(vm);
+                return;
             }
         } else {
-            return m_compile_str(vm);
+            m_compile_str(vm);
+            return;
         }
     }
 #endif
     be_return_nil(vm);
 }
 
-static int _issubv(bvm *vm, bbool (*filter)(bvm*, int))
+static void _issubv(bvm *vm, bbool (*filter)(bvm*, int))
 {
     bbool status = bfalse;
     if (be_top(vm) >= 2 && filter(vm, 1)) {
@@ -468,14 +470,14 @@ static int _issubv(bvm *vm, bbool (*filter)(bvm*, int))
     be_return(vm);
 }
 
-int be_baselib_issubclass(bvm *vm)
+void be_baselib_issubclass(bvm *vm)
 {
-    return _issubv(vm, be_isclass);
+    _issubv(vm, be_isclass);
 }
 
-int be_baselib_isinstance(bvm *vm)
+void be_baselib_isinstance(bvm *vm)
 {
-    return _issubv(vm, be_isinstance);
+    _issubv(vm, be_isinstance);
 }
 
 #if !BE_USE_PRECOMPILED_OBJECT
@@ -512,7 +514,7 @@ extern const bclass be_class_list;
 extern const bclass be_class_map;
 extern const bclass be_class_range;
 extern const bclass be_class_bytes;
-extern int be_nfunc_open(bvm *vm);
+extern void be_nfunc_open(bvm *vm);
 /* @const_object_info_begin
 vartab m_builtin (scope: local) {
     assert, func(be_baselib_assert)

--- a/src/be_baselib.h
+++ b/src/be_baselib.h
@@ -10,22 +10,22 @@
 
 #include "be_object.h"
 
-int be_baselib_assert(bvm *vm);
-int be_baselib_print(bvm *vm);
-int be_baselib_input(bvm *vm);
-int be_baselib_super(bvm *vm);
-int be_baselib_type(bvm *vm);
-int be_baselib_classname(bvm *vm);
-int be_baselib_classof(bvm *vm);
-int be_baselib_number(bvm *vm);
-int be_baselib_str(bvm *vm);
-int be_baselib_int(bvm *vm);
-int be_baselib_real(bvm *vm);
-int be_baselib_module(bvm *vm);
-int be_baselib_size(bvm *vm);
-int be_baselib_compile(bvm *vm);
-int be_baselib_issubclass(bvm *vm);
-int be_baselib_isinstance(bvm *vm);
-int be_baselib_iterator(bvm *vm);
+void be_baselib_assert(bvm *vm);
+void be_baselib_print(bvm *vm);
+void be_baselib_input(bvm *vm);
+void be_baselib_super(bvm *vm);
+void be_baselib_type(bvm *vm);
+void be_baselib_classname(bvm *vm);
+void be_baselib_classof(bvm *vm);
+void be_baselib_number(bvm *vm);
+void be_baselib_str(bvm *vm);
+void be_baselib_int(bvm *vm);
+void be_baselib_real(bvm *vm);
+void be_baselib_module(bvm *vm);
+void be_baselib_size(bvm *vm);
+void be_baselib_compile(bvm *vm);
+void be_baselib_issubclass(bvm *vm);
+void be_baselib_isinstance(bvm *vm);
+void be_baselib_iterator(bvm *vm);
 
 #endif

--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -610,7 +610,7 @@ static void bytes_new_object(bvm *vm, size_t size)
  *    Arg2: int - buffer size. Always fixed (negative or positive)
  *
  * */
-static int m_init(bvm *vm)
+static void m_init(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = { 0, 0, NULL, 0, -1, NULL, bfalse, bfalse, bfalse }; /* initialize prev_values to invalid to force a write at the end */
@@ -686,7 +686,7 @@ static int m_init(bvm *vm)
 }
 
 /* deallocate buffer */
-static int m_deinit(bvm *vm)
+static void m_deinit(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
     if (attr.bufptr != NULL && !attr.mapped) {
@@ -748,7 +748,7 @@ size_t be_bytes_tohex(char * out, size_t outsz, const uint8_t * in, size_t insz)
   return pout - out;
 }
 
-static int m_tostring(bvm *vm)
+static void m_tostring(bvm *vm)
 {
     int argc = be_top(vm);
     int32_t max_len = 32;  /* limit to 32 bytes by default */
@@ -781,7 +781,7 @@ static int m_tostring(bvm *vm)
     be_return(vm);
 }
 
-static int m_tohex(bvm *vm)
+static void m_tohex(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
     if (attr.bufptr) {              /* pointer looks valid */
@@ -802,7 +802,7 @@ static int m_tohex(bvm *vm)
 /*
  * Copy the buffer into a string without any changes
  */
-static int m_asstring(bvm *vm)
+static void m_asstring(bvm *vm)
 {
     buf_impl attr = bytes_check_data(vm, 0);
     check_ptr(vm, &attr);
@@ -814,7 +814,7 @@ static int m_asstring(bvm *vm)
     be_return(vm);
 }
 
-static int m_fromstring(bvm *vm)
+static void m_fromstring(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc >= 2 && be_isstring(vm, 2)) {
@@ -845,7 +845,7 @@ static int m_fromstring(bvm *vm)
  *       obvisouly -1 is idntical to 1
  *       size==0 does nothing
  */
-static int m_add(bvm *vm)
+static void m_add(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 4); /* we reserve 4 bytes anyways */
@@ -884,7 +884,7 @@ static int m_add(bvm *vm)
  *       obvisouly -1 is identical to 1
  *       0 returns nil
  */
-static int m_get(bvm *vm, bbool sign)
+static void m_get(bvm *vm, bbool sign)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
@@ -935,7 +935,7 @@ static int m_get(bvm *vm, bbool sign)
  * Get a float (32 bits)
  * `getfloat(index:int [, big_endian:bool]) -> real`
  */
-static int m_getfloat(bvm *vm)
+static void m_getfloat(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
@@ -962,15 +962,15 @@ static int m_getfloat(bvm *vm)
 }
 
 /* signed int */
-static int m_geti(bvm *vm)
+static void m_geti(bvm *vm)
 {
-    return m_get(vm, 1);
+    m_get(vm, 1);
 }
 
 /* unsigned int */
-static int m_getu(bvm *vm)
+static void m_getu(bvm *vm)
 {
-    return m_get(vm, 0);
+    m_get(vm, 0);
 }
 
 /*
@@ -981,7 +981,7 @@ static int m_getu(bvm *vm)
  *       obvisouly -1 is identical to 1
  *       0 returns nil
  */
-static int m_set(bvm *vm)
+static void m_set(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
@@ -1023,7 +1023,7 @@ static int m_set(bvm *vm)
  * `setfloat(index:int, value:real or int [, big_endian:bool]) -> nil`
  * 
  */
-static int m_setfloat(bvm *vm)
+static void m_setfloat(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
@@ -1054,7 +1054,7 @@ static int m_setfloat(bvm *vm)
  * `addfloat(value:real or int [, big_endian:bool]) -> instance`
  * 
  */
-static int m_addfloat(bvm *vm)
+static void m_addfloat(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 4); /* we reserve 4 bytes anyways */
@@ -1083,7 +1083,7 @@ static int m_addfloat(bvm *vm)
  * `setbytes(index:int, fill:bytes [, from:int, len:int]) -> nil`
  * 
  */
-static int m_setbytes(bvm *vm)
+static void m_setbytes(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
@@ -1130,7 +1130,7 @@ static int m_setbytes(bvm *vm)
  * `reverse([index:int, len:int, grouplen:int]) -> self`
  * 
  */
-static int m_reverse(bvm *vm)
+static void m_reverse(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
@@ -1182,7 +1182,7 @@ static int m_reverse(bvm *vm)
     be_return(vm);
 }
 
-static int m_setitem(bvm *vm)
+static void m_setitem(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
@@ -1203,7 +1203,7 @@ static int m_setitem(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_item(bvm *vm)
+static void m_item(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
@@ -1251,21 +1251,21 @@ static int m_item(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_size(bvm *vm)
+static void m_size(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
     be_pushint(vm, attr.len);
     be_return(vm);
 }
 
-static int m_tobool(bvm *vm)
+static void m_tobool(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
     be_pushbool(vm, attr.len > 0 ? 1 : 0);
     be_return(vm);
 }
 
-static int m_resize(bvm *vm)
+static void m_resize(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = m_read_attributes(vm, 1);
@@ -1289,7 +1289,7 @@ static int m_resize(bvm *vm)
     be_return(vm);
 }
 
-static int m_clear(bvm *vm)
+static void m_clear(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
     check_ptr_modifiable(vm, &attr);
@@ -1299,7 +1299,7 @@ static int m_clear(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_merge(bvm *vm)
+static void m_merge(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = m_read_attributes(vm, 1); /* no resize yet */
@@ -1332,7 +1332,7 @@ static int m_merge(bvm *vm)
     be_return_nil(vm); /* return self */
 }
 
-static int m_copy(bvm *vm)
+static void m_copy(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
     check_ptr(vm, &attr);
@@ -1345,7 +1345,7 @@ static int m_copy(bvm *vm)
 }
 
 /* accept bytes or int or nil as operand */
-static int m_connect(bvm *vm)
+static void m_connect(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = m_read_attributes(vm, 1);
@@ -1378,7 +1378,7 @@ static int m_connect(bvm *vm)
     be_return_nil(vm); /* return self */
 }
 
-static int m_appendhex(bvm *vm)
+static void m_appendhex(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = m_read_attributes(vm, 1);
@@ -1402,7 +1402,7 @@ static int m_appendhex(bvm *vm)
     be_return_nil(vm); /* return self */
 }
 
-static int m_appendb64(bvm *vm)
+static void m_appendb64(bvm *vm)
 {
     int argc = be_top(vm);
     buf_impl attr = m_read_attributes(vm, 1);
@@ -1439,7 +1439,7 @@ static int m_appendb64(bvm *vm)
     be_return_nil(vm); /* return self */
 }
 
-static int bytes_equal(bvm *vm, bbool iseq)
+static void bytes_equal(bvm *vm, bbool iseq)
 {
     bbool ret;
     buf_impl attr1 = m_read_attributes(vm, 1);
@@ -1458,14 +1458,14 @@ static int bytes_equal(bvm *vm, bbool iseq)
     be_return(vm);
 }
 
-static int m_equal(bvm *vm)
+static void m_equal(bvm *vm)
 {
-    return bytes_equal(vm, btrue);
+    bytes_equal(vm, btrue);
 }
 
-static int m_nequal(bvm *vm)
+static void m_nequal(bvm *vm)
 {
-    return bytes_equal(vm, bfalse);
+    bytes_equal(vm, bfalse);
 }
 
 /*
@@ -1475,7 +1475,7 @@ static int m_nequal(bvm *vm)
  * 
  * `b.tob64() -> string`
  */
-static int m_tob64(bvm *vm)
+static void m_tob64(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
     check_ptr(vm, &attr);
@@ -1495,7 +1495,7 @@ static int m_tob64(bvm *vm)
  * 
  * `bytes().fromb64() -> bytes()`
  */
-static int m_fromb64(bvm *vm)
+static void m_fromb64(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc >= 2 && be_isstring(vm, 2)) {
@@ -1527,7 +1527,7 @@ static int m_fromb64(bvm *vm)
  * 
  * `bytes().fromhexx() -> bytes()`
  */
-static int m_fromhex(bvm *vm)
+static void m_fromhex(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc >= 2 && be_isstring(vm, 2)) {
@@ -1575,7 +1575,7 @@ static int m_fromhex(bvm *vm)
  * 
  * `_buffer() -> comptr`
  */
-static int m_buffer(bvm *vm)
+static void m_buffer(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
     be_pushcomptr(vm, attr.bufptr);
@@ -1588,7 +1588,7 @@ static int m_buffer(bvm *vm)
  * 
  * `ismapped() -> bool`
  */
-static int m_is_mapped(bvm *vm)
+static void m_is_mapped(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
     bbool mapped = (attr.mapped || (attr.bufptr == NULL));
@@ -1601,7 +1601,7 @@ static int m_is_mapped(bvm *vm)
  * 
  * `isreadonly() -> bool`
  */
-static int m_is_readonly(bvm *vm)
+static void m_is_readonly(bvm *vm)
 {
     buf_impl attr = m_read_attributes(vm, 1);
     be_pushbool(vm, attr.solidified);
@@ -1617,7 +1617,7 @@ static int m_is_readonly(bvm *vm)
  * 
  * `_change_buffer(comptr) -> comptr`
  */
-static int m_change_buffer(bvm *vm)
+static void m_change_buffer(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc >= 2 && be_iscomptr(vm, 2)) {

--- a/src/be_debuglib.c
+++ b/src/be_debuglib.c
@@ -58,7 +58,7 @@ static void dump_value(bvalue *value)
     be_writestring(">, attributes:\n");
 }
 
-static int m_attrdump(bvm *vm)
+static void m_attrdump(bvm *vm)
 {
     if (be_top(vm) >= 1) {
         bvalue *v = be_indexof(vm, 1);
@@ -74,7 +74,7 @@ static int m_attrdump(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_codedump(bvm *vm)
+static void m_codedump(bvm *vm)
 {
     if (be_top(vm) >= 1) {
         bvalue *v = be_indexof(vm, 1);
@@ -85,7 +85,7 @@ static int m_codedump(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_gcdebug(bvm *vm) {
+static void m_gcdebug(bvm *vm) {
     int argc = be_top(vm);
     if (argc >= 1 && be_isbool(vm, 1)) {
         if (be_tobool(vm, 1)) {
@@ -98,13 +98,13 @@ static int m_gcdebug(bvm *vm) {
     be_return(vm);
 }
 
-static int m_traceback(bvm *vm)
+static void m_traceback(bvm *vm)
 {
     be_tracestack(vm);
     be_return_nil(vm);
 }
 
-static int m_caller(bvm *vm)
+static void m_caller(bvm *vm)
 {
     int depth = 1;
     if (be_top(vm) >= 1 && be_isint(vm, 1)) {
@@ -125,7 +125,7 @@ static int m_caller(bvm *vm)
 }
 
 #if BE_USE_DEBUG_HOOK
-static int m_sethook(bvm *vm)
+static void m_sethook(bvm *vm)
 {
     if (be_top(vm) >= 2) {
         be_pushvalue(vm, 1);
@@ -137,14 +137,14 @@ static int m_sethook(bvm *vm)
 }
 #endif
 
-static int m_top(bvm *vm)
+static void m_top(bvm *vm)
 {
     bint top = vm->top - vm->stack + 1;
     be_pushint(vm, top);
     be_return(vm);
 }
 
-static int m_calldepth(bvm *vm)
+static void m_calldepth(bvm *vm)
 {
     bint depth = be_stack_count(&vm->callstack);
     be_pushint(vm, depth);
@@ -152,7 +152,7 @@ static int m_calldepth(bvm *vm)
 }
 
 #if BE_DEBUG_VAR_INFO
-static int v_getname(bvm *vm, bbool(*getter)(bvm *vm, int, int))
+static void v_getname(bvm *vm, bbool(*getter)(bvm *vm, int, int))
 {
     int index, level = 1;
     if (be_top(vm) < 1)
@@ -172,14 +172,14 @@ static int v_getname(bvm *vm, bbool(*getter)(bvm *vm, int, int))
     be_return_nil(vm);
 }
 
-static int m_varname(bvm *vm)
+static void m_varname(bvm *vm)
 {
-    return v_getname(vm, be_debug_varname);
+    v_getname(vm, be_debug_varname);
 }
 
-static int m_upvname(bvm *vm)
+static void m_upvname(bvm *vm)
 {
-    return v_getname(vm, be_debug_upvname);
+    v_getname(vm, be_debug_upvname);
 }
 #endif
 
@@ -193,7 +193,7 @@ static void map_insert(bvm *vm, const char *key, int value)
     be_pop(vm, 2);
 }
 
-static int m_counters(bvm *vm)
+static void m_counters(bvm *vm)
 {
     be_newobject(vm, "map");
     map_insert(vm, "instruction", vm->counter_ins);
@@ -213,7 +213,7 @@ static int m_counters(bvm *vm)
 }
 #endif
 
-static int m_allocs(bvm *vm) {
+static void m_allocs(bvm *vm) {
 #if BE_USE_PERF_COUNTERS
     be_pushint(vm, vm->counter_mem_alloc);
     be_return(vm);
@@ -222,7 +222,7 @@ static int m_allocs(bvm *vm) {
 #endif
 }
 
-static int m_frees(bvm *vm) {
+static void m_frees(bvm *vm) {
 #if BE_USE_PERF_COUNTERS
     be_pushint(vm, vm->counter_mem_free);
     be_return(vm);
@@ -231,7 +231,7 @@ static int m_frees(bvm *vm) {
 #endif
 }
 
-static int m_reallocs(bvm *vm) {
+static void m_reallocs(bvm *vm) {
 #if BE_USE_PERF_COUNTERS
     be_pushint(vm, vm->counter_mem_realloc);
     be_return(vm);

--- a/src/be_filelib.c
+++ b/src/be_filelib.c
@@ -15,7 +15,7 @@
 
 #define READLINE_STEP           100
 
-static int i_write(bvm *vm)
+static void i_write(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     if(be_iscomptr(vm, -1) && (be_isstring(vm, 2) || be_isbytes(vm, 2))) {
@@ -44,7 +44,7 @@ static size_t readsize(bvm *vm, int argc, void *fh)
     return be_fsize(fh) - be_ftell(fh);
 }
 
-static int i_read(bvm *vm)
+static void i_read(bvm *vm)
 {
     int argc = be_top(vm);
     be_getmember(vm, 1, ".p");
@@ -64,7 +64,7 @@ static int i_read(bvm *vm)
     be_return_nil(vm);
 }
 
-static int i_readbytes(bvm *vm)
+static void i_readbytes(bvm *vm)
 {
     int argc = be_top(vm);
     be_getmember(vm, 1, ".p");
@@ -114,7 +114,7 @@ static int i_readbytes(bvm *vm)
     be_return_nil(vm);
 }
 
-static int i_readline(bvm *vm)
+static void i_readline(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     if (be_iscomptr(vm, -1)) {
@@ -138,7 +138,7 @@ static int i_readline(bvm *vm)
     be_return_nil(vm);
 }
 
-static int i_seek(bvm *vm)
+static void i_seek(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     if (be_iscomptr(vm, -1) && be_isint(vm, 2)) {
@@ -148,7 +148,7 @@ static int i_seek(bvm *vm)
     be_return_nil(vm);
 }
 
-static int i_tell(bvm *vm)
+static void i_tell(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     if (be_iscomptr(vm, -1)) {
@@ -160,7 +160,7 @@ static int i_tell(bvm *vm)
     be_return_nil(vm);
 }
 
-static int i_size(bvm *vm)
+static void i_size(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     if (be_iscomptr(vm, -1)) {
@@ -172,7 +172,7 @@ static int i_size(bvm *vm)
     be_return_nil(vm);
 }
 
-static int i_flush(bvm *vm)
+static void i_flush(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     if (be_iscomptr(vm, -1)) {
@@ -182,7 +182,7 @@ static int i_flush(bvm *vm)
     be_return_nil(vm);
 }
 
-static int i_close(bvm *vm)
+static void i_close(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     if (be_iscomptr(vm, -1)) {
@@ -194,7 +194,7 @@ static int i_close(bvm *vm)
     be_return_nil(vm);
 }
 
-static int i_savecode(bvm *vm)
+static void i_savecode(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc >= 2 && be_isclosure(vm, 2)) {
@@ -215,9 +215,9 @@ static int i_savecode(bvm *vm)
 }
 
 #if !BE_USE_PRECOMPILED_OBJECT
-static int m_open(bvm *vm)
+static void m_open(bvm *vm)
 #else
-int be_nfunc_open(bvm *vm)
+void be_nfunc_open(bvm *vm)
 #endif
 {
     int argc = be_top(vm);

--- a/src/be_gclib.c
+++ b/src/be_gclib.c
@@ -10,7 +10,7 @@
 
 #if BE_USE_GC_MODULE
 
-static int m_allocated(bvm *vm)
+static void m_allocated(bvm *vm)
 {
     size_t count = be_gc_memcount(vm);
     if (count < 0x80000000) {
@@ -21,7 +21,7 @@ static int m_allocated(bvm *vm)
     be_return(vm);
 }
 
-static int m_collect(bvm *vm)
+static void m_collect(bvm *vm)
 {
     be_gc_collect(vm);
     be_return_nil(vm);

--- a/src/be_globallib.c
+++ b/src/be_globallib.c
@@ -39,7 +39,7 @@ static void dump_map_keys(bvm *vm, bmap *map)
     }
 }
 
-static int m_globals(bvm *vm)
+static void m_globals(bvm *vm)
 {
     be_newobject(vm, "list");
     dump_map_keys(vm, global(vm).vtab);
@@ -47,7 +47,7 @@ static int m_globals(bvm *vm)
     be_return(vm);
 }
 
-static int m_contains(bvm *vm)
+static void m_contains(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1 && be_isstring(vm, 1)) {
@@ -59,7 +59,7 @@ static int m_contains(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_findglobal(bvm *vm)
+static void m_findglobal(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1 && be_isstring(vm, 1)) {
@@ -70,7 +70,7 @@ static int m_findglobal(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_setglobal(bvm *vm)
+static void m_setglobal(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 2 && be_isstring(vm, 1)) {
@@ -83,7 +83,7 @@ static int m_setglobal(bvm *vm)
 /* Remove a global variable from global scope */
 /* Internally the global name cannot be removed but it's value is replaced with BE_NONE */
 /* and global function pretend that BE_NONE is equivalent to the name being absent */
-static int m_undef(bvm *vm)
+static void m_undef(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1 && be_isstring(vm, 1)) {

--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -37,7 +37,7 @@ static void dump_map_keys(bvm *vm, bmap *map)
     }
 }
 
-static int m_attrlist(bvm *vm)
+static void m_attrlist(bvm *vm)
 {
     int top = be_top(vm);
     be_newobject(vm, "list");
@@ -63,7 +63,7 @@ static void m_findmember_protected(bvm *vm, void* data)
     be_getmember(vm, 1, (const char*) data);
 }
 
-static int m_findmember(bvm *vm)
+static void m_findmember(bvm *vm)
 {
     int top = be_top(vm);
     bbool protected = btrue; /* run protected, i.e. don't raise an exception if not found */
@@ -93,7 +93,7 @@ static int m_findmember(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_contains(bvm *vm)
+static void m_contains(bvm *vm)
 {
     bbool contains = bfalse;
     int top = be_top(vm);
@@ -106,7 +106,7 @@ static int m_contains(bvm *vm)
     be_return(vm);
 }
 
-static int m_setmember(bvm *vm)
+static void m_setmember(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 3 && (be_isinstance(vm, 1) || be_ismodule(vm, 1) || be_isclass(vm, 1)) && be_isstring(vm, 2)) {
@@ -116,7 +116,7 @@ static int m_setmember(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_toptr(bvm *vm)
+static void m_toptr(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1) {
@@ -137,7 +137,7 @@ static int m_toptr(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_solidified(bvm *vm)
+static void m_solidified(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1) {
@@ -151,7 +151,7 @@ static int m_solidified(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_fromptr(bvm *vm)
+static void m_fromptr(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1) {
@@ -176,7 +176,7 @@ static int m_fromptr(bvm *vm)
 }
 
 /* load module by name, like `import` would do. But don't create a global variable from it. */
-static int m_getmodule(bvm *vm)
+static void m_getmodule(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1) {
@@ -192,7 +192,7 @@ static int m_getmodule(bvm *vm)
 }
 
 /* set or chang the cached value for the named module, this allows monkey patching. **USE WITH CARE** */
-static int m_setmodule(bvm *vm)
+static void m_setmodule(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 2) {
@@ -206,7 +206,7 @@ static int m_setmodule(bvm *vm)
 }
 
 /* checks if the function (berry bytecode bproto only) is hinted as a method */
-static int m_ismethod(bvm *vm)
+static void m_ismethod(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1) {
@@ -221,7 +221,7 @@ static int m_ismethod(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_name(bvm *vm)
+static void m_name(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1) {

--- a/src/be_jsonlib.c
+++ b/src/be_jsonlib.c
@@ -365,7 +365,7 @@ static const char* parser_value(bvm *vm, const char *json)
     return NULL;
 }
 
-static int m_json_load(bvm *vm)
+static void m_json_load(bvm *vm)
 {
     if (be_isstring(vm, 1)) {
         const char *json = be_tostring(vm, 1);
@@ -503,7 +503,7 @@ static void value_dump(bvm *vm, int *indent, int idx, int fmt)
     }
 }
 
-static int m_json_dump(bvm *vm)
+static void m_json_dump(bvm *vm)
 {
     int indent = 0, argc = be_top(vm);
     int fmt = 0;

--- a/src/be_listlib.c
+++ b/src/be_listlib.c
@@ -32,7 +32,7 @@ static void list_getindex(bvm *vm, int index)
     }
 }
 
-static int m_init(bvm *vm)
+static void m_init(bvm *vm)
 {
     int i, argc = be_top(vm);
     if (argc > 1 && be_islist(vm, 2)) {
@@ -57,7 +57,7 @@ static void push_element(bvm *vm)
     be_pop(vm, 1);
 }
 
-static int m_tostring(bvm *vm)
+static void m_tostring(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 1);
@@ -82,7 +82,7 @@ static int m_tostring(bvm *vm)
     be_return(vm);
 }
 
-static int m_push(bvm *vm)
+static void m_push(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 2);
@@ -91,7 +91,7 @@ static int m_push(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_pop(bvm *vm)
+static void m_pop(bvm *vm)
 {
     int argc = be_top(vm);
     be_getmember(vm, 1, ".p");
@@ -108,7 +108,7 @@ static int m_pop(bvm *vm)
     be_return(vm);
 }
 
-static int m_insert(bvm *vm)
+static void m_insert(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 3);
@@ -118,7 +118,7 @@ static int m_insert(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_remove(bvm *vm)
+static void m_remove(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 2);
@@ -127,7 +127,7 @@ static int m_remove(bvm *vm)
     be_return_nil(vm);
 }
 
-static int item_range(bvm *vm)
+static void item_range(bvm *vm)
 {
     bint lower, upper;
     bint size = be_data_size(vm, -1); /* get source list size */
@@ -161,7 +161,7 @@ static int item_range(bvm *vm)
     be_return(vm);
 }
 
-static int item_list(bvm *vm)
+static void item_list(bvm *vm)
 {
     int i, srcsize, idxsize;
     be_getmember(vm, 2, ".p"); /* get index list */
@@ -191,7 +191,7 @@ static int item_list(bvm *vm)
     be_return(vm);
 }
 
-static int m_item(bvm *vm)
+static void m_item(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 2);
@@ -203,17 +203,19 @@ static int m_item(bvm *vm)
     if (be_isinstance(vm, 2)) {
         const char *cname = be_classname(vm, 2);
         if (!strcmp(cname, "range")) {
-            return item_range(vm);
+            item_range(vm);
+            return;
         }
         if (!strcmp(cname, "list")) {
-            return item_list(vm);
+            item_list(vm);
+            return;
         }
     }
     be_raise(vm, "index_error", "list index out of range");
     be_return_nil(vm);
 }
 
-static int m_find(bvm *vm)
+static void m_find(bvm *vm)
 {
     bbool found = bfalse;
     int idx;
@@ -242,7 +244,7 @@ static int m_find(bvm *vm)
     }
 }
 
-static int m_setitem(bvm *vm)
+static void m_setitem(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 3);
@@ -254,7 +256,7 @@ static int m_setitem(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_size(bvm *vm)
+static void m_size(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 1);
@@ -262,7 +264,7 @@ static int m_size(bvm *vm)
     be_return(vm);
 }
 
-static int m_tobool(bvm *vm)
+static void m_tobool(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 1);
@@ -270,7 +272,7 @@ static int m_tobool(bvm *vm)
     be_return(vm);
 }
 
-static int m_resize(bvm *vm)
+static void m_resize(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 2);
@@ -279,7 +281,7 @@ static int m_resize(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_clear(bvm *vm)
+static void m_clear(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 1);
@@ -288,7 +290,7 @@ static int m_clear(bvm *vm)
     be_return_nil(vm);
 }
 
-static int iter_closure(bvm *vm)
+static void iter_closure(bvm *vm)
 {
     /* for better performance, we operate the upvalues
      * directly without using by the stack. */
@@ -307,7 +309,7 @@ static int iter_closure(bvm *vm)
     be_return(vm);
 }
 
-static int m_iter(bvm *vm)
+static void m_iter(bvm *vm)
 {
     be_pushntvclosure(vm, iter_closure, 2);
     be_getmember(vm, 1, ".p");
@@ -318,7 +320,7 @@ static int m_iter(bvm *vm)
     be_return(vm);
 }
 
-static int m_connect(bvm *vm)
+static void m_connect(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc >= 2) {
@@ -330,7 +332,7 @@ static int m_connect(bvm *vm)
     be_return(vm); /* return self */
 }
 
-static int m_merge(bvm *vm)
+static void m_merge(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc >= 2) {
@@ -408,7 +410,7 @@ static void list_concat(bvm *vm, blist *list, const char * delimiter)
     }
 }
 
-static int m_concat(bvm *vm)
+static void m_concat(bvm *vm)
 {
     bvalue *value;
     int top = be_top(vm);
@@ -423,7 +425,7 @@ static int m_concat(bvm *vm)
     be_return(vm);
 }
 
-static int m_reverse(bvm *vm)
+static void m_reverse(bvm *vm)
 {
     int top = be_top(vm);
     be_getmember(vm, 1, ".p");
@@ -433,7 +435,7 @@ static int m_reverse(bvm *vm)
     be_return(vm);
 }
 
-static int m_copy(bvm *vm)
+static void m_copy(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 1);
@@ -444,7 +446,7 @@ static int m_copy(bvm *vm)
     be_return(vm);
 }
 
-static int list_equal(bvm *vm, bbool iseq)
+static void list_equal(bvm *vm, bbool iseq)
 {
     int i, j, res;
     bbool (*eqfunc)(bvm*) = iseq ? be_iseq : be_isneq;
@@ -470,7 +472,7 @@ static int list_equal(bvm *vm, bbool iseq)
     be_return(vm);
 }
 
-static int m_keys(bvm *vm)
+static void m_keys(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 1);
@@ -483,14 +485,14 @@ static int m_keys(bvm *vm)
     be_return(vm);
 }
 
-static int m_equal(bvm *vm)
+static void m_equal(bvm *vm)
 {
-    return list_equal(vm, btrue);
+    list_equal(vm, btrue);
 }
 
-static int m_nequal(bvm *vm)
+static void m_nequal(bvm *vm)
 {
-    return list_equal(vm, bfalse);
+    list_equal(vm, bfalse);
 }
 
 #if !BE_USE_PRECOMPILED_OBJECT

--- a/src/be_maplib.c
+++ b/src/be_maplib.c
@@ -22,7 +22,7 @@
         be_return(vm);                                  \
     }
 
-static int m_init(bvm *vm)
+static void m_init(bvm *vm)
 {
     if (be_top(vm) > 1 && be_ismap(vm, 2)) {
         be_pushvalue(vm, 2);
@@ -54,7 +54,7 @@ static void push_value(bvm *vm)
     }
 }
 
-static int m_tostring(bvm *vm)
+static void m_tostring(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     map_check_data(vm, 1);
@@ -78,7 +78,7 @@ static int m_tostring(bvm *vm)
     be_return(vm);
 }
 
-static int m_remove(bvm *vm)
+static void m_remove(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     map_check_data(vm, 2);
@@ -87,7 +87,7 @@ static int m_remove(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_item(bvm *vm)
+static void m_item(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     map_check_data(vm, 2);
@@ -98,7 +98,7 @@ static int m_item(bvm *vm)
     be_return(vm);
 }
 
-static int m_setitem(bvm *vm)
+static void m_setitem(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     map_check_data(vm, 3);
@@ -108,7 +108,7 @@ static int m_setitem(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_find(bvm *vm)
+static void m_find(bvm *vm)
 {
     int argc = be_top(vm);
     be_getmember(vm, 1, ".p");
@@ -121,7 +121,7 @@ static int m_find(bvm *vm)
     be_return(vm);
 }
 
-static int m_contains(bvm *vm)
+static void m_contains(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     map_check_data(vm, 2);
@@ -130,7 +130,7 @@ static int m_contains(bvm *vm)
     be_return(vm);
 }
 
-static int m_insert(bvm *vm)
+static void m_insert(bvm *vm)
 {
     bbool res;
     be_getmember(vm, 1, ".p");
@@ -142,7 +142,7 @@ static int m_insert(bvm *vm)
     be_return(vm);
 }
 
-static int m_size(bvm *vm)
+static void m_size(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     map_check_data(vm, 1);
@@ -150,7 +150,7 @@ static int m_size(bvm *vm)
     be_return(vm);
 }
 
-static int m_tobool(bvm *vm)
+static void m_tobool(bvm *vm)
 {
     be_getmember(vm, 1, ".p");
     map_check_data(vm, 1);
@@ -158,7 +158,7 @@ static int m_tobool(bvm *vm)
     be_return(vm);
 }
 
-static int iter_closure(bvm *vm)
+static void iter_closure(bvm *vm)
 {
     /* for better performance, we operate the upvalues
      * directly without using by the stack. */
@@ -178,7 +178,7 @@ static int iter_closure(bvm *vm)
     be_return(vm);
 }
 
-static int m_iter(bvm *vm)
+static void m_iter(bvm *vm)
 {
     be_pushntvclosure(vm, iter_closure, 2);
     be_getmember(vm, 1, ".p");
@@ -189,7 +189,7 @@ static int m_iter(bvm *vm)
     be_return(vm);
 }
 
-static int keys_iter_closure(bvm *vm)
+static void keys_iter_closure(bvm *vm)
 {
     /* for better performance, we operate the upvalues
      * directly without using by the stack. */
@@ -209,7 +209,7 @@ static int keys_iter_closure(bvm *vm)
     be_return(vm);
 }
 
-static int m_keys(bvm *vm)
+static void m_keys(bvm *vm)
 {
     be_pushntvclosure(vm, keys_iter_closure, 2);
     be_getmember(vm, 1, ".p");

--- a/src/be_mathlib.c
+++ b/src/be_mathlib.c
@@ -34,7 +34,7 @@
   #define mathfunc(func)        func
 #endif
 
-static int m_isnan(bvm *vm)
+static void m_isnan(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isreal(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -45,7 +45,7 @@ static int m_isnan(bvm *vm)
     be_return(vm);
 }
 
-static int m_isinf(bvm *vm)
+static void m_isinf(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isreal(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -56,7 +56,7 @@ static int m_isinf(bvm *vm)
     be_return(vm);
 }
 
-static int m_abs(bvm *vm)
+static void m_abs(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -67,7 +67,7 @@ static int m_abs(bvm *vm)
     be_return(vm);
 }
 
-static int m_ceil(bvm *vm)
+static void m_ceil(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -78,7 +78,7 @@ static int m_ceil(bvm *vm)
     be_return(vm);
 }
 
-static int m_floor(bvm *vm)
+static void m_floor(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -89,7 +89,7 @@ static int m_floor(bvm *vm)
     be_return(vm);
 }
 
-static int m_round(bvm *vm)
+static void m_round(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -100,7 +100,7 @@ static int m_round(bvm *vm)
     be_return(vm);
 }
 
-static int m_sin(bvm *vm)
+static void m_sin(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -111,7 +111,7 @@ static int m_sin(bvm *vm)
     be_return(vm);
 }
 
-static int m_cos(bvm *vm)
+static void m_cos(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -122,7 +122,7 @@ static int m_cos(bvm *vm)
     be_return(vm);
 }
 
-static int m_tan(bvm *vm)
+static void m_tan(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -133,7 +133,7 @@ static int m_tan(bvm *vm)
     be_return(vm);
 }
 
-static int m_asin(bvm *vm)
+static void m_asin(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -144,7 +144,7 @@ static int m_asin(bvm *vm)
     be_return(vm);
 }
 
-static int m_acos(bvm *vm)
+static void m_acos(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -155,7 +155,7 @@ static int m_acos(bvm *vm)
     be_return(vm);
 }
 
-static int m_atan(bvm *vm)
+static void m_atan(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -166,7 +166,7 @@ static int m_atan(bvm *vm)
     be_return(vm);
 }
 
-static int m_atan2(bvm *vm)
+static void m_atan2(bvm *vm)
 {
     if (be_top(vm) >= 2 && be_isnumber(vm, 1) && be_isnumber(vm, 2)) {
         breal y = be_toreal(vm, 1);
@@ -178,7 +178,7 @@ static int m_atan2(bvm *vm)
     be_return(vm);
 }
 
-static int m_sinh(bvm *vm)
+static void m_sinh(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -189,7 +189,7 @@ static int m_sinh(bvm *vm)
     be_return(vm);
 }
 
-static int m_cosh(bvm *vm)
+static void m_cosh(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -200,7 +200,7 @@ static int m_cosh(bvm *vm)
     be_return(vm);
 }
 
-static int m_tanh(bvm *vm)
+static void m_tanh(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -211,7 +211,7 @@ static int m_tanh(bvm *vm)
     be_return(vm);
 }
 
-static int m_sqrt(bvm *vm)
+static void m_sqrt(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -222,7 +222,7 @@ static int m_sqrt(bvm *vm)
     be_return(vm);
 }
 
-static int m_exp(bvm *vm)
+static void m_exp(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -233,7 +233,7 @@ static int m_exp(bvm *vm)
     be_return(vm);
 }
 
-static int m_log(bvm *vm)
+static void m_log(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -244,7 +244,7 @@ static int m_log(bvm *vm)
     be_return(vm);
 }
 
-static int m_log10(bvm *vm)
+static void m_log10(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -255,7 +255,7 @@ static int m_log10(bvm *vm)
     be_return(vm);
 }
 
-static int m_deg(bvm *vm)
+static void m_deg(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -266,7 +266,7 @@ static int m_deg(bvm *vm)
     be_return(vm);
 }
 
-static int m_rad(bvm *vm)
+static void m_rad(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
         breal x = be_toreal(vm, 1);
@@ -277,7 +277,7 @@ static int m_rad(bvm *vm)
     be_return(vm);
 }
 
-static int m_pow(bvm *vm)
+static void m_pow(bvm *vm)
 {
     if (be_top(vm) >= 2 && be_isnumber(vm, 1) && be_isnumber(vm, 2)) {
         breal x = be_toreal(vm, 1);
@@ -289,7 +289,7 @@ static int m_pow(bvm *vm)
     be_return(vm);
 }
 
-static int m_srand(bvm *vm)
+static void m_srand(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isint(vm, 1)) {
         srand((unsigned int)be_toint(vm, 1));
@@ -297,7 +297,7 @@ static int m_srand(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_rand(bvm *vm)
+static void m_rand(bvm *vm)
 {
     be_pushint(vm, rand());
     be_return(vm);
@@ -318,7 +318,7 @@ static int m_check_int_or_has_real(bvm *vm)
     return has_real;
 }
 
-static int m_min_max(bvm *vm, int is_min) {
+static void m_min_max(bvm *vm, int is_min) {
     int argc = be_top(vm);
     if (argc > 0) {
         /* see if at least one argument is float, else they are all ints */
@@ -348,14 +348,14 @@ static int m_min_max(bvm *vm, int is_min) {
 
 }
 
-int m_min(bvm *vm)
+void m_min(bvm *vm)
 {
-    return m_min_max(vm, 1);
+    m_min_max(vm, 1);
 }
 
-int m_max(bvm *vm)
+void m_max(bvm *vm)
 {
-    return m_min_max(vm, 0);
+    m_min_max(vm, 0);
 }
 
 #if !BE_USE_PRECOMPILED_OBJECT

--- a/src/be_object.c
+++ b/src/be_object.c
@@ -73,7 +73,7 @@ void be_commonobj_delete(bvm *vm, bgcobject *obj)
 }
 
 /* generic destroy method for comobj, just call be_os_free() on the pointer */
-int be_commonobj_destroy_generic(bvm* vm)
+void be_commonobj_destroy_generic(bvm* vm)
 {
     int argc = be_top(vm);
     if (argc > 0) {

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -262,6 +262,6 @@ typedef const char* (*breader)(struct blexer*, void*, size_t*);
 const char* be_vtype2str(bvalue *v);
 bvalue* be_indexof(bvm *vm, int idx);
 void be_commonobj_delete(bvm *vm, bgcobject *obj);
-int be_commonobj_destroy_generic(bvm* vm);
+void be_commonobj_destroy_generic(bvm* vm);
 
 #endif

--- a/src/be_oslib.c
+++ b/src/be_oslib.c
@@ -20,7 +20,7 @@
   #error the dependent macro BE_USE_FILE_SYSTEM must be enabled
 #endif
 
-static int m_getcwd(bvm *vm)
+static void m_getcwd(bvm *vm)
 {
     char *buf = be_malloc(vm, FNAME_BUF_SIZE);
     if (be_getcwd(buf, FNAME_BUF_SIZE)) {
@@ -32,7 +32,7 @@ static int m_getcwd(bvm *vm)
     be_return(vm);
 }
 
-static int m_chdir(bvm *vm)
+static void m_chdir(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
         int res = be_chdir(be_tostring(vm, 1));
@@ -41,7 +41,7 @@ static int m_chdir(bvm *vm)
     be_return(vm);
 }
 
-static int m_mkdir(bvm *vm)
+static void m_mkdir(bvm *vm)
 {
     int res = 1;
     if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
@@ -51,7 +51,7 @@ static int m_mkdir(bvm *vm)
     be_return(vm);
 }
 
-static int m_remove(bvm *vm)
+static void m_remove(bvm *vm)
 {
     int res = 1;
     if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
@@ -61,7 +61,7 @@ static int m_remove(bvm *vm)
     be_return(vm);
 }
 
-static int m_listdir(bvm *vm)
+static void m_listdir(bvm *vm)
 {
     int res;
     bdirinfo info;
@@ -85,7 +85,7 @@ static int m_listdir(bvm *vm)
     be_return(vm);
 }
 
-static int m_system(bvm *vm)
+static void m_system(bvm *vm)
 {
     int res = -1, i, argc = be_top(vm);
     if (argc > 0) {
@@ -105,7 +105,7 @@ static int m_system(bvm *vm)
     be_return(vm);
 }
 
-static int m_exit(bvm *vm)
+static void m_exit(bvm *vm)
 {
     int status = 0;
     if (be_top(vm)) {
@@ -121,7 +121,7 @@ static int m_exit(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_path_isdir(bvm *vm)
+static void m_path_isdir(bvm *vm)
 {
     const char *path = NULL;
     if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
@@ -131,7 +131,7 @@ static int m_path_isdir(bvm *vm)
     be_return(vm);
 }
 
-static int m_path_isfile(bvm *vm)
+static void m_path_isfile(bvm *vm)
 {
     const char *path = NULL;
     if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
@@ -141,7 +141,7 @@ static int m_path_isfile(bvm *vm)
     be_return(vm);
 }
 
-static int m_path_split(bvm *vm)
+static void m_path_split(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
         const char *path = be_tostring(vm, 1);
@@ -163,7 +163,7 @@ static int m_path_split(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_path_splitext(bvm *vm)
+static void m_path_splitext(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
         const char *path = be_tostring(vm, 1);
@@ -177,7 +177,7 @@ static int m_path_splitext(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_path_exists(bvm *vm)
+static void m_path_exists(bvm *vm)
 {
     const char *path = NULL;
     if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
@@ -187,7 +187,7 @@ static int m_path_exists(bvm *vm)
     be_return(vm);
 }
 
-static int m_path_join(bvm *vm)
+static void m_path_join(bvm *vm)
 {
     char *buf, *p;
     int i, len = 0, argc = be_top(vm);

--- a/src/be_rangelib.c
+++ b/src/be_rangelib.c
@@ -9,7 +9,7 @@
 #include "be_func.h"
 #include "be_vm.h"
 
-static int m_init(bvm *vm)
+static void m_init(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc < 3) { be_raise(vm, "value_error", "missing arguments"); }
@@ -30,7 +30,7 @@ static int m_init(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_tostring(bvm *vm)
+static void m_tostring(bvm *vm)
 {
     be_getmember(vm, 1, "__incr__");
     int incr = be_toint(vm, -1);
@@ -78,25 +78,25 @@ static int m_tostring(bvm *vm)
     be_return(vm);
 }
 
-static int m_upper(bvm *vm)
+static void m_upper(bvm *vm)
 {
     be_getmember(vm, 1, "__upper__");
     be_return(vm);
 }
 
-static int m_lower(bvm *vm)
+static void m_lower(bvm *vm)
 {
     be_getmember(vm, 1, "__lower__");
     be_return(vm);
 }
 
-static int m_incr(bvm *vm)
+static void m_incr(bvm *vm)
 {
     be_getmember(vm, 1, "__incr__");
     be_return(vm);
 }
 
-static int m_setrange(bvm *vm)
+static void m_setrange(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc < 3) { be_raise(vm, "value_error", "missing arguments"); }
@@ -117,7 +117,7 @@ static int m_setrange(bvm *vm)
     be_return_nil(vm);
 }
 
-static int iter_closure(bvm *vm)
+static void iter_closure(bvm *vm)
 {
     /* for better performance, we operate the upvalues
      * directly without using by the stack. */
@@ -136,7 +136,7 @@ static int iter_closure(bvm *vm)
     be_return(vm);
 }
 
-static int m_iter(bvm *vm)
+static void m_iter(bvm *vm)
 {
     be_pushntvclosure(vm, iter_closure, 3);
     be_getmember(vm, 1, "__lower__");

--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -568,7 +568,7 @@ static void m_solidify_module(bvm *vm, bbool str_literal, bmodule *ml, void* fou
 
 }
 
-static int m_dump(bvm *vm)
+static void m_dump(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1) {
@@ -818,7 +818,7 @@ static void m_compact_class(bvm *vm, bbool str_literal, const bclass *cla, void*
 // build a consolidated 'ktab' array
 // check that the array is not bigger than 256 (which is the max acceptable constants)
 // (for now) print the potential saving
-static int m_compact(bvm *vm)
+static void m_compact(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1) {
@@ -850,7 +850,7 @@ static int m_compact(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_nocompact(bvm *vm)
+static void m_nocompact(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1) {

--- a/src/be_strictlib.c
+++ b/src/be_strictlib.c
@@ -16,7 +16,7 @@
 
 #if BE_USE_STRICT_MODULE
 
-static int m_init(bvm *vm)
+static void m_init(bvm *vm)
 {
     comp_set_strict(vm);    /* enable compiler strict mode */
     be_return_nil(vm);

--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -665,7 +665,7 @@ static bbool convert_to_real(bvm *vm, int index, breal *val)
     return converted;
 }
 
-int be_str_format(bvm *vm)
+void be_str_format(bvm *vm)
 {
     int top = be_top(vm);
     if (top > 0 && be_isstring(vm, 1)) {
@@ -798,7 +798,7 @@ static bint _sfind(const char *s1, const char *s2, bint begin, bint end)
     return -1;
 }
 
-static int str_find(bvm *vm)
+static void str_find(bvm *vm)
 {
     be_pushint(vm, str_operation(vm, _sfind, -1));
     be_return(vm);
@@ -815,7 +815,7 @@ static bint _scount(const char *s1, const char *s2, bint begin, bint end)
     return count;
 }
 
-static int str_count(bvm *vm)
+static void str_count(bvm *vm)
 {
     be_pushint(vm, str_operation(vm, _scount, 0));
     be_return(vm);
@@ -866,7 +866,7 @@ static bbool _split_index(bvm *vm)
     return bfalse;
 }
 
-static int str_split(bvm *vm)
+static void str_split(bvm *vm)
 {
     int top = be_top(vm);
     be_newobject(vm, "list");
@@ -878,7 +878,7 @@ static int str_split(bvm *vm)
     be_return(vm);
 }
 
-static int str_i2hex(bvm *vm)
+static void str_i2hex(bvm *vm)
 {
     int top = be_top(vm);
     if (top && be_isint(vm, 1)) {
@@ -897,7 +897,7 @@ static int str_i2hex(bvm *vm)
     be_return_nil(vm);
 }
 
-static int str_byte(bvm *vm)
+static void str_byte(bvm *vm)
 {
     if (be_top(vm) && be_isstring(vm, 1)) {
         const bbyte *s = (const bbyte *)be_tostring(vm, 1);
@@ -907,7 +907,7 @@ static int str_byte(bvm *vm)
     be_return_nil(vm);
 }
 
-static int str_char(bvm *vm)
+static void str_char(bvm *vm)
 {
     if (be_top(vm) && be_isint(vm, 1)) {
         char c = be_toint(vm, 1) & 0xFF;
@@ -918,7 +918,7 @@ static int str_char(bvm *vm)
 }
 
 // boolean to select whether we call toupper() or tolower()
-static int str_touplower(bvm *vm, bbool up)
+static void str_touplower(bvm *vm, bbool up)
 {
     if (be_top(vm) && be_isstring(vm, 1)) {
         const char *p, *s = be_tostring(vm, 1);
@@ -936,15 +936,15 @@ static int str_touplower(bvm *vm, bbool up)
     be_return_nil(vm);
 }
 
-static int str_tolower(bvm *vm) {
-    return str_touplower(vm, bfalse);
+static void str_tolower(bvm *vm) {
+    str_touplower(vm, bfalse);
 }
 
-static int str_toupper(bvm *vm) {
-    return str_touplower(vm, btrue);
+static void str_toupper(bvm *vm) {
+    str_touplower(vm, btrue);
 }
 
-static int str_tr(bvm *vm)
+static void str_tr(bvm *vm)
 {
     if (be_top(vm) == 3 && be_isstring(vm, 1) && be_isstring(vm, 2) && be_isstring(vm, 3)) {
         const char *p, *s = be_tostring(vm, 1);
@@ -977,7 +977,7 @@ static int str_tr(bvm *vm)
     be_return_nil(vm);
 }
 
-static int str_replace(bvm *vm)
+static void str_replace(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 3 && be_isstring(vm, 1) && be_isstring(vm, 2) && be_isstring(vm, 3)) {
@@ -997,7 +997,7 @@ static int str_replace(bvm *vm)
     be_return_nil(vm);
 }
 
-static int str_escape(bvm *vm)
+static void str_escape(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 1 && be_isstring(vm, 1)) {
@@ -1015,7 +1015,7 @@ static int str_escape(bvm *vm)
     be_return_nil(vm);
 }
 
-static int str_startswith(bvm *vm)
+static void str_startswith(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 2 && be_isstring(vm, 1) && be_isstring(vm, 2)) {
@@ -1042,7 +1042,7 @@ static int str_startswith(bvm *vm)
     be_return_nil(vm);
 }
 
-static int str_endswith(bvm *vm)
+static void str_endswith(bvm *vm)
 {
     int top = be_top(vm);
     if (top >= 2 && be_isstring(vm, 1) && be_isstring(vm, 2)) {

--- a/src/be_strlib.h
+++ b/src/be_strlib.h
@@ -26,7 +26,7 @@ const char* be_splitpath(const char *path);
 const char* be_splitname(const char *path);
 const char* be_pushvfstr(bvm *vm, const char *format, va_list arg);
 bstring* be_strindex(bvm *vm, bstring *str, bvalue *idx);
-int be_str_format(bvm *vm);
+void be_str_format(bvm *vm);
 
 #ifdef __cplusplus
 }

--- a/src/be_syslib.c
+++ b/src/be_syslib.c
@@ -9,7 +9,7 @@
 
 #if BE_USE_SYS_MODULE
 
-static int m_path(bvm *vm)
+static void m_path(bvm *vm)
 {
     be_getbuiltin(vm, "list");
     be_module_path(vm);

--- a/src/be_timelib.c
+++ b/src/be_timelib.c
@@ -10,7 +10,7 @@
 
 #if BE_USE_TIME_MODULE
 
-static int m_time(bvm *vm)
+static void m_time(bvm *vm)
 {
     be_pushint(vm, (bint)time(NULL));
     be_return(vm);
@@ -24,7 +24,7 @@ static void time_insert(bvm *vm, const char *key, int value)
     be_pop(vm, 2);
 }
 
-static int m_dump(bvm *vm)
+static void m_dump(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isint(vm, 1)) {
         time_t ts = be_toint(vm, 1);
@@ -44,7 +44,7 @@ static int m_dump(bvm *vm)
     be_return_nil(vm);
 }
 
-static int m_clock(bvm *vm)
+static void m_clock(bvm *vm)
 {
     be_pushreal(vm, clock() / (breal)CLOCKS_PER_SEC);
     be_return(vm);

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -1371,7 +1371,7 @@ void be_dofunc(bvm *vm, bvalue *v, int argc)
 }
 
 /* Default empty constructor */
-int be_default_init_native_function(bvm *vm)
+void be_default_init_native_function(bvm *vm)
 {
     int argc = be_top(vm);
     if (argc >= 1) {

--- a/src/be_vm.h
+++ b/src/be_vm.h
@@ -148,7 +148,7 @@ struct bvm {
 #define BASE_FRAME          (1 << 0)
 #define PRIM_FUNC           (1 << 1)
 
-int be_default_init_native_function(bvm *vm);
+void be_default_init_native_function(bvm *vm);
 void be_dofunc(bvm *vm, bvalue *v, int argc);
 bbool be_value2bool(bvm *vm, bvalue *v);
 bbool be_vm_iseq(bvm *vm, bvalue *a, bvalue *b);

--- a/src/berry.h
+++ b/src/berry.h
@@ -155,7 +155,7 @@ enum berrorcode {
  */
 typedef struct bvm bvm;
 
-typedef int (*bntvfunc)(bvm*); /**< native function pointer */
+typedef void (*bntvfunc)(bvm*); /**< native function pointer */
 
 /**
  * @struct bclass
@@ -703,7 +703,7 @@ typedef int (*bctypefunc)(bvm*, const void*); /**< bctypefunc */
  *
  * @param vm virtual machine instance virtual machine instance
  */
-#define be_return(vm)           return be_returnvalue(vm)
+#define be_return(vm)           {be_returnvalue(vm); return;}
 
 /**
  * @def be_return_nil
@@ -712,7 +712,7 @@ typedef int (*bctypefunc)(bvm*, const void*); /**< bctypefunc */
  *
  * @param vm virtual machine instance virtual machine instance
  */
-#define be_return_nil(vm)       return be_returnnilvalue(vm)
+#define be_return_nil(vm)       {be_returnnilvalue(vm); return;}
 
 /**
  * @def be_loadfile
@@ -2013,7 +2013,7 @@ BERRY_API bbool be_isge(bvm *vm);
  * @param vm virtual machine instance
  * @return (???)
  */
-BERRY_API int be_returnvalue(bvm *vm);
+BERRY_API void be_returnvalue(bvm *vm);
 
 /**
  * @fn int be_returnnilvalue(bvm*)
@@ -2023,7 +2023,7 @@ BERRY_API int be_returnvalue(bvm *vm);
  * @param vm virtual machine instance
  * @return (???)
  */
-BERRY_API int be_returnnilvalue(bvm *vm);
+BERRY_API void be_returnnilvalue(bvm *vm);
 
 /**
  * @fn void be_call(bvm*, int)

--- a/src/berry.h
+++ b/src/berry.h
@@ -23,7 +23,7 @@ extern "C" {
  * @brief do not modify the version number!
  *
  */
-#define BERRY_VERSION           "1.1.0"
+#define BERRY_VERSION           "1.2.0"
 
 #if BE_STACK_TOTAL_MAX < BE_STACK_FREE_MIN * 2
 #error "The value of the macro BE_STACK_TOTAL_MAX is too small."


### PR DESCRIPTION
Follow-up of #487

It appears that `bntvfunc` returns an `int` that is always `0` and always ignored. This PR is a breaking change to the FFI interface to reduce code size (on Tasmota this reduces code size by 2KB).

I also propose to change version number to "1.2.0" as to mark the breaking change of C interface.