### PR TITLE
Fix out-of-bounds read in bytes().setbytes() with explicit len

### DIFF
--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -1125,7 +1125,7 @@ static int m_setbytes(bvm *vm)
         if (argc >= 5 && be_isint(vm, 5)) {
             from_len = be_toint(vm, 5);
             if (from_len < 0) { from_len = 0; }
-            if (from_len >= (int32_t)from_len_total) { from_len = from_len_total; }
+            if (from_len > (int32_t)(from_len_total - from_byte)) { from_len = from_len_total - from_byte; }
         }
         if (idx + from_len >= attr.len) { from_len = attr.len - idx; }
 

--- a/tests/bytes.be
+++ b/tests/bytes.be
@@ -294,6 +294,19 @@ a = b.copy()
 a.setbytes(0, a0)
 assert(a == bytes('112233445566'))
 
+# explicit len larger than the bytes remaining after `from`: must clamp to
+# what is actually available in the source buffer, not read past its end
+# (regression test: from_len used to be clamped against the source's total
+# length instead of against `from_len_total - from_byte`)
+var src_fixed = bytes(-6)              # fixed-size, exact allocation, no headroom
+src_fixed.setbytes(0, bytes('aabbccddeeff'))
+a = a0.copy()
+a.setbytes(0, src_fixed, 4, 100)        # only 2 bytes (eeff) remain from offset 4
+assert(a == bytes('EEFF33445566778899'))
+a = a0.copy()
+a.setbytes(0, src_fixed, 6, 100)        # from_byte at exact end: 0 bytes remain
+assert(a == a0)
+
 # reverse
 assert(bytes().reverse() == bytes())
 assert(bytes("AA").reverse() == bytes("AA"))


### PR DESCRIPTION
## Bug

In `m_setbytes()` (src/be_byteslib.c), when the caller passes an
explicit `len` argument, it is clamped against the source's *total*
length (`from_len_total`), not against the bytes actually remaining
after `from_byte`:

```c
if (from_len >= (int32_t)from_len_total) { from_len = from_len_total; }
```

So whenever `from_byte > 0` and `len` falls in
`(from_len_total - from_byte, from_len_total]`, the subsequent

```c
memmove(attr.bufptr + idx, buf_ptr + from_byte, from_len)
```

reads `from_len` bytes starting at `buf_ptr + from_byte`, which runs
past the end of the source buffer.

Reproduction: with a 1000-byte source `src`,
`dst.setbytes(0, src, 999, 999)` computes a read window of
`[999, 1998)` against a source that is only valid over `[0, 1000)` --
i.e. it reads 998 bytes past the end of the source allocation.
Confirmed via an instrumented build showing the exact out-of-bounds
read window at runtime.

## Fix

Clamp `len` against what's actually left after `from_byte`:

```c
if (from_len > (int32_t)(from_len_total - from_byte)) { from_len = from_len_total - from_byte; }
```

## Testing

Added two regression assertions to `tests/bytes.be` using a
fixed-size, no-headroom source buffer (`bytes(-6)`) so the boundary
is exact:
- an oversized explicit `len` with `from_byte > 0`, which must clamp
  to the bytes actually remaining
- `from_byte` at the exact end of the source (0 bytes remaining)

Confirmed the new assertions fail against unmodified master and pass
after this fix. Ran the full `tests/*.be` suite (55 files) before and
after: no regressions -- the only failures are two pre-existing,
unrelated platform-specific quirks (`tests/comptr.be` `%p` format,
`tests/math.be` NaN string formatting) present identically on
unmodified master.