### PR TITLE
Berry pointer arithmetic and fast bytes access

### DIFF
--- a/src/be_object.h
+++ b/src/be_object.h
@@ -249,6 +249,7 @@ typedef const char* (*breader)(struct blexer*, void*, size_t*);
 #define var_setmodule(_v, _o)   var_setobj(_v, BE_MODULE, _o)
 #define var_setindex(_v, _i)    { var_settype(_v, BE_INDEX); (_v)->v.i = (_i); }
 #define var_setproto(_v, _o)    var_setobj(_v, BE_PROTO, _o)
+#define var_setcomptr(_v, _o)   var_setobj(_v, BE_COMPTR, _o)
 
 #define var_tobool(_v)          ((_v)->v.b)
 #define var_toint(_v)           ((_v)->v.i)

--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -680,6 +680,10 @@ newframe: /* a new call frame */
                 var_setstr(dst, s);
             } else if (var_isinstance(a)) {
                 ins_binop(vm, "+", ins);
+            } else if (var_iscomptr(a) && var_isint(b)) {
+                uint8_t * p = (uint8_t*) var_toobj(a);
+                p += var_toint(b);
+                var_setcomptr(dst, p);
             } else {
                 binop_error(vm, "+", a, b);
             }
@@ -694,6 +698,10 @@ newframe: /* a new call frame */
                 var_setreal(dst, x - y);
             } else if (var_isinstance(a)) {
                 ins_binop(vm, "-", ins);
+            } else if (var_iscomptr(a) && var_isint(b)) {
+                uint8_t * p = (uint8_t*) var_toobj(a);
+                p -= var_toint(b);
+                var_setcomptr(dst, p);
             } else {
                 binop_error(vm, "-", a, b);
             }
@@ -1050,6 +1058,9 @@ newframe: /* a new call frame */
                 bstring *s = be_strindex(vm, var_tostr(b), c);
                 reg = vm->reg;
                 var_setstr(RA(), s);
+            } else if (var_iscomptr(b) && var_isint(c)) {
+                uint8_t * p = var_toobj(b);
+                var_setint(RA(), p[var_toint(c)]);
             } else {
                 vm_error(vm, "type_error",
                     "value '%s' does not support subscriptable",
@@ -1070,6 +1081,9 @@ newframe: /* a new call frame */
                 be_dofunc(vm, top, 3); /* call method 'setitem' */
                 vm->top -= 4;
                 reg = vm->reg;
+            } else if (var_iscomptr(a) && var_isint(b) && var_isint(c)) {
+                uint8_t * p = var_toobj(a);
+                p[var_toint(b)] = var_toint(c);
             } else {
                 vm_error(vm, "type_error",
                     "value '%s' does not support index assignment",

--- a/tests/comptr.be
+++ b/tests/comptr.be
@@ -1,0 +1,25 @@
+# test about comptr
+import introspect
+
+var p = introspect.toptr(1024)
+assert(str(p) == '<ptr: 0x400>')
+
+p += 1
+assert(p == introspect.toptr(1025))
+
+p -= 2
+assert(p == introspect.toptr(1023))
+
+# use comptr[idx] to read or write bytes
+var b = bytes("11223344")
+p = b._buffer()                 # p is comptr
+assert(p[0] == 0x11)
+assert(p[1] == 0x22)
+assert(p[2] == 0x33)
+assert(p[3] == 0x44)
+
+p[0] = 0xFF
+p[1] = 0x55
+p[2] = 0xFEBC                   # shoud truncate to 0xBC
+assert(b == bytes("FF55BC44"))
+assert(p[0] == 255)             # check it's unsigned


### PR DESCRIPTION
Add super fast byte access, that bypasses instance access:

```berry
var b = bytes("FF112233")
var p = b._buffer() # access the 'comptr' for the raw buffer

print(p[0])    # 255 = 0xFF
print(p[1])     # 17 = 0x11

p[2] = 0xBC
print(b)       # bytes('FF11BC33')
```

This will be used by Berry animation framework for fast access to raw bytes