### PR TITLE
Add Big Endian for getbits() and setbits() 

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -1787,7 +1787,7 @@ be_local_closure(getbits,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
-    0,                          /* varg */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
@@ -1803,38 +1803,38 @@ be_local_closure(getbits,   /* name */
     &be_const_str_getbits,
     &be_const_str_solidified,
     ( &(const binstruction[32]) {  /* code */
-      0x180C0500,  //  0000  LE R3 R2 K0
-      0x740E0002,  //  0001  JMPT R3 #0005
-      0x540E001F,  //  0002  LDINT R3 32
-      0x240C0403,  //  0003  GT R3 R2 R3
-      0x780E0000,  //  0004  JMPF R3 #0006
-      0xB0060302,  //  0005  RAISE 1 K1 K2
-      0x580C0000,  //  0006  LDCONST R3 K0
-      0x3C100303,  //  0007  SHR R4 R1 K3
-      0x54160007,  //  0008  LDINT R5 8
-      0x10040205,  //  0009  MOD R1 R1 R5
-      0x58140000,  //  000A  LDCONST R5 K0
-      0x24180500,  //  000B  GT R6 R2 K0
-      0x781A0011,  //  000C  JMPF R6 #001F
-      0x541A0007,  //  000D  LDINT R6 8
-      0x04180C01,  //  000E  SUB R6 R6 R1
-      0x241C0C02,  //  000F  GT R7 R6 R2
-      0x781E0000,  //  0010  JMPF R7 #0012
-      0x5C180400,  //  0011  MOVE R6 R2
-      0x381E0806,  //  0012  SHL R7 K4 R6
-      0x041C0F04,  //  0013  SUB R7 R7 K4
-      0x381C0E01,  //  0014  SHL R7 R7 R1
-      0x94200004,  //  0015  GETIDX R8 R0 R4
-      0x2C201007,  //  0016  AND R8 R8 R7
-      0x3C201001,  //  0017  SHR R8 R8 R1
-      0x38201005,  //  0018  SHL R8 R8 R5
-      0x300C0608,  //  0019  OR R3 R3 R8
-      0x00140A06,  //  001A  ADD R5 R5 R6
-      0x04080406,  //  001B  SUB R2 R2 R6
-      0x58040000,  //  001C  LDCONST R1 K0
-      0x00100904,  //  001D  ADD R4 R4 K4
-      0x7001FFEB,  //  001E  JMP  #000B
-      0x80040600,  //  001F  RET 1 R3
+      0x180C0500,  //  0000  LE	R3	R2	K0
+      0x740E0002,  //  0001  JMPT	R3	#0005
+      0x540E001F,  //  0002  LDINT	R3	32
+      0x240C0403,  //  0003  GT	R3	R2	R3
+      0x780E0000,  //  0004  JMPF	R3	#0006
+      0xB0060302,  //  0005  RAISE	1	K1	K2
+      0x580C0000,  //  0006  LDCONST	R3	K0
+      0x3C100303,  //  0007  SHR	R4	R1	K3
+      0x54160007,  //  0008  LDINT	R5	8
+      0x10040205,  //  0009  MOD	R1	R1	R5
+      0x58140000,  //  000A  LDCONST	R5	K0
+      0x24180500,  //  000B  GT	R6	R2	K0
+      0x781A0011,  //  000C  JMPF	R6	#001F
+      0x541A0007,  //  000D  LDINT	R6	8
+      0x04180C01,  //  000E  SUB	R6	R6	R1
+      0x241C0C02,  //  000F  GT	R7	R6	R2
+      0x781E0000,  //  0010  JMPF	R7	#0012
+      0x5C180400,  //  0011  MOVE	R6	R2
+      0x381E0806,  //  0012  SHL	R7	K4	R6
+      0x041C0F04,  //  0013  SUB	R7	R7	K4
+      0x381C0E01,  //  0014  SHL	R7	R7	R1
+      0x94200004,  //  0015  GETIDX	R8	R0	R4
+      0x2C201007,  //  0016  AND	R8	R8	R7
+      0x3C201001,  //  0017  SHR	R8	R8	R1
+      0x38201005,  //  0018  SHL	R8	R8	R5
+      0x300C0608,  //  0019  OR	R3	R3	R8
+      0x00140A06,  //  001A  ADD	R5	R5	R6
+      0x04080406,  //  001B  SUB	R2	R2	R6
+      0x58040000,  //  001C  LDCONST	R1	K0
+      0x00100904,  //  001D  ADD	R4	R4	K4
+      0x7001FFEB,  //  001E  JMP		#000B
+      0x80040600,  //  001F  RET	1	R3
     })
   )
 );
@@ -1847,7 +1847,7 @@ be_local_closure(setbits,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     4,                          /* argc */
-    0,                          /* varg */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
@@ -1863,43 +1863,43 @@ be_local_closure(setbits,   /* name */
     &be_const_str_setbits,
     &be_const_str_solidified,
     ( &(const binstruction[37]) {  /* code */
-      0x14100500,  //  0000  LT R4 R2 K0
-      0x74120002,  //  0001  JMPT R4 #0005
-      0x5412001F,  //  0002  LDINT R4 32
-      0x24100404,  //  0003  GT R4 R2 R4
-      0x78120000,  //  0004  JMPF R4 #0006
-      0xB0060302,  //  0005  RAISE 1 K1 K2
-      0x60100009,  //  0006  GETGBL R4 G9
-      0x5C140600,  //  0007  MOVE R5 R3
-      0x7C100200,  //  0008  CALL R4 1
-      0x5C0C0800,  //  0009  MOVE R3 R4
-      0x3C100303,  //  000A  SHR R4 R1 K3
-      0x54160007,  //  000B  LDINT R5 8
-      0x10040205,  //  000C  MOD R1 R1 R5
-      0x24140500,  //  000D  GT R5 R2 K0
-      0x78160014,  //  000E  JMPF R5 #0024
-      0x54160007,  //  000F  LDINT R5 8
-      0x04140A01,  //  0010  SUB R5 R5 R1
-      0x24180A02,  //  0011  GT R6 R5 R2
-      0x781A0000,  //  0012  JMPF R6 #0014
-      0x5C140400,  //  0013  MOVE R5 R2
-      0x381A0805,  //  0014  SHL R6 K4 R5
-      0x04180D04,  //  0015  SUB R6 R6 K4
-      0x541E00FE,  //  0016  LDINT R7 255
-      0x38200C01,  //  0017  SHL R8 R6 R1
-      0x041C0E08,  //  0018  SUB R7 R7 R8
-      0x94200004,  //  0019  GETIDX R8 R0 R4
-      0x2C201007,  //  001A  AND R8 R8 R7
-      0x2C240606,  //  001B  AND R9 R3 R6
-      0x38241201,  //  001C  SHL R9 R9 R1
-      0x30201009,  //  001D  OR R8 R8 R9
-      0x98000808,  //  001E  SETIDX R0 R4 R8
-      0x3C0C0605,  //  001F  SHR R3 R3 R5
-      0x04080405,  //  0020  SUB R2 R2 R5
-      0x58040000,  //  0021  LDCONST R1 K0
-      0x00100904,  //  0022  ADD R4 R4 K4
-      0x7001FFE8,  //  0023  JMP  #000D
-      0x80040000,  //  0024  RET 1 R0
+      0x14100500,  //  0000  LT	R4	R2	K0
+      0x74120002,  //  0001  JMPT	R4	#0005
+      0x5412001F,  //  0002  LDINT	R4	32
+      0x24100404,  //  0003  GT	R4	R2	R4
+      0x78120000,  //  0004  JMPF	R4	#0006
+      0xB0060302,  //  0005  RAISE	1	K1	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140600,  //  0007  MOVE	R5	R3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x5C0C0800,  //  0009  MOVE	R3	R4
+      0x3C100303,  //  000A  SHR	R4	R1	K3
+      0x54160007,  //  000B  LDINT	R5	8
+      0x10040205,  //  000C  MOD	R1	R1	R5
+      0x24140500,  //  000D  GT	R5	R2	K0
+      0x78160014,  //  000E  JMPF	R5	#0024
+      0x54160007,  //  000F  LDINT	R5	8
+      0x04140A01,  //  0010  SUB	R5	R5	R1
+      0x24180A02,  //  0011  GT	R6	R5	R2
+      0x781A0000,  //  0012  JMPF	R6	#0014
+      0x5C140400,  //  0013  MOVE	R5	R2
+      0x381A0805,  //  0014  SHL	R6	K4	R5
+      0x04180D04,  //  0015  SUB	R6	R6	K4
+      0x541E00FE,  //  0016  LDINT	R7	255
+      0x38200C01,  //  0017  SHL	R8	R6	R1
+      0x041C0E08,  //  0018  SUB	R7	R7	R8
+      0x94200004,  //  0019  GETIDX	R8	R0	R4
+      0x2C201007,  //  001A  AND	R8	R8	R7
+      0x2C240606,  //  001B  AND	R9	R3	R6
+      0x38241201,  //  001C  SHL	R9	R9	R1
+      0x30201009,  //  001D  OR	R8	R8	R9
+      0x98000808,  //  001E  SETIDX	R0	R4	R8
+      0x3C0C0605,  //  001F  SHR	R3	R3	R5
+      0x04080405,  //  0020  SUB	R2	R2	R5
+      0x58040000,  //  0021  LDCONST	R1	K0
+      0x00100904,  //  0022  ADD	R4	R4	K4
+      0x7001FFE8,  //  0023  JMP		#000D
+      0x80040000,  //  0024  RET	1	R0
     })
   )
 );

--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -1718,7 +1718,8 @@ class Bytes : bytes
 #-   valuer (int)
 #-------------------------------------------------------------#
   def getbits(offset_bits, len_bits)
-    if len_bits <= 0 || len_bits > 32 raise "value_error", "length in bits must be between 0 and 32" end
+    if len_bits < 0 || len_bits > 32 raise "value_error", "length in bits must be between 0 and 32" end
+    if len_bits == 0 return nil end
     var ret = 0
   
     var offset_bytes = offset_bits >> 3
@@ -1802,39 +1803,43 @@ be_local_closure(getbits,   /* name */
     }),
     &be_const_str_getbits,
     &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x180C0500,  //  0000  LE	R3	R2	K0
+    ( &(const binstruction[36]) {  /* code */
+      0x140C0500,  //  0000  LT	R3	R2	K0
       0x740E0002,  //  0001  JMPT	R3	#0005
       0x540E001F,  //  0002  LDINT	R3	32
       0x240C0403,  //  0003  GT	R3	R2	R3
       0x780E0000,  //  0004  JMPF	R3	#0006
       0xB0060302,  //  0005  RAISE	1	K1	K2
-      0x580C0000,  //  0006  LDCONST	R3	K0
-      0x3C100303,  //  0007  SHR	R4	R1	K3
-      0x54160007,  //  0008  LDINT	R5	8
-      0x10040205,  //  0009  MOD	R1	R1	R5
-      0x58140000,  //  000A  LDCONST	R5	K0
-      0x24180500,  //  000B  GT	R6	R2	K0
-      0x781A0011,  //  000C  JMPF	R6	#001F
-      0x541A0007,  //  000D  LDINT	R6	8
-      0x04180C01,  //  000E  SUB	R6	R6	R1
-      0x241C0C02,  //  000F  GT	R7	R6	R2
-      0x781E0000,  //  0010  JMPF	R7	#0012
-      0x5C180400,  //  0011  MOVE	R6	R2
-      0x381E0806,  //  0012  SHL	R7	K4	R6
-      0x041C0F04,  //  0013  SUB	R7	R7	K4
-      0x381C0E01,  //  0014  SHL	R7	R7	R1
-      0x94200004,  //  0015  GETIDX	R8	R0	R4
-      0x2C201007,  //  0016  AND	R8	R8	R7
-      0x3C201001,  //  0017  SHR	R8	R8	R1
-      0x38201005,  //  0018  SHL	R8	R8	R5
-      0x300C0608,  //  0019  OR	R3	R3	R8
-      0x00140A06,  //  001A  ADD	R5	R5	R6
-      0x04080406,  //  001B  SUB	R2	R2	R6
-      0x58040000,  //  001C  LDCONST	R1	K0
-      0x00100904,  //  001D  ADD	R4	R4	K4
-      0x7001FFEB,  //  001E  JMP		#000B
-      0x80040600,  //  001F  RET	1	R3
+      0x1C0C0500,  //  0006  EQ	R3	R2	K0
+      0x780E0001,  //  0007  JMPF	R3	#000A
+      0x4C0C0000,  //  0008  LDNIL	R3
+      0x80040600,  //  0009  RET	1	R3
+      0x580C0000,  //  000A  LDCONST	R3	K0
+      0x3C100303,  //  000B  SHR	R4	R1	K3
+      0x54160007,  //  000C  LDINT	R5	8
+      0x10040205,  //  000D  MOD	R1	R1	R5
+      0x58140000,  //  000E  LDCONST	R5	K0
+      0x24180500,  //  000F  GT	R6	R2	K0
+      0x781A0011,  //  0010  JMPF	R6	#0023
+      0x541A0007,  //  0011  LDINT	R6	8
+      0x04180C01,  //  0012  SUB	R6	R6	R1
+      0x241C0C02,  //  0013  GT	R7	R6	R2
+      0x781E0000,  //  0014  JMPF	R7	#0016
+      0x5C180400,  //  0015  MOVE	R6	R2
+      0x381E0806,  //  0016  SHL	R7	K4	R6
+      0x041C0F04,  //  0017  SUB	R7	R7	K4
+      0x381C0E01,  //  0018  SHL	R7	R7	R1
+      0x94200004,  //  0019  GETIDX	R8	R0	R4
+      0x2C201007,  //  001A  AND	R8	R8	R7
+      0x3C201001,  //  001B  SHR	R8	R8	R1
+      0x38201005,  //  001C  SHL	R8	R8	R5
+      0x300C0608,  //  001D  OR	R3	R3	R8
+      0x00140A06,  //  001E  ADD	R5	R5	R6
+      0x04080406,  //  001F  SUB	R2	R2	R6
+      0x58040000,  //  0020  LDCONST	R1	K0
+      0x00100904,  //  0021  ADD	R4	R4	K4
+      0x7001FFEB,  //  0022  JMP		#000F
+      0x80040600,  //  0023  RET	1	R3
     })
   )
 );

--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -1712,30 +1712,37 @@ class Bytes : bytes
 #- Reads a bit-field in a `bytes()` object
 #-
 #- Input:
-#-   offset_bits  (int): bit number to start reading from (0 = LSB)
-#-   len_bits     (int): how many bits to read
+#-   offset_bits  (int): bit number to start from (0 = LSB of byte 0).
+#-                       Big-endian reverses per-byte bit order (0 = MSB for each byte).
+#-   len_bits     (int): how many bits to read. Positive assumes Little-Endian, negative Big-Endian
 #- Output:
 #-   valuer (int)
 #-------------------------------------------------------------#
   def getbits(offset_bits, len_bits)
-    if len_bits < 0 || len_bits > 32 raise "value_error", "length in bits must be between 0 and 32" end
+    if len_bits < -32 || len_bits > 32 raise "value_error", "length in bits must be between 0 and 32" end
     if len_bits == 0 return nil end
+    var big_endian = len_bits < 0
+    if big_endian  len_bits = -len_bits end
     var ret = 0
-  
     var offset_bytes = offset_bits >> 3
-    offset_bits = offset_bits % 8
-
+    offset_bits = offset_bits & 7
     var bit_shift = 0                   #- bit number to write to -#
-  
+
     while (len_bits > 0)
       var block_bits = 8 - offset_bits    # how many bits to read in the current block (block = byte) -#
       if block_bits > len_bits  block_bits = len_bits end
-  
-      var mask = ( (1<<block_bits) - 1) << offset_bits
-      ret = ret | ( ((self[offset_bytes] & mask) >> offset_bits) << bit_shift)
-  
-      #- move the input window -#
-      bit_shift += block_bits
+      var byte_val = self[offset_bytes]
+
+      var mask_val = (1 << block_bits) - 1
+
+      if big_endian
+        bit_shift = 8 - offset_bits - block_bits # non-zero only on the last partial byte
+        ret = (ret << block_bits) | ((byte_val >> bit_shift) & mask_val)  # shift ret left to make space for new bits
+      else
+        ret = ret | (((byte_val >> offset_bits) & mask_val) << bit_shift) # append to the left of ret
+        bit_shift += block_bits
+      end
+
       len_bits -= block_bits
       offset_bits = 0                   #- start at full next byte -#
       offset_bytes += 1
@@ -1743,35 +1750,43 @@ class Bytes : bytes
   
     return ret
   end
-  
-  #-------------------------------------------------------------
-  #- 'setbits' function
-  #-
-  #- Writes a bit-field in a `bytes()` object
-  #-
-  #- Input:
-  #-   offset_bits  (int): bit number to start writing to (0 = LSB)
-  #-   len_bits     (int): how many bits to write
-  #-   val          (int): value to set
-  #-------------------------------------------------------------#
+
+#-------------------------------------------------------------
+#- 'setbits' function
+#-
+#- Writes a bit-field in a `bytes()` object
+#-
+#- Input:
+#-   offset_bits  (int): bit number to start from (0 = LSB of byte 0).
+#-                       Big-endian reverses per-byte bit order (0 = MSB for each byte).
+#-   len_bits     (int): how many bits to write. Positive assumes Little-Endian, negative Big-Endian
+#-   val          (int): value to set
+#-------------------------------------------------------------#
   def setbits(offset_bits, len_bits, val)
-    if len_bits < 0 || len_bits > 32 raise "value_error", "length in bits must be between 0 and 32" end
+    if len_bits < -32 || len_bits > 32 raise "value_error", "length in bits must be between -32 and 32" end
 
     val = int(val)      #- convert bool or others to int -#
+    var big_endian = len_bits < 0
+    if big_endian  len_bits = -len_bits end
     var offset_bytes = offset_bits >> 3
-    offset_bits = offset_bits % 8
-  
+    offset_bits = offset_bits & 7
+
     while (len_bits > 0)
       var block_bits = 8 - offset_bits    #- how many bits to write in the current block (block = byte) -#
       if block_bits > len_bits  block_bits = len_bits end
-  
-      var mask_val = (1<<block_bits) - 1  #- mask to the n bits to get for this block -#
-      var mask_b_inv = 0xFF - (mask_val << offset_bits)
-      self[offset_bytes] = (self[offset_bytes] & mask_b_inv) | ((val & mask_val) << offset_bits)
-  
-      #- move the input window -#
-      val >>= block_bits
+      var mask_val = (1 << block_bits) - 1
       len_bits -= block_bits
+      var extracted
+
+      if big_endian
+        extracted = (val >> len_bits) & mask_val
+        offset_bits = 8 - offset_bits - block_bits  # non-zero only on the last partial byte
+      else
+        extracted = val & mask_val
+        val >>= block_bits
+      end
+      self[offset_bytes] = (self[offset_bytes] & ((mask_val << offset_bits) ^ 0xFF)) | (extracted << offset_bits)
+
       offset_bits = 0                   #- start at full next byte -#
       offset_bytes += 1
     end
@@ -1786,7 +1801,7 @@ end
 ********************************************************************/
 be_local_closure(getbits,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    12,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1795,51 +1810,65 @@ be_local_closure(getbits,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(value_error),
-    /* K2   */  be_nested_str(length_X20in_X20bits_X20must_X20be_X20between_X200_X20and_X2032),
+    /* K0   */  be_nested_str(value_error),
+    /* K1   */  be_nested_str(length_X20in_X20bits_X20must_X20be_X20between_X200_X20and_X2032),
+    /* K2   */  be_const_int(0),
     /* K3   */  be_const_int(3),
     /* K4   */  be_const_int(1),
     }),
     &be_const_str_getbits,
     &be_const_str_solidified,
-    ( &(const binstruction[36]) {  /* code */
-      0x140C0500,  //  0000  LT	R3	R2	K0
-      0x740E0002,  //  0001  JMPT	R3	#0005
-      0x540E001F,  //  0002  LDINT	R3	32
-      0x240C0403,  //  0003  GT	R3	R2	R3
-      0x780E0000,  //  0004  JMPF	R3	#0006
-      0xB0060302,  //  0005  RAISE	1	K1	K2
-      0x1C0C0500,  //  0006  EQ	R3	R2	K0
-      0x780E0001,  //  0007  JMPF	R3	#000A
-      0x4C0C0000,  //  0008  LDNIL	R3
-      0x80040600,  //  0009  RET	1	R3
-      0x580C0000,  //  000A  LDCONST	R3	K0
-      0x3C100303,  //  000B  SHR	R4	R1	K3
-      0x54160007,  //  000C  LDINT	R5	8
-      0x10040205,  //  000D  MOD	R1	R1	R5
-      0x58140000,  //  000E  LDCONST	R5	K0
-      0x24180500,  //  000F  GT	R6	R2	K0
-      0x781A0011,  //  0010  JMPF	R6	#0023
-      0x541A0007,  //  0011  LDINT	R6	8
-      0x04180C01,  //  0012  SUB	R6	R6	R1
-      0x241C0C02,  //  0013  GT	R7	R6	R2
-      0x781E0000,  //  0014  JMPF	R7	#0016
-      0x5C180400,  //  0015  MOVE	R6	R2
-      0x381E0806,  //  0016  SHL	R7	K4	R6
-      0x041C0F04,  //  0017  SUB	R7	R7	K4
-      0x381C0E01,  //  0018  SHL	R7	R7	R1
-      0x94200004,  //  0019  GETIDX	R8	R0	R4
-      0x2C201007,  //  001A  AND	R8	R8	R7
-      0x3C201001,  //  001B  SHR	R8	R8	R1
-      0x38201005,  //  001C  SHL	R8	R8	R5
-      0x300C0608,  //  001D  OR	R3	R3	R8
-      0x00140A06,  //  001E  ADD	R5	R5	R6
-      0x04080406,  //  001F  SUB	R2	R2	R6
-      0x58040000,  //  0020  LDCONST	R1	K0
-      0x00100904,  //  0021  ADD	R4	R4	K4
-      0x7001FFEB,  //  0022  JMP		#000F
-      0x80040600,  //  0023  RET	1	R3
+    ( &(const binstruction[50]) {  /* code */
+      0x540DFFDF,  //  0000  LDINT	R3	-32
+      0x140C0403,  //  0001  LT	R3	R2	R3
+      0x740E0002,  //  0002  JMPT	R3	#0006
+      0x540E001F,  //  0003  LDINT	R3	32
+      0x240C0403,  //  0004  GT	R3	R2	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0xB0060101,  //  0006  RAISE	1	K0	K1
+      0x1C0C0502,  //  0007  EQ	R3	R2	K2
+      0x780E0001,  //  0008  JMPF	R3	#000B
+      0x4C0C0000,  //  0009  LDNIL	R3
+      0x80040600,  //  000A  RET	1	R3
+      0x140C0502,  //  000B  LT	R3	R2	K2
+      0x780E0000,  //  000C  JMPF	R3	#000E
+      0x44080400,  //  000D  NEG	R2	R2
+      0x58100002,  //  000E  LDCONST	R4	K2
+      0x3C140303,  //  000F  SHR	R5	R1	K3
+      0x541A0006,  //  0010  LDINT	R6	7
+      0x2C040206,  //  0011  AND	R1	R1	R6
+      0x58180002,  //  0012  LDCONST	R6	K2
+      0x241C0502,  //  0013  GT	R7	R2	K2
+      0x781E001B,  //  0014  JMPF	R7	#0031
+      0x541E0007,  //  0015  LDINT	R7	8
+      0x041C0E01,  //  0016  SUB	R7	R7	R1
+      0x24200E02,  //  0017  GT	R8	R7	R2
+      0x78220000,  //  0018  JMPF	R8	#001A
+      0x5C1C0400,  //  0019  MOVE	R7	R2
+      0x94200005,  //  001A  GETIDX	R8	R0	R5
+      0x38260807,  //  001B  SHL	R9	K4	R7
+      0x04241304,  //  001C  SUB	R9	R9	K4
+      0x780E0009,  //  001D  JMPF	R3	#0028
+      0x542A0007,  //  001E  LDINT	R10	8
+      0x04281401,  //  001F  SUB	R10	R10	R1
+      0x04281407,  //  0020  SUB	R10	R10	R7
+      0x5C181400,  //  0021  MOVE	R6	R10
+      0x38280807,  //  0022  SHL	R10	R4	R7
+      0x3C2C1006,  //  0023  SHR	R11	R8	R6
+      0x2C2C1609,  //  0024  AND	R11	R11	R9
+      0x3028140B,  //  0025  OR	R10	R10	R11
+      0x5C101400,  //  0026  MOVE	R4	R10
+      0x70020004,  //  0027  JMP		#002D
+      0x3C281001,  //  0028  SHR	R10	R8	R1
+      0x2C281409,  //  0029  AND	R10	R10	R9
+      0x38281406,  //  002A  SHL	R10	R10	R6
+      0x3010080A,  //  002B  OR	R4	R4	R10
+      0x00180C07,  //  002C  ADD	R6	R6	R7
+      0x04080407,  //  002D  SUB	R2	R2	R7
+      0x58040002,  //  002E  LDCONST	R1	K2
+      0x00140B04,  //  002F  ADD	R5	R5	K4
+      0x7001FFE1,  //  0030  JMP		#0013
+      0x80040800,  //  0031  RET	1	R4
     })
   )
 );
@@ -1850,7 +1879,7 @@ be_local_closure(getbits,   /* name */
 ********************************************************************/
 be_local_closure(setbits,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    12,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1859,52 +1888,67 @@ be_local_closure(setbits,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(value_error),
-    /* K2   */  be_nested_str(length_X20in_X20bits_X20must_X20be_X20between_X200_X20and_X2032),
+    /* K0   */  be_nested_str(value_error),
+    /* K1   */  be_nested_str(length_X20in_X20bits_X20must_X20be_X20between_X20_X2D32_X20and_X2032),
+    /* K2   */  be_const_int(0),
     /* K3   */  be_const_int(3),
     /* K4   */  be_const_int(1),
     }),
     &be_const_str_setbits,
     &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0x14100500,  //  0000  LT	R4	R2	K0
-      0x74120002,  //  0001  JMPT	R4	#0005
-      0x5412001F,  //  0002  LDINT	R4	32
-      0x24100404,  //  0003  GT	R4	R2	R4
-      0x78120000,  //  0004  JMPF	R4	#0006
-      0xB0060302,  //  0005  RAISE	1	K1	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140600,  //  0007  MOVE	R5	R3
-      0x7C100200,  //  0008  CALL	R4	1
-      0x5C0C0800,  //  0009  MOVE	R3	R4
-      0x3C100303,  //  000A  SHR	R4	R1	K3
-      0x54160007,  //  000B  LDINT	R5	8
-      0x10040205,  //  000C  MOD	R1	R1	R5
-      0x24140500,  //  000D  GT	R5	R2	K0
-      0x78160014,  //  000E  JMPF	R5	#0024
-      0x54160007,  //  000F  LDINT	R5	8
-      0x04140A01,  //  0010  SUB	R5	R5	R1
-      0x24180A02,  //  0011  GT	R6	R5	R2
-      0x781A0000,  //  0012  JMPF	R6	#0014
-      0x5C140400,  //  0013  MOVE	R5	R2
-      0x381A0805,  //  0014  SHL	R6	K4	R5
-      0x04180D04,  //  0015  SUB	R6	R6	K4
-      0x541E00FE,  //  0016  LDINT	R7	255
-      0x38200C01,  //  0017  SHL	R8	R6	R1
-      0x041C0E08,  //  0018  SUB	R7	R7	R8
-      0x94200004,  //  0019  GETIDX	R8	R0	R4
-      0x2C201007,  //  001A  AND	R8	R8	R7
-      0x2C240606,  //  001B  AND	R9	R3	R6
-      0x38241201,  //  001C  SHL	R9	R9	R1
-      0x30201009,  //  001D  OR	R8	R8	R9
-      0x98000808,  //  001E  SETIDX	R0	R4	R8
-      0x3C0C0605,  //  001F  SHR	R3	R3	R5
-      0x04080405,  //  0020  SUB	R2	R2	R5
-      0x58040000,  //  0021  LDCONST	R1	K0
-      0x00100904,  //  0022  ADD	R4	R4	K4
-      0x7001FFE8,  //  0023  JMP		#000D
-      0x80040000,  //  0024  RET	1	R0
+    ( &(const binstruction[52]) {  /* code */
+      0x5411FFDF,  //  0000  LDINT	R4	-32
+      0x14100404,  //  0001  LT	R4	R2	R4
+      0x74120002,  //  0002  JMPT	R4	#0006
+      0x5412001F,  //  0003  LDINT	R4	32
+      0x24100404,  //  0004  GT	R4	R2	R4
+      0x78120000,  //  0005  JMPF	R4	#0007
+      0xB0060101,  //  0006  RAISE	1	K0	K1
+      0x60100009,  //  0007  GETGBL	R4	G9
+      0x5C140600,  //  0008  MOVE	R5	R3
+      0x7C100200,  //  0009  CALL	R4	1
+      0x5C0C0800,  //  000A  MOVE	R3	R4
+      0x14100502,  //  000B  LT	R4	R2	K2
+      0x78120000,  //  000C  JMPF	R4	#000E
+      0x44080400,  //  000D  NEG	R2	R2
+      0x3C140303,  //  000E  SHR	R5	R1	K3
+      0x541A0006,  //  000F  LDINT	R6	7
+      0x2C040206,  //  0010  AND	R1	R1	R6
+      0x24180502,  //  0011  GT	R6	R2	K2
+      0x781A001F,  //  0012  JMPF	R6	#0033
+      0x541A0007,  //  0013  LDINT	R6	8
+      0x04180C01,  //  0014  SUB	R6	R6	R1
+      0x241C0C02,  //  0015  GT	R7	R6	R2
+      0x781E0000,  //  0016  JMPF	R7	#0018
+      0x5C180400,  //  0017  MOVE	R6	R2
+      0x381E0806,  //  0018  SHL	R7	K4	R6
+      0x041C0F04,  //  0019  SUB	R7	R7	K4
+      0x04080406,  //  001A  SUB	R2	R2	R6
+      0x4C200000,  //  001B  LDNIL	R8
+      0x78120007,  //  001C  JMPF	R4	#0025
+      0x3C240602,  //  001D  SHR	R9	R3	R2
+      0x2C241207,  //  001E  AND	R9	R9	R7
+      0x5C201200,  //  001F  MOVE	R8	R9
+      0x54260007,  //  0020  LDINT	R9	8
+      0x04241201,  //  0021  SUB	R9	R9	R1
+      0x04241206,  //  0022  SUB	R9	R9	R6
+      0x5C041200,  //  0023  MOVE	R1	R9
+      0x70020002,  //  0024  JMP		#0028
+      0x2C240607,  //  0025  AND	R9	R3	R7
+      0x5C201200,  //  0026  MOVE	R8	R9
+      0x3C0C0606,  //  0027  SHR	R3	R3	R6
+      0x94240005,  //  0028  GETIDX	R9	R0	R5
+      0x38280E01,  //  0029  SHL	R10	R7	R1
+      0x542E00FE,  //  002A  LDINT	R11	255
+      0x3428140B,  //  002B  XOR	R10	R10	R11
+      0x2C24120A,  //  002C  AND	R9	R9	R10
+      0x38281001,  //  002D  SHL	R10	R8	R1
+      0x3024120A,  //  002E  OR	R9	R9	R10
+      0x98000A09,  //  002F  SETIDX	R0	R5	R9
+      0x58040002,  //  0030  LDCONST	R1	K2
+      0x00140B04,  //  0031  ADD	R5	R5	K4
+      0x7001FFDD,  //  0032  JMP		#0011
+      0x80040000,  //  0033  RET	1	R0
     })
   )
 );

--- a/tests/bytes.be
+++ b/tests/bytes.be
@@ -381,3 +381,100 @@ assert_error(def () b.addfloat(true) end, 'type_error')
 assert_error(def () b.addfloat(nil) end, 'type_error')
 assert_error(def () b.addfloat('foo') end, 'type_error')
 assert_error(def () b.addfloat() end, 'type_error')
+
+
+#- getbits / setbits -#
+
+#- Single byte - endiannes does't matter -#
+def getbit_and_setbit_roundtrip(byte, offset, length, val)
+    # check for expected value within a predefined byte
+    assert(byte.getbits(offset, length) == val)
+
+    # set the value at a position, roundtrip and should return same value
+    assert(bytes(-2).setbits(offset, length, val).getbits(offset, length) == val)
+end
+
+b = bytes("ABCD") # bytes constructor uses big endian, btw
+assert(b.get(0) == 0xAB)    
+assert(b.get(1) == 0xCD)
+assert(b.get(0,-2) == 0xABCD)
+# little endian
+v=0x3;    o=0;   l= 2;   getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xB;    o=0;   l= 4;   getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xA;    o=4;   l= 4;   getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xAB;   o=0;   l= 8;   getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xDA;   o=4;   l= 8;   getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xDAB;  o=0;   l= 12;  getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xC;    o=12;  l= 4;   getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xCDAB; o=0;   l= 16;  getbit_and_setbit_roundtrip(b, o, l, v)
+
+
+#- LE: read from known pattern -#
+b = bytes("A55A")
+assert(b.getbits(0, 16) == 0x5AA5)
+
+
+#- setbit - input value read/write -#
+b = bytes(-3)
+b.setbits(0, 8, 0xDEADAB)
+assert(b == bytes("AB0000"))
+# endiannes and offset only influences the output
+b = bytes(-3)
+b.setbits(4, 8, 0xBEEFAB)
+assert(b == bytes("B00A00")) # write down bytes vertically if it doesn't make sense ;)
+
+#- setbit - input longer than length - partial byte-#
+b = bytes("0000")
+b.setbits(0, 4, 0xFFFF)
+assert(b == bytes("0F00"))
+assert(b.getbits(0, 4) == 0xF)
+
+
+#- LE: single-bit set -#
+b = bytes("5A")
+b.setbits(0, 1, 1)
+assert(b == bytes("5B"))        #- LSB 0→1 -#
+b = bytes("5A")
+b.setbits(7, 1, 1)
+assert(b == bytes("DA"))        #- MSB 0→1 -#
+b.setbits(7, 1, 0)
+assert(b == bytes("5A"))        #- MSB 1→0 -#
+
+#- LE: partial middle of byte -#
+b = bytes("00")
+b.setbits(2, 3, 5)              #- 5 = 101b at bits 2,3,4 -#
+assert(b == bytes("14"))        #- 0001_0100 -#
+assert(b.getbits(2, 3) == 5)
+
+b = bytes("FF")
+b.setbits(1, 2, 0)
+assert(b == bytes("F9"))        #- clear bits 1,2 → 1111_1001 -#
+assert(b.getbits(1, 2) == 0)
+
+#- LE: full byte -#
+b = bytes("00")
+b.setbits(0, 8, 0x5A)
+assert(b == bytes("5A"))
+b.setbits(0, 8, 0xA5)
+assert(b == bytes("A5"))
+
+#- LE: multi-byte -#
+b = bytes("0000")
+b.setbits(0, 16, 0xA55A)
+assert(b == bytes("5AA5"))      #- LE wire order: LSB first -#
+b = bytes("0000")
+b.setbits(8, 8, 0x5A)
+assert(b == bytes("005A"))
+
+#- LE: cross-byte partial  -#
+b = bytes("0000")
+b.setbits(4, 10, 0xFFF)
+assert(b == bytes("F03F"))      #- byte0 bits 4-7 = 0xF, byte1 bits 0-5 = 0x3F -#
+assert(b.getbits(4, 10) == 0x3FF)
+
+
+# length check
+assert_error(def () bytes("00").getbits(0, 33) end, 'value_error')
+assert_error(def () bytes("00").setbits(0, 33, 0) end, 'value_error')
+assert_error(def () bytes("00").getbits(0, -33) end, 'value_error')
+assert_error(def () bytes("00").setbits(0, -33, 0) end, 'value_error')

--- a/tests/bytes.be
+++ b/tests/bytes.be
@@ -474,6 +474,8 @@ assert(b.getbits(4, 10) == 0x3FF)
 
 
 # length check
+assert(bytes("FF").getbits(0, 0) == nil)
+assert(bytes("FF").setbits(0, 0, 0) == bytes("FF"))
 assert_error(def () bytes("00").getbits(0, 33) end, 'value_error')
 assert_error(def () bytes("00").setbits(0, 33, 0) end, 'value_error')
 assert_error(def () bytes("00").getbits(0, -33) end, 'value_error')

--- a/tests/bytes.be
+++ b/tests/bytes.be
@@ -407,21 +407,41 @@ v=0xDA;   o=4;   l= 8;   getbit_and_setbit_roundtrip(b, o, l, v)
 v=0xDAB;  o=0;   l= 12;  getbit_and_setbit_roundtrip(b, o, l, v)
 v=0xC;    o=12;  l= 4;   getbit_and_setbit_roundtrip(b, o, l, v)
 v=0xCDAB; o=0;   l= 16;  getbit_and_setbit_roundtrip(b, o, l, v)
+# big endian
+v=0xB;    o=4;   l= -4;  getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xA;    o=0;   l= -4;  getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xAB;   o=0;   l= -8;  getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xBC;   o=4;   l= -8;  getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xABC;  o=0;   l= -12; getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xD;    o=12;  l= -4;  getbit_and_setbit_roundtrip(b, o, l, v)
+v=0xABCD; o=0;   l= -16; getbit_and_setbit_roundtrip(b, o, l, v)
 
 
 #- LE: read from known pattern -#
 b = bytes("A55A")
 assert(b.getbits(0, 16) == 0x5AA5)
 
+#- BE: read from known pattern -#
+b = bytes("A55A")
+assert(b.getbits(0, -16) == 0xA55A)
+
 
 #- setbit - input value read/write -#
+# we always truncate input value according to big endian - so in both cases we will see alteration of A and B nibbles in the output
 b = bytes(-3)
 b.setbits(0, 8, 0xDEADAB)
+assert(b == bytes("AB0000"))
+# endiannes doesn't matter for a single contiguous byte:
+b = bytes(-3)
+b.setbits(0, -8, 0xBEEFAB)
 assert(b == bytes("AB0000"))
 # endiannes and offset only influences the output
 b = bytes(-3)
 b.setbits(4, 8, 0xBEEFAB)
 assert(b == bytes("B00A00")) # write down bytes vertically if it doesn't make sense ;)
+b = bytes(-3)
+b.setbits(4, -8, 0xBEEFAB)
+assert(b == bytes("0AB000"))
 
 #- setbit - input longer than length - partial byte-#
 b = bytes("0000")
@@ -440,6 +460,17 @@ assert(b == bytes("DA"))        #- MSB 0→1 -#
 b.setbits(7, 1, 0)
 assert(b == bytes("5A"))        #- MSB 1→0 -#
 
+#- BE: single-bit -#
+b = bytes("5A")
+b.setbits(0, -1, 1)
+assert(b == bytes("DA"))        # MSB-0 bit 0 (phys 7) 0→1
+b = bytes("5A")
+b.setbits(7, -1, 1)
+assert(b == bytes("5B"))        # MSB-0 bit 7 (phys 0) 0→1
+b.setbits(7, -1, 0)
+assert(b == bytes("5A"))
+
+
 #- LE: partial middle of byte -#
 b = bytes("00")
 b.setbits(2, 3, 5)              #- 5 = 101b at bits 2,3,4 -#
@@ -451,12 +482,34 @@ b.setbits(1, 2, 0)
 assert(b == bytes("F9"))        #- clear bits 1,2 → 1111_1001 -#
 assert(b.getbits(1, 2) == 0)
 
+#- BE: partial middle of byte -#
+b = bytes("00")
+b.setbits(1, -3, 5)
+assert(b == bytes("50"))        # 5 = 101b at bits 1,2,3 → phys 6,5,4 = 0101_0000
+assert(b.getbits(1, -3) == 5)
+
+b = bytes("FF")
+b.setbits(1, -2, 0)
+assert(b == bytes("9F"))        # clear bits 1,2 (phys 6,5) → 1001_1111
+assert(b.getbits(1, -2) == 0)
+
+
 #- LE: full byte -#
 b = bytes("00")
 b.setbits(0, 8, 0x5A)
 assert(b == bytes("5A"))
 b.setbits(0, 8, 0xA5)
 assert(b == bytes("A5"))
+
+#- BE: full byte -#
+b = bytes("00")
+b.setbits(0, -8, 0x5A)
+# print(b.getbits(0, 8))
+# print(b)
+assert(b == bytes("5A"))
+b.setbits(0, -8, 0xA5)
+assert(b == bytes("A5"))
+
 
 #- LE: multi-byte -#
 b = bytes("0000")
@@ -466,11 +519,37 @@ b = bytes("0000")
 b.setbits(8, 8, 0x5A)
 assert(b == bytes("005A"))
 
+#- BE multi-byte = MSB-first byte order (opposite of LE) -#
+b = bytes("0000")
+b.setbits(0, -16, 0xA55A)
+assert(b == bytes("A55A"))      # BE wire order: MSB first 
+b = bytes("0000")
+b.setbits(8, -8, 0x5A)
+assert(b == bytes("005A"))
+
+
 #- LE: cross-byte partial  -#
 b = bytes("0000")
 b.setbits(4, 10, 0xFFF)
 assert(b == bytes("F03F"))      #- byte0 bits 4-7 = 0xF, byte1 bits 0-5 = 0x3F -#
 assert(b.getbits(4, 10) == 0x3FF)
+
+
+#- BE: cross-byte partial -#
+b = bytes("0000")
+b.setbits(4, -10, 0xFFF)
+assert(b == bytes("0FFC"))      # byte0 bits 4-7 = 0x0F, byte1 bits 0-5 = 0xFC
+assert(b.getbits(4, -10) == 0x3FF)
+
+#- mixing LE/BE -#
+b = bytes(-3)
+b.setbits(0, -12, 0xABC)
+b.setbits(12, 12, 0xDEF) # F corrupts C nibble, one nibble empty
+assert(b == bytes("ABF0DE")) 
+b = bytes(-4) # let's try again
+b.setbits(0, -12, 0xABC)
+b.setbits(16, 12, 0xDEF) # we need to start in byte 2
+assert(b == bytes("ABC0EF0D"))
 
 
 # length check


### PR DESCRIPTION
Changes:
- Analogously to `get()`, `set()`, the negative length arg in `getbits()` and `setbits()` sets Big Endian for reading and writing bits.
- Analogously to `get()`, zero length in `getbits()` will return nil
- Bunch of testcases for bit reading/writing

The need for this came about when reading signals in CAN messages in my little [project](https://github.com/dzid26/ESP32-DualCAN) where I chose Berry for scripting car automations.

There are some interesting variations how bit numbering within a byte can be interpreted.  People refer to them as [in/consistent](https://www.ietf.org/rfc/ien/ien137.txt),  [lsb0/msb0](https://github.com/ebroecker/canmatrix/wiki/signal-Byteorder) and [normal/inverted](https://vi-firmware.openxcplatform.com/en/master/config/bit-numbering.html).  It gets pretty confusing especially when thinking of data spanning multiple bytes.  lsb0/msb0 is meaningless to me if bits can be inverted...

Let's just say that for working with a single data at the time that is in a code and not sent over a medium, only one numbering makes sense for Big Endian - msb0, consistent or normal. 

-----

Now why would anyone use different numberings?  
One reason is that at low level the hardware may have bits ordered differently and perhaps we want to stream uncompressed bits over a medium, it is often better to start with MSB.  Just like in numbering in English language. And unlike numbering in German which is objectively worse.  `Einundzwanzig`. 

Second reason is visualization of mixed endianness data. If have bytes incrementing down, the little endian starts in right top corner and big endian ends in left top corner. People want to have just one table header, so they fiddle with bits numbering

This is the for CANbus - the signal definition file (DBC) allows to define mixed signals in one byte array and so it uses _inverted_ bits numbering for big endian to make visualisation indexing constant. 
In [Kvaser ](https://kvaser.com/developer-blog/an-introduction-j1939-and-dbc-files/)software the table is indexed using Little Endian interpretation, but we can insert Big Endian signal into it
<img width="100" height="137" alt="image" src="https://github.com/user-attachments/assets/e255a488-3d2b-41fa-b6d6-57f78cdfcdfe" />
It's MSB is on 7th bit in 0th byte and that's exactly how its offset is defined in DBC file. 

If I put 0 as an offset in DBC, I would get this abomination: 
<img width="104" height="133" alt="image" src="https://github.com/user-attachments/assets/1d4515a9-0ad7-420f-8a2a-cfb02374f86d" />

So that's pretty terrible numbering. 

--------
We don't care about making drawings mixed endianness signals in a table. - Setbit/getbits functions always works with one signal at the time. And we don't interface with transmission mediums directly. - So we do the only reasonable thing and define signal with normal numbering, so **0** offset will give us fully filled byte. Example - first little endian:
```
# Little Endian
> bytes(-3).setbits(0, 12, 0xFFF)  
bytes('FF0F00')
```
<img width="207" height="280" alt="image" src="https://github.com/user-attachments/assets/5f916965-6e0e-49cc-99ca-b293e5f69987" />

And big endian:
```
# Big Endian
> bytes(-3).setbits(0, -12, 0xFFF) 
bytes('FFF000')
```
All we have to do to visualize Big Endian is redraw bit indexes header in MS Paint to match Big Endian _normal_ aka _consistent_ bit order:
<img width="207" height="280" alt="image" src="https://github.com/user-attachments/assets/1b8833e6-5f56-4e41-9dd6-be2085c17061" />

-----

Side note, for converting CANbus DBC _inverted_ offset to this _normal_ big endian offset, all I have to do is ```off + 7 - 2*(off % 8)``` .
Side note 2, I kinda want to add getibits and setibits helpers for arbitrary length signed integers...