### PR TITLE
'compile' option to compile in local context

### DIFF
--- a/src/be_baselib.c
+++ b/src/be_baselib.c
@@ -412,21 +412,21 @@ static int raise_compile_error(bvm *vm)
     return 0;
 }
 
-static int m_compile_str(bvm *vm)
+static int m_compile_str(bvm *vm, bbool islocal)
 {
     int len = be_strlen(vm, 1);
     const char *src = be_tostring(vm, 1);
-    int res = be_loadbuffer(vm, "string", src, len);
+    int res = be_loadbuffer_local(vm, "string", src, len, islocal);
     if (res == BE_OK) {
         be_return(vm);
     }
     return raise_compile_error(vm);
 }
 
-static int m_compile_file(bvm *vm)
+static int m_compile_file(bvm *vm, bbool islocal)
 {
     const char *fname = be_tostring(vm, 1);
-    int res = be_loadfile(vm, fname);
+    int res = be_loadfile_local(vm, fname, islocal);
     if (res == BE_OK) {
         be_return(vm);
     } else if (res == BE_IO_ERROR) {
@@ -443,14 +443,18 @@ int be_baselib_compile(bvm *vm)
     if (be_top(vm) && be_isstring(vm, 1)) {
         if (be_top(vm) >= 2 && be_isstring(vm, 2)) {
             const char *s = be_tostring(vm, 2);
+            bbool islocal = bfalse;
+            if (be_top(vm) >= 3 && be_isbool(vm, 3)) {
+                islocal = be_tobool(vm, 3);
+            }
             if (!strcmp(s, "string")) {
-                return m_compile_str(vm);
+                return m_compile_str(vm, islocal);
             }
             if (!strcmp(s, "file")) {
-                return m_compile_file(vm);
+                return m_compile_file(vm, islocal);
             }
         } else {
-            return m_compile_str(vm);
+            return m_compile_str(vm, bfalse);       /* default to global context */
         }
     }
 #endif

--- a/src/be_exec.c
+++ b/src/be_exec.c
@@ -219,6 +219,15 @@ BERRY_API int be_loadbuffer(bvm *vm,
     return be_protectedparser(vm, name, _sgets, &sbuf, bfalse);
 }
 
+BERRY_API int be_loadbuffer_local(bvm *vm,
+    const char *name, const char *buffer, size_t length, bbool islocal)
+{
+    struct strbuf sbuf;
+    sbuf.s = buffer;
+    sbuf.len = length;
+    return be_protectedparser(vm, name, _sgets, &sbuf, islocal);
+}
+
 static int fileparser(bvm *vm, const char *name, bbool islocal)
 {
     int res = BE_IO_ERROR;

--- a/src/berry.h
+++ b/src/berry.h
@@ -725,6 +725,16 @@ typedef int (*bctypefunc)(bvm*, const void*); /**< bctypefunc */
 #define be_loadfile(vm, name)   be_loadmode((vm), (name), 0)
 
 /**
+ * @def be_loadfile
+ * @note FFI function
+ * @brief be_loadfile
+ *
+ * @param vm virtual machine instance virtual machine instance
+ * @param name (???)
+ */
+#define be_loadfile_local(vm, name, islocal)   be_loadmode((vm), (name), islocal)
+
+/**
  * @def be_loadmodule
  * @note FFI function
  * @brief be_loadmodule
@@ -741,11 +751,23 @@ typedef int (*bctypefunc)(bvm*, const void*); /**< bctypefunc */
  * @brief be_loadstring
  *
  * @param vm virtual machine instance virtual machine instance
- * @param str (???)
+ * @param str Berry code to be compiled in global context
  *
  */
 #define be_loadstring(vm, str) \
     be_loadbuffer((vm), "string", (str), strlen(str))
+
+/**
+ * @def be_loadstring_local
+ * @note FFI function
+ * @brief be_loadstring
+ *
+ * @param vm virtual machine instance virtual machine instance
+ * @param str Berry code to be compiled in local or global context
+ *
+ */
+#define be_loadstring_local(vm, str, islocal) \
+    be_loadbuffer_local((vm), "string", (str), strlen(str), islocal)
 
 /**
  * @def be_dostring
@@ -2201,6 +2223,24 @@ BERRY_API bctypefunc be_get_ctype_func_hanlder(bvm *vm);
  * @return (???)
  */
 BERRY_API int be_loadbuffer(bvm *vm, const char *name, const char *buffer, size_t length);
+
+/**
+ * @fn int be_loadbuffer_local(bvm*, const char*, const char*, size_t)
+ * @note code load API
+ * @brief load a piece of source code from the buffer and compile it into bytecode, in local or global context
+ *
+ * f the compilation is successful, be_loadbuffer will compile the source code into a Berry function and place
+ * it on the top of the virtual stack. If the compilation encounters an error, be_loadbuffer will return
+ * an error value of type berrorcode (Section errorcode), and if possible, will store the
+ * specific error message string at the top of the virtual stack.
+ *
+ * @param vm virtual machine instance
+ * @param name string, which is usually used to mark the source of the source code
+ * @param buffer buffer for storing the source code
+ * @param length length of the buffer
+ * @return (???)
+ */
+BERRY_API int be_loadbuffer_local(bvm *vm, const char *name, const char *buffer, size_t length, bbool islocal);
 
 /**
  * @fn int be_loadmode(bvm *vm, const char *name, bbool islocal)


### PR DESCRIPTION
During compilation to `.bec` files, now the compilation is done in local context rather than global context.

Example, when solidifying:
```berry
class AClass
end

return AClass
```

Before, the `.bec` file would always create `AClass` global object; now it returns the `AClass` object but does not create an entry in globals anymore. This is useful to have the ability to unload in the future.

Also add an option to Berry native `compile(code_or_filename:string [, mode:string, islocal:bool]) -> function`. Now if `islocal` is `true`, the compilation is done in local context, or by default in global context.