### PR TITLE
Fix warnings in lcov when running `make test`

### DIFF
--- a/testall.be
+++ b/testall.be
@@ -1,7 +1,7 @@
 #! ./berry
 import os
 
-os.system('lcov', '-q -c -i -d . -o init.info')
+os.system('lcov', '-q -c -i -d . -o init.info --ignore-errors gcov,unsupported')
 
 var exec = './berry'
 var path = 'tests'
@@ -30,9 +30,9 @@ if failed != 0
 end
 
 var cmds = [
-    'lcov -q -c -d ./ -o cover.info',
-    'lcov -q -a init.info -a cover.info -o total.info',
-    'lcov --remove total.info */usr/include/* -o final.info',
+    'lcov -q -c -d ./ -o cover.info --ignore-errors gcov,unsupported',
+    'lcov -q -a init.info -a cover.info -o total.info --ignore-errors gcov,unsupported',
+    'lcov --remove total.info */usr/include/* -o final.info --ignore-errors gcov,unsupported',
     'genhtml -q -o test_report --legend --title "lcov" --prefix=./ final.info',
     'rm -f init.info cover.info total.info final.info'
 ]


### PR DESCRIPTION
Fix warnings in lcov when running `make test`. Silence normal warnings.

Now output is (macos):
```
[Run Testcases...]
Message summary:
  3 ignore messages:
    gcov: 2
    unsupported: 1
run testcase: preproc_str.be
run testcase: global.be
run testcase: bitwise.be
run testcase: compiler.be
run testcase: list.be
run testcase: virtual_methods.be
run testcase: division_by_zero.be
run testcase: preproc_pbt.be
run testcase: json_advanced.be
run testcase: class_static.be
run testcase: introspect.be
run testcase: checkspace.be
run testcase: os.be
run testcase: subobject.be
run testcase: class_const.be
run testcase: range.be
run testcase: walrus.be
run testcase: cond_expr.be
run testcase: member_indirect.be
run testcase: bool.be
run testcase: lexer.be
run testcase: assignment.be
run testcase: reference.be
run testcase: exceptions.be
run testcase: bytes_b64.be
run testcase: debug.be
value type <class>, attributes:
['caller_name_chain', 'guess_my_name__', 'main']
run testcase: preproc.be
run testcase: class.be
run testcase: compound.be
run testcase: bytes_fixed.be
run testcase: lexergc.be
run testcase: introspect_ismethod.be
run testcase: map.be
run testcase: super_auto.be
run testcase: parser.be
run testcase: pbt_helper.be
run testcase: function.be
run testcase: closure.be
run testcase: vararg.be
run testcase: comptr.be
run testcase: json_test_stack_size.be
run testcase: preproc_mod.be
run testcase: preproc_err.be
run testcase: json.be
run testcase: int.be
run testcase: super_leveled.be
run testcase: bytes.be
run testcase: relop.be
run testcase: call.be
run testcase: suffix.be
run testcase: virtual_methods2.be
run testcase: for.be
run testcase: math.be
run testcase: module.be
run testcase: string.be
run testcase: overload.be
123
test results: 56 total, 0 failed (all tests passed).
Message summary:
  3 ignore messages:
    gcov: 2
    unsupported: 1
Message summary:
  no messages were reported
Excluding /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/math.h
Removed 1 files
Writing data to final.info
Summary coverage rate:
  source files: 43
  lines.......: 73.4% (9423 of 12839 lines)
  functions...: 76.7% (805 of 1050 functions)
Message summary:
  no messages were reported
Overall coverage rate:
  source files: 43
  lines.......: 73.4% (9423 of 12839 lines)
  functions...: 76.7% (805 of 1050 functions)
Message summary:
  no messages were reported
```