### PR TITLE
Force left bracket without spaces for calls

### DIFF
--- a/src/be_lexer.h
+++ b/src/be_lexer.h
@@ -54,7 +54,8 @@ typedef enum {
     OptNot,         /* operator, ! */
     OptFlip,        /* operator, ~ */
     /* postfix operator or bracket */
-    OptLBK,         /* operator, ( bracket */
+    OptSpaceLBK,    /* operator, ( bracket (with space/newline before) */
+    OptCallLBK,     /* operator, ( bracket (call - no space before) */
     OptRBK,         /* operator, ) bracket */
     OptLSB,         /* operator, [ square bracket */
     OptRSB,         /* operator, ] square bracket */
@@ -67,6 +68,7 @@ typedef enum {
     OptColon,       /* operator, : */
     OptQuestion,    /* operator, ? */
     OptArrow,       /* operator, -> */
+    OptWalrus,      /* operator, := */
     /* keyword */
     KeyIf,          /* keyword if */
     KeyElif,        /* keyword elif */
@@ -90,8 +92,6 @@ typedef enum {
     KeyExcept,      /* keyword except */
     KeyRaise,       /* keyword raise */
     KeyStatic,      /* keyword static */
-    /* Walrus operator */
-    OptWalrus,      /* operator, := */
 } btokentype;
 
 struct blexerreader {
@@ -126,6 +126,7 @@ typedef struct blexer {
     struct blexerreader reader;
     bmap *strtab;
     bvm *vm;
+    int had_whitespace; /* track if whitespace/newline preceded current token */
 } blexer;
 
 void be_lexer_init(blexer *lexer, bvm *vm,

--- a/tools/coc/str_build.py
+++ b/tools/coc/str_build.py
@@ -62,7 +62,7 @@ class str_build:
         return size
     
     def keywords(self):
-        opif = 50
+        opif = 52
         tab = {
             "if": opif,             "elif": opif + 1 ,
             "else": opif + 2 ,      "while": opif + 3 ,


### PR DESCRIPTION
This change in the parser forces any call to have parenthesis open right after the identifier:

```berry
f(1)       # this is a normal function call

f (1)      # are two separate statements, equivalent to:
f; (1);    # this would actually trigger an exception in 'strict' mode since there is no side effect
```

This allows construct like:
```berry
for i:0..10
  (i%3) || print(i)
end

# which is now different to the way it was previously parsed:
for i : (0..10)(i%3) || print(i) end
```

No functional impact and no impact to existing code. Fixes #371