### PR TITLE
Alternative to strnlen

### DIFF
--- a/src/be_lexer.c
+++ b/src/be_lexer.c
@@ -284,7 +284,12 @@ static void tr_string(blexer *lexer)
             break;
         }
     }
-    lexer->buf.len = dst - lexbuf(lexer);
+    size_t len = dst - lexbuf(lexer);
+    /* equivalent to strnlen() */
+    /* lexer->buf.len = strnlen(lexbuf(lexer), len); */
+    const char* str = (const char*) lexbuf(lexer);
+    const char* found = memchr(str, '\0', len);
+    lexer->buf.len = found ? (size_t)(found - str) : len;
 }
 
 static int skip_newline(blexer *lexer)


### PR DESCRIPTION
Avoid using strnlen() which is non-standard and use an alternative implementation. This is the last `strnlen()` used in Berry.