### PR TITLE
Fix typo in `be_set_ctype_func_handler()`

### DIFF
--- a/src/be_vm.c
+++ b/src/be_vm.c
@@ -1404,7 +1404,7 @@ BERRY_API void be_set_obs_hook(bvm *vm, bobshook hook)
     vm->obshook = hook;
 }
 
-BERRY_API void be_set_ctype_func_hanlder(bvm *vm, bctypefunc handler)
+BERRY_API void be_set_ctype_func_handler(bvm *vm, bctypefunc handler)
 {
     vm->ctypefunc = handler;
 }

--- a/src/berry.h
+++ b/src/berry.h
@@ -2165,14 +2165,14 @@ BERRY_API void be_vm_delete(bvm *vm);
 BERRY_API void be_set_obs_hook(bvm *vm, bobshook hook);
 
 /**
- * @fn void be_set_ctype_func_hanlder(bvm*, bctypefunc)
+ * @fn void be_set_ctype_func_handler(bvm*, bctypefunc)
  * @note Observability hook
  * @brief (???)
  *
  * @param vm virtual machine instance
  * @param handler
  */
-BERRY_API void be_set_ctype_func_hanlder(bvm *vm, bctypefunc handler);
+BERRY_API void be_set_ctype_func_handler(bvm *vm, bctypefunc handler);
 
 /**
  * @fn bctypefunc be_get_ctype_func_hanlder(bvm*)


### PR DESCRIPTION
Fix typo in `be_set_ctype_func_handler()`