### PR TITLE
Ensure 100% coverage for `gc` module

### DIFF
--- a/src/be_gclib.c
+++ b/src/be_gclib.c
@@ -13,11 +13,17 @@
 static int m_allocated(bvm *vm)
 {
     size_t count = be_gc_memcount(vm);
+#if BE_INTGER_TYPE >= 2
+    /* bint is 64-bit: can always represent the memory count as int */
+    be_pushint(vm, (bint)count);
+#else
+    /* bint is 32-bit: fall back to real if count >= 2GB */
     if (count < 0x80000000) {
         be_pushint(vm, (bint)count);
     } else {
         be_pushreal(vm, (breal)count);
     }
+#endif
     be_return(vm);
 }
 

--- a/tests/gc.be
+++ b/tests/gc.be
@@ -1,0 +1,29 @@
+import gc
+
+# gc.collect() returns nil
+assert(gc.collect() == nil)
+
+# gc.allocated() returns a number (int for normal heap sizes)
+var mem = gc.allocated()
+assert(type(mem) == 'int' || type(mem) == 'real')
+assert(mem > 0)
+
+# allocating objects increases memory usage
+var before = gc.allocated()
+var l = []
+for i : 0..99
+    l.push(str(i))
+end
+var after = gc.allocated()
+assert(after > before)
+
+# collecting after freeing should reduce or maintain allocation
+l = nil
+gc.collect()
+var post = gc.allocated()
+assert(post < after)
+
+# gc.allocated() is consistent across calls (non-decreasing without allocation)
+var a1 = gc.allocated()
+var a2 = gc.allocated()
+assert(a2 >= a1 || a2 == a1)


### PR DESCRIPTION
Ensure 100% coverage for `gc` module

Also simplify `gc.allocated()` that does not need to use `real` if `int` is already 64 bits.