### PR TITLE
Fix global-buffer-overflow in lexer and invalid format in string.format

### DIFF
--- a/src/be_lexer.c
+++ b/src/be_lexer.c
@@ -686,6 +686,7 @@ static btokentype scan_string(blexer *lexer)
         while ((c = lgetc(lexer)) != EOS && (c != end)) {
             save(lexer);
             if (c == '\\') {
+                if (lgetc(lexer) == EOS) { c = EOS; break; }
                 save(lexer); /* skip '\\.' */
             }
         }

--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -601,16 +601,22 @@ static const char* get_mode(const char *str, char *buf, size_t buf_len)
     }
     p = skip2dig(p); /* skip width (2 digits at most) */
     if (*p == '.') {
-        p = skip2dig(++p); /* skip width (2 digits at most) */
+        p = skip2dig(++p); /* skip precision (2 digits at most) */
     }
     *(buf++) = '%';
     size_t mode_size = p - str + 1;
     /* Leave 2 bytes for the leading % and the trailing '\0' */
-    if (mode_size > buf_len - 2) { 
-        mode_size = buf_len - 2;
+    /* Also ensure the format specifier character is always included */
+    if (mode_size > buf_len - 2) {
+        /* truncate flags/width but always keep the conversion specifier */
+        size_t max = buf_len - 2;
+        strncpy(buf, str, max - 1);
+        buf[max - 1] = p[0]; /* conversion specifier */
+        buf[max] = '\0';
+    } else {
+        strncpy(buf, str, mode_size);
+        buf[mode_size] = '\0';
     }
-    strncpy(buf, str, mode_size);
-    buf[mode_size] = '\0';
     return p;
 }
 

--- a/tests/string.be
+++ b/tests/string.be
@@ -150,7 +150,7 @@ assert(string.format("%s", false) == 'false')
 assert(string.format("%q", "\ntest") == '\'\\ntest\'')
 
 # corrupt format string should not crash the VM
-string.format("%0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f", 3.5)
+assert(string.format("%0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f", 3.5) == '3.500000')
 
 # format is now synonym to string.format
 assert(format == string.format)


### PR DESCRIPTION
- be_lexer.c: scan_string could read past the static `eos` buffer when a backslash escape appeared at the very end of input. Add an EOS check after saving the backslash to avoid the out-of-bounds read and properly report "unfinished string".

- be_strlib.c: get_mode truncated long format specifiers (e.g. %0000...0f) by dropping the trailing conversion character, producing an invalid format string passed to snprintf. Preserve the conversion specifier when truncating.

Fixes #509