### PR TITLE
Faster `type()` function

### DIFF
--- a/src/be_baselib.c
+++ b/src/be_baselib.c
@@ -201,7 +201,15 @@ int be_baselib_super(bvm *vm)
 int be_baselib_type(bvm *vm)
 {
     if (be_top(vm)) {
+#if BE_USE_PRECOMPILED_OBJECT
+        bvalue *v = be_indexof(vm, 1);
+        bstring *s = be_vtype2bstring(v);
+        bvalue *reg = be_incrtop(vm);
+        be_assert(reg < vm->stacktop);
+        var_setstr(reg, s);
+#else
         be_pushstring(vm, be_typename(vm, 1));
+#endif
         be_return(vm);
     }
     be_return_nil(vm);

--- a/src/be_object.c
+++ b/src/be_object.c
@@ -10,6 +10,7 @@
 #include "be_mem.h"
 #include "be_gc.h"
 #include "be_vm.h"
+#include "be_string.h"
 
 #define cast_comobj(o)      gc_cast(o, BE_COMOBJ, bcommomobj)
 
@@ -33,6 +34,50 @@ const char* be_vtype2str(bvalue *v)
     case BE_COMPTR: return "ptr";
     default: return "invalid type";
     }
+}
+
+#if BE_USE_PRECOMPILED_OBJECT
+extern const bcstring be_const_str_nil;
+extern const bcstring be_const_str_int;
+extern const bcstring be_const_str_real;
+extern const bcstring be_const_str_bool;
+extern const bcstring be_const_str_function;
+extern const bcstring be_const_str_proto;
+extern const bcstring be_const_str_class;
+extern const bcstring be_const_str_string;
+extern const bcstring be_const_str_list;
+extern const bcstring be_const_str_map;
+extern const bcstring be_const_str_instance;
+extern const bcstring be_const_str_module;
+extern const bcstring be_const_str_var;
+extern const bcstring be_const_str_ptr;
+extern const bcstring be_const_str_invalid_type;
+#endif
+
+bstring* be_vtype2bstring(bvalue *v)
+{
+#if BE_USE_PRECOMPILED_OBJECT
+    switch(var_primetype(v)) {
+    case BE_NIL: return (bstring*) &be_const_str_nil;
+    case BE_INT: return (bstring*) &be_const_str_int;
+    case BE_REAL: return (bstring*) &be_const_str_real;
+    case BE_BOOL: return (bstring*) &be_const_str_bool;
+    case BE_CLOSURE: case BE_NTVCLOS: case BE_CTYPE_FUNC:
+    case BE_NTVFUNC: return (bstring*) &be_const_str_function;
+    case BE_PROTO: return (bstring*) &be_const_str_proto;
+    case BE_CLASS: return (bstring*) &be_const_str_class;
+    case BE_STRING: return (bstring*) &be_const_str_string;
+    case BE_LIST: return (bstring*) &be_const_str_list;
+    case BE_MAP: return (bstring*) &be_const_str_map;
+    case BE_INSTANCE: return (bstring*) &be_const_str_instance;
+    case BE_MODULE: return (bstring*) &be_const_str_module;
+    case BE_INDEX: return (bstring*) &be_const_str_var;
+    case BE_COMPTR: return (bstring*) &be_const_str_ptr;
+    default: return (bstring*) &be_const_str_invalid_type;
+    }
+#else
+    return be_newstr(vm, be_vtype2str(v));
+#endif
 }
 
 bvalue* be_indexof(bvm *vm, int idx)

--- a/src/be_object.h
+++ b/src/be_object.h
@@ -261,6 +261,7 @@ typedef const char* (*breader)(struct blexer*, void*, size_t*);
 #define var_toidx(_v)           cast_int(var_toint(_v))
 
 const char* be_vtype2str(bvalue *v);
+bstring* be_vtype2bstring(bvalue *v);
 bvalue* be_indexof(bvm *vm, int idx);
 void be_commonobj_delete(bvm *vm, bgcobject *obj);
 int be_commonobj_destroy_generic(bvm* vm);


### PR DESCRIPTION
Berry, implement a faster `type()` function that returns directly the solidified `bstring` object rather than doing a map lookup in the string pool at each execution.