### PR TITLE
Fix sign extension for 3-byte signed bytes().geti()

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -918,14 +918,14 @@ static int m_get(bvm *vm, bbool sign)
                         if (sign) { ret = (int16_t)(uint16_t) ret; }
                         break;
             case 3:     ret = buf_get3_le(&attr, idx);
-                        if (sign & (ret & 0x800000)) { ret = ret | 0xFF000000; }
+                        if (sign && (ret & 0x800000)) { ret = ret | 0xFF000000; }
                         break;
             case 4:     ret = buf_get4_le(&attr, idx);    break;
             case -2:    ret = buf_get2_be(&attr, idx);
                         if (sign) { ret = (int16_t)(uint16_t) ret; }
                         break;
             case -3:    ret = buf_get3_be(&attr, idx);
-                        if (sign & (ret & 0x800000)) { ret = ret | 0xFF000000; }
+                        if (sign && (ret & 0x800000)) { ret = ret | 0xFF000000; }
                         break;
             case -4:    ret = buf_get4_be(&attr, idx);    break;
             default:    be_raise(vm, "type_error", "size must be -4, -3, -2, -1, 0, 1, 2, 3 or 4.");

--- a/tests/bytes.be
+++ b/tests/bytes.be
@@ -331,6 +331,18 @@ a = bytes("01020304")
 assert(a.get(1, 3) == 0x040302)
 assert(a.get(1, -3) == 0x020304)
 
+# signed 3-bytes get() must sign-extend when the top bit (bit 23) is set
+a = bytes("FFFFFF")
+assert(a.geti(0, 3) == -1)
+assert(a.geti(0, -3) == -1)
+a = bytes("000080")
+assert(a.geti(0, 3) == -8388608)   #- 0x800000 sign-extended -#
+a = bytes("800000")
+assert(a.geti(0, -3) == -8388608)
+# and it must not sign-extend when the top bit is clear
+a = bytes("FFFF7F")
+assert(a.geti(0, 3) == 0x7FFFFF)
+
 # append base64
 b = bytes("AABBCC")
 c = bytes("001122")


### PR DESCRIPTION
### Bug

\`bytes().geti(idx, 3)\` and \`bytes().geti(idx, -3)\` never sign-extend the 24-bit result, even though the docstring and the 2-byte/4-byte cases in the same function do.

The relevant code in \`m_get()\` (src/be_byteslib.c):

```c
case 3:     ret = buf_get3_le(&attr, idx);
            if (sign & (ret & 0x800000)) { ret = ret | 0xFF000000; }
            break;
...
case -3:    ret = buf_get3_be(&attr, idx);
            if (sign & (ret & 0x800000)) { ret = ret | 0xFF000000; }
            break;
```

\`sign\` is always 0 or 1. \`(ret & 0x800000)\` is always 0 or \`0x800000\` (bit 23 set, bit 0 clear). Bitwise-ANDing \`sign\` (whose only possibly-set bit is bit 0) with \`0x800000\` (which never has bit 0 set) is **always 0**, so the sign-extension branch can never be taken, no matter the sign flag or the value's top bit.

### Repro (on current master)

```berry
> bytes("FFFFFF").geti(0, 3)
16777215          # should be -1
> bytes("FFFFFF").geti(0, -3)
16777215          # should be -1
```

The 2-byte and 4-byte paths are unaffected since they sign-extend via a C type cast (\`(int16_t)(uint16_t) ret\`) rather than this manual bit trick.

### Fix

Change the bitwise \`&\` to a logical \`&&\` in both branches, matching the intent (and matching how \`&&\`/logical checks are used elsewhere in the same function).

### Testing

Built master with this change (gcc/MinGW) and ran the full \`tests/*.be\` suite — no regressions (the only two pre-existing failures on this host, \`comptr.be\` and \`math.be\`, are unrelated MinGW/MSVCRT \`%p\`/NaN string-formatting differences from glibc, present before this change too, and not touched by this PR).

Added regression tests to \`tests/bytes.be\` covering signed 3-byte little- and big-endian reads, including a case with the top bit clear to confirm the fix doesn't over-extend.