### PR TITLE
Fix mutating a list during iteration

### DIFF
--- a/src/be_api.c
+++ b/src/be_api.c
@@ -913,31 +913,30 @@ BERRY_API bbool be_pushiter(bvm *vm, int index)
         var_setobj(iter, BE_COMPTR, NULL);
         return btrue;
     } else if (var_islist(v)) {
-        blist *list = var_toobj(v);
         bvalue *iter = be_incrtop(vm);
-        var_setobj(iter, BE_COMPTR, be_list_data(list) - 1);
+        var_setint(iter, -1); /* index-based: start before first element */
         return btrue;
     }
     return bfalse;
 }
 
-static int list_next(bvm *vm)
+static int list_next(bvm *vm, bvalue *v)
 {
     bvalue *iter = be_indexof(vm, -1);
-    bvalue *next, *dst = be_incrtop(vm);
-    next = cast(bvalue*, var_toobj(iter)) + 1;
-    var_setobj(iter, BE_COMPTR, next);
-    var_setval(dst, next);
+    bint idx = var_toint(iter) + 1;
+    blist *list = var_toobj(v);
+    var_setint(iter, idx);
+    bvalue *dst = be_incrtop(vm);
+    var_setval(dst, be_list_at(list, idx));
     return 1;
 }
 
 static bbool list_hasnext(bvm *vm, bvalue *v)
 {
-    bvalue *next;
     bvalue *iter = be_indexof(vm, -1);
     blist *obj = var_toobj(v);
-    next = cast(bvalue*, var_toobj(iter)) + 1;
-    return next >= be_list_data(obj) && next < be_list_end(obj);
+    bint idx = var_toint(iter) + 1;
+    return idx >= 0 && idx < be_list_count(obj);
 }
 
 static int map_next(bvm *vm, bvalue *v)
@@ -969,7 +968,7 @@ BERRY_API int be_iter_next(bvm *vm, int index)
 {
     bvalue *o = be_indexof(vm, index);
     if (var_islist(o)) {
-        return list_next(vm);
+        return list_next(vm, o);
     } else if (var_ismap(o)) {
         return map_next(vm, o);
     }

--- a/src/be_listlib.c
+++ b/src/be_listlib.c
@@ -294,15 +294,15 @@ static int iter_closure(bvm *vm)
      * directly without using by the stack. */
     bntvclos *func = var_toobj(vm->cf->func);
     bvalue *uv0 = be_ntvclos_upval(func, 0)->value; /* list value */
-    bvalue *uv1 = be_ntvclos_upval(func, 1)->value; /* iter value */
-    bvalue *next = cast(bvalue*, var_toobj(uv1)) + 1;
+    bvalue *uv1 = be_ntvclos_upval(func, 1)->value; /* iter value (index) */
+    bint idx = var_toint(uv1) + 1;
     blist *list = var_toobj(uv0);
-    if (next >= be_list_end(list)) {
+    if (idx >= be_list_count(list)) {
         be_stop_iteration(vm);
     }
-    var_toobj(uv1) = next; /* set upvale[1] (iter value) */
+    var_setint(uv1, idx); /* set upvalue[1] (iter index) */
     /* push next value to top */
-    var_setval(vm->top, next);
+    var_setval(vm->top, be_list_at(list, idx));
     be_incrtop(vm);
     be_return(vm);
 }
@@ -312,7 +312,7 @@ static int m_iter(bvm *vm)
     be_pushntvclosure(vm, iter_closure, 2);
     be_getmember(vm, 1, ".p");
     be_setupval(vm, -2, 0);
-    be_pushiter(vm, -1);
+    be_pushint(vm, -1); /* start index before first element */
     be_setupval(vm, -3, 1);
     be_pop(vm, 2);
     be_return(vm);

--- a/tests/list_mutate_iter.be
+++ b/tests/list_mutate_iter.be
@@ -1,0 +1,33 @@
+# Test: mutating a list during iteration should not segfault
+# This reproduces the bug where pushing to a list during a for loop
+# caused a stale pointer dereference due to list reallocation.
+
+var entities = []
+
+class Entity
+    var x, y
+    def init(x, y)
+        self.x = x
+        self.y = y
+    end
+    def update()
+        entities.push(Entity(10, 10))
+    end
+end
+
+entities.push(Entity(1, 2))
+
+var count = 0
+for e : entities
+    assert(type(e) == 'instance')
+    assert(classname(e) == 'Entity')
+    e.update()
+    count += 1
+    if count > 10
+        break
+    end
+end
+
+assert(count > 1)
+# The list should have grown from the pushes during iteration
+assert(entities.size() > 1)


### PR DESCRIPTION
Fixes #523

## Fix: list iterator use-after-free on mutation during iteration

### Bug

Iterating over a list with `for` and mutating it (e.g. `list.push()`) inside the loop body causes undefined behavior — reading garbage values, corrupted types, and eventually a segfault.

```berry
var items = []
items.push("a")
for e : items
    items.push("b")  # triggers realloc → stale iterator pointer → crash
end
```

### Root cause

The list iterator stored a raw `bvalue*` pointer directly into the list's internal data array. When `push()` caused the list to exceed its capacity, `be_realloc()` moved the data to a new memory block. The iterator's pointer was never updated, so subsequent iterations dereferenced freed memory.

This affected two code paths:
- `iter_closure()` in `be_listlib.c` — used by Berry `for` loops via the `iter()` method
- `be_pushiter()` / `list_next()` / `list_hasnext()` in `be_api.c` — used by C-side iteration (tostring, find, JSON serialization, etc.)

### Fix

Replace the raw pointer with an integer index in both paths. The index is resolved to `list->data[idx]` on each access, so it remains valid regardless of reallocation.

Changes in `be_listlib.c`:
- `iter_closure()`: upvalue 1 is now a `bint` index instead of a `BE_COMPTR` pointer. Increments the index and bounds-checks against `be_list_count()`.
- `m_iter()`: pushes `int(-1)` (before first element) as the initial iterator state instead of calling `be_pushiter()`.

Changes in `be_api.c`:
- `be_pushiter()`: for lists, pushes `int(-1)` instead of `BE_COMPTR` pointing to `data - 1`.
- `list_next()`: reads the index from the iter value, increments it, and indexes into the list. Now takes a `bvalue *v` parameter (the list) for consistency with `map_next()`.
- `list_hasnext()`: compares `index + 1` against `be_list_count()` instead of pointer comparison.

### Impact

- Mutating a list during `for` iteration no longer crashes. The iterator will see newly pushed elements (the loop keeps going until the index reaches the current size), which is a reasonable and predictable behavior.
- No performance impact — an integer increment + array index is equivalent cost to a pointer increment + dereference.
- The C API functions `be_pushiter`/`be_iter_next`/`be_iter_hasnext` for lists now also use index-based iteration, making all internal callers (tostring, find, JSON) safe as well.
- All existing tests pass.
