### PR TITLE
Force type to 8 bits

### DIFF
--- a/src/be_parser.h
+++ b/src/be_parser.h
@@ -45,7 +45,7 @@ typedef struct {
     int t; /* patch list of 'exit when true' */
     int f; /* patch list of 'exit when false' */
     bbyte not; /* not mark */
-    exptype_t type;
+    exptype_t type : 8;
 } bexpdesc;
 
 typedef struct bblockinfo {


### PR DESCRIPTION
In #404, the field `type` was mistakenly changed from `bbyte` to `exptype_t` to make debugging much easier. However the field was promoted `int` size. This change forces 8-bit.