### PR TITLE
'introspect.module' option to not cache module entry

### DIFF
--- a/src/be_introspectlib.c
+++ b/src/be_introspectlib.c
@@ -182,7 +182,11 @@ static int m_getmodule(bvm *vm)
     if (top >= 1) {
         bvalue *v = be_indexof(vm, 1);
         if (var_isstr(v)) {
-            int ret = be_module_load(vm, var_tostr(v));
+            bbool no_cache = bfalse;
+            if (top >= 2) {
+                no_cache = be_tobool(vm, 2);
+            }
+            int ret = be_module_load_nocache(vm, var_tostr(v), no_cache);
             if (ret == BE_OK) {
                 be_return(vm);
             }

--- a/src/be_module.c
+++ b/src/be_module.c
@@ -275,8 +275,8 @@ static void module_init(bvm *vm) {
     }
 }
 
-/* load module to vm->top */
-int be_module_load(bvm *vm, bstring *path)
+/* load module to vm->top, option to cache or not */
+int be_module_load_nocache(bvm *vm, bstring *path, bbool nocache)
 {
     int res = BE_OK;
     if (!load_cached(vm, path)) {
@@ -284,12 +284,20 @@ int be_module_load(bvm *vm, bstring *path)
         if (res == BE_IO_ERROR)
             res = load_package(vm, path);
         if (res == BE_OK) {
-            /* on first load of the module, try running the '()' function */
+            /* on first load of the module, try running the 'init' function */
             module_init(vm);
-            be_cache_module(vm, path);
+            if (!nocache) { /* cache the module if it is loaded successfully */
+                be_cache_module(vm, path);
+            }
         }
     }
     return res;
+}
+
+/* load module to vm->top */
+int be_module_load(bvm *vm, bstring *path)
+{
+    return be_module_load_nocache(vm, path, bfalse);
 }
 
 BERRY_API bbool be_getmodule(bvm *vm, const char *k)

--- a/src/be_module.h
+++ b/src/be_module.h
@@ -34,6 +34,7 @@ typedef struct bmodule {
 bmodule* be_module_new(bvm *vm);
 void be_module_delete(bvm *vm, bmodule *module);
 int be_module_load(bvm *vm, bstring *path);
+int be_module_load_nocache(bvm *vm, bstring *path, bbool cache);
 void be_cache_module(bvm *vm, bstring *name);
 int be_module_attr(bvm *vm, bmodule *module, bstring *attr, bvalue *dst);
 bbool be_module_setmember(bvm *vm, bmodule *module, bstring *attr, bvalue *src);


### PR DESCRIPTION
Add ability to load a module (`import`) without caching the entry in the global table, which makes it possible to completely unload it later:
- `introspect.module(name:string [, noload:bool]) -> any` : new `noload` optional boolean, if `true` do not cache entry
- add internal api `be_module_load_nocache`