### PR TITLE
Fix compilation warnings when running `make test`

### DIFF
--- a/src/be_lexer.c
+++ b/src/be_lexer.c
@@ -380,7 +380,7 @@ static bint scan_hexadecimal(blexer *lexer)
     bint res = 0;
     int dig, num = 0;
     while ((dig = be_char2hex(lgetc(lexer))) >= 0) {
-        res = ((bint)res << 4) + dig;
+        res = (bint)(((buint)res << 4) + (buint)dig);
         next(lexer);
         ++num;
     }

--- a/src/be_strlib.c
+++ b/src/be_strlib.c
@@ -345,7 +345,7 @@ BERRY_API bint be_str2int(const char *str, const char **endstr)
         /* hex literal */
         str += 2;       /* skip 0x or 0X */
         while ((c = be_char2hex(*str++)) >= 0) {
-            sum = sum * 16 + c;
+            sum = (bint)((buint)sum * 16 + (buint)c);
         }
         if (endstr) {
             *endstr = str - 1;

--- a/src/berry.h
+++ b/src/berry.h
@@ -48,8 +48,10 @@ extern "C" {
 #endif
 #define BE_INT_FORMAT           "%" BE_INT_FMTLEN "d" /**< BE_INT_FORMAT */
 
-typedef uint8_t bbyte;   /**< bbyte */
-typedef BE_INTEGER bint; /**< bint */
+typedef uint8_t bbyte;             /**< bbyte */
+typedef BE_INTEGER bint;           /**< bint */
+typedef unsigned BE_INTEGER buint; /**< buint (unsigned bint, for well-defined wrap-around arithmetic) */
+
 
 #if BE_USE_SINGLE_FLOAT != 0
   typedef float                 breal; /**< breal */


### PR DESCRIPTION
Fix compilation warnings when compiling using `make test`. No functional change.