### PR TITLE
Remove size limit for solidified bytes()

### DIFF
--- a/src/be_solidifylib.c
+++ b/src/be_solidifylib.c
@@ -275,7 +275,9 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, const bvalue * value, 
 
             char * hex_out = be_pushbuffer(vm, hex_len);
             be_bytes_tohex(hex_out, hex_len, bufptr, len);
-            logfmt("be_const_bytes_instance(%s)", hex_out);
+            lognofmt("be_const_bytes_instance(");
+            lognofmt(hex_out);
+            lognofmt(")");
             be_pop(vm, 1);
         } else if (ins->super || ins->sub) {
             be_raise(vm, "internal_error", "instance must not have a super/sub class");


### PR DESCRIPTION
Remove the arbitrary size limit when solidifying `bytes()` objects