### PR TITLE
Remove unwanted 'tab' in packages.json

### DIFF
--- a/tools/plugins/vscode/skiars.berry-1.2.0/package.json
+++ b/tools/plugins/vscode/skiars.berry-1.2.0/package.json
@@ -3,7 +3,7 @@
     "displayName": "Berry Script Language",
     "description": "A small embedded script language.",
     "version": "1.2.0",
-	"icon": "berry-icon.png",
+    "icon": "berry-icon.png",
     "publisher": "skiars",
     "engines": {
         "vscode": "^1.15.1"


### PR DESCRIPTION
Remove unwanted 'tab' in packages.json which indirectly breaks the unit tests.