### PR TITLE
Harden VM and compiler against corrupt bytecode and hostile input

### DIFF
--- a/default/berry_conf.h
+++ b/default/berry_conf.h
@@ -172,6 +172,16 @@
  **/
 #define BE_USE_OVERLOAD_HASH            1
 
+/* Macro: BE_MAX_PARSER_DEPTH
+ * Hard limit on parser recursion depth (nested expressions and blocks).
+ * Each level costs ~hundreds of bytes of native C stack, so this protects
+ * pathological source from overflowing the C stack at compile time.
+ * Stored in a bbyte, so values above 255 are clamped.
+ * Default: 25 (safe on ESP32 with an 8 KB task stack; well above any
+ * realistic hand-written Berry code).
+ **/
+#define BE_MAX_PARSER_DEPTH             25
+
 /* Macro: BE_USE_DEBUG_HOOK
  * Berry debug hook switch.
  * Default: 0

--- a/src/be_bytecode.c
+++ b/src/be_bytecode.c
@@ -35,7 +35,7 @@
 #if BE_USE_BYTECODE_SAVER || BE_USE_BYTECODE_LOADER
 static void bytecode_error(bvm *vm, const char *msg)
 {
-    be_raise(vm, "io_error", msg);
+    be_raise(vm, "bytecode_error", msg);
 }
 
 static uint8_t vm_sizeinfo(void)
@@ -320,41 +320,62 @@ void be_bytecode_save(bvm *vm, const char *filename, bproto *proto)
 #if BE_USE_BYTECODE_LOADER
 static bbool load_proto(bvm *vm, void *fp, bproto **proto, int info, int version);
 
-static uint8_t load_byte(void *fp)
+/* Robustness limits for values read from the .bec file.
+ * codesize / nconst / nproto are stored as int16_t in bproto, so 32767
+ * is the absolute hard ceiling. Method/global/var counts are bounded
+ * to the same value to keep allocations sane. */
+#define BYTECODE_MAX_COUNT          32767
+
+static void load_bytes(bvm *vm, void *fp, void *buf, size_t len)
+{
+    if (be_fread(fp, buf, len) != len) {
+        bytecode_error(vm, "truncated bytecode file.");
+    }
+}
+
+static uint8_t load_byte(bvm *vm, void *fp)
 {
     uint8_t buffer[1];
-    if (be_fread(fp, buffer, sizeof(buffer)) == sizeof(buffer)) {
-        return buffer[0];
-    }
-    return 0;
+    load_bytes(vm, fp, buffer, sizeof(buffer));
+    return buffer[0];
 }
 
-static uint16_t load_word(void *fp)
+static uint16_t load_word(bvm *vm, void *fp)
 {
     uint8_t buffer[2];
-    if (be_fread(fp, buffer, sizeof(buffer)) == sizeof(buffer)) {
-        return ((uint16_t)buffer[1] << 8) | buffer[0];
-    }
-    return 0;
+    load_bytes(vm, fp, buffer, sizeof(buffer));
+    return ((uint16_t)buffer[1] << 8) | buffer[0];
 }
 
-static uint32_t load_long(void *fp)
+static uint32_t load_long(bvm *vm, void *fp)
 {
     uint8_t buffer[4];
-    if (be_fread(fp, buffer, sizeof(buffer)) == sizeof(buffer)) {
-        return ((uint32_t)buffer[3] << 24)
-            | ((uint32_t)buffer[2] << 16)
-            | ((uint32_t)buffer[1] << 8)
-            | buffer[0];
-    }
-    return 0;
+    load_bytes(vm, fp, buffer, sizeof(buffer));
+    return ((uint32_t)buffer[3] << 24)
+        | ((uint32_t)buffer[2] << 16)
+        | ((uint32_t)buffer[1] << 8)
+        | buffer[0];
 }
 
-static int load_head(void *fp)
+/* Read a non-negative count and reject obviously corrupt values
+ * (negative when reinterpreted as int, or larger than the loader ceiling). */
+static int load_count(bvm *vm, void *fp, const char *what)
+{
+    uint32_t raw = load_long(vm, fp);
+    if (raw > (uint32_t)BYTECODE_MAX_COUNT) {
+        bytecode_error(vm, be_pushfstring(vm,
+            "invalid %s count in bytecode (got %u).", what, raw));
+    }
+    return (int)raw;
+}
+
+static int load_head(bvm *vm, void *fp)
 {
     int res;
     uint8_t buffer[8] = { 0 };
-    be_fread(fp, buffer, sizeof(buffer));
+    if (be_fread(fp, buffer, sizeof(buffer)) != sizeof(buffer)) {
+        bytecode_error(vm, "truncated bytecode header.");
+    }
     res = buffer[0] == MAGIC_NUMBER1 &&
           buffer[1] == MAGIC_NUMBER2 &&
           buffer[2] == MAGIC_NUMBER3 &&
@@ -368,7 +389,7 @@ static int load_head(void *fp)
 
 bbool be_bytecode_check(const char *path)
 {
-    void *fp = be_fopen(path, "r");
+    void *fp = be_fopen(path, "rb");
     if (fp) {
         uint8_t buffer[3], rb;
         rb = (uint8_t)be_fread(fp, buffer, 3);
@@ -382,42 +403,42 @@ bbool be_bytecode_check(const char *path)
     return bfalse;
 }
 
-static bint load_int(void *fp)
+static bint load_int(bvm *vm, void *fp)
 {
 #if USE_64BIT_INT
     bint i;
-    i = load_long(fp);
-    i |= (bint)load_long(fp) << 32;
+    i = load_long(vm, fp);
+    i |= (bint)load_long(vm, fp) << 32;
     return i;
 #else
-    return load_long(fp);
+    return load_long(vm, fp);
 #endif
 }
 
-static breal load_real(void *fp)
+static breal load_real(bvm *vm, void *fp)
 {
 #if BE_USE_SINGLE_FLOAT
     union { breal r; uint32_t i; } u;
-    u.i = load_long(fp);
+    u.i = load_long(vm, fp);
     return u.r;
 #else
     union {
         breal r;
         uint64_t i;
     } u;
-    u.i = load_long(fp);
-    u.i |= (uint64_t)load_long(fp) << 32;
+    u.i = load_long(vm, fp);
+    u.i |= (uint64_t)load_long(vm, fp) << 32;
     return u.r;
 #endif
 }
 
 static bstring* load_string(bvm *vm, void *fp)
 {
-    uint16_t len = load_word(fp);
+    uint16_t len = load_word(vm, fp);
     if (len > 0) {
         bstring *str;
         char *buf = be_malloc(vm, len);
-        be_fread(fp, buf, len);
+        load_bytes(vm, fp, buf, len);
         str = be_newstrn(vm, buf, len);
         be_free(vm, buf, len);
         return str;
@@ -439,8 +460,8 @@ static void load_class(bvm *vm, void *fp, bvalue *v, int version)
     bclass *c = be_newclass(vm, NULL, NULL);
     var_setclass(v, c);
     c->name = load_string(vm, fp);
-    nvar = load_long(fp);
-    count = load_long(fp);
+    nvar = load_count(vm, fp, "class member-variable");
+    count = load_count(vm, fp, "class method");
     while (count--) { /* load method table */
         bvalue *value;
         bstring *name = cache_string(vm, fp);
@@ -474,34 +495,45 @@ static void load_class(bvm *vm, void *fp, bvalue *v, int version)
 
 static void load_value(bvm *vm, void *fp, bvalue *v, int version)
 {
-    switch (load_byte(fp)) {
-    case BE_INT: var_setint(v, load_int(fp)); break;
-    case BE_REAL: var_setreal(v, load_real(fp)); break;
+    uint8_t type = load_byte(vm, fp);
+    switch (type) {
+    case BE_NIL: var_setnil(v); break;
+    case BE_INT: var_setint(v, load_int(vm, fp)); break;
+    case BE_REAL: var_setreal(v, load_real(vm, fp)); break;
     case BE_STRING: var_setstr(v, load_string(vm, fp)); break;
     case BE_CLASS: load_class(vm, fp, v, version); break;
-    default: break;
+    default:
+        bytecode_error(vm, be_pushfstring(vm,
+            "unsupported constant type %u in bytecode.", type));
     }
 }
 
 static void load_bytecode(bvm *vm, void *fp, bproto *proto, int info)
 {
-    int size = (int)load_long(fp);
+    int size = load_count(vm, fp, "instruction");
     if (size) {
         binstruction *code, *end;
         int bcnt = be_builtin_count(vm);
         blist *list = var_toobj(be_indexof(vm, info));
+        int gcnt = be_list_count(list);
         be_assert(be_islist(vm, info));
         proto->code = be_malloc(vm, sizeof(binstruction) * size);
-        proto->codesize = size;
+        proto->codesize = (int16_t)size;
         code = proto->code;
         for (end = code + size; code < end; ++code) {
-            binstruction ins = (binstruction)load_long(fp);
+            binstruction ins = (binstruction)load_long(vm, fp);
             binstruction op = IGET_OP(ins);
             /* fix global variable index */
             if (op == OP_GETGBL || op == OP_SETGBL) {
                 int idx = IGET_Bx(ins);
                 if (idx >= bcnt) { /* does not fix builtin index */
-                    bvalue *name = be_list_at(list, idx - bcnt);
+                    bvalue *name;
+                    if (idx - bcnt >= gcnt) {
+                        bytecode_error(vm, be_pushfstring(vm,
+                            "global index %d out of range (have %d).",
+                            idx - bcnt, gcnt));
+                    }
+                    name = be_list_at(list, idx - bcnt);
                     idx = be_global_find(vm, var_tostr(name));
                     ins = (ins & ~IBx_MASK) | ISET_Bx(idx);
                 }
@@ -513,12 +545,12 @@ static void load_bytecode(bvm *vm, void *fp, bproto *proto, int info)
 
 static void load_constant(bvm *vm, void *fp, bproto *proto, int version)
 {
-    int size = (int)load_long(fp); /* nconst */
+    int size = load_count(vm, fp, "constant"); /* nconst */
     if (size) {
         bvalue *end, *v = be_malloc(vm, sizeof(bvalue) * size);
         memset(v, 0, sizeof(bvalue) * size);
         proto->ktab = v;
-        proto->nconst = size;
+        proto->nconst = (int16_t)size;
         for (end = v + size; v < end; ++v) {
             load_value(vm, fp, v, version);
         }
@@ -527,12 +559,12 @@ static void load_constant(bvm *vm, void *fp, bproto *proto, int version)
 
 static void load_proto_table(bvm *vm, void *fp, bproto *proto, int info, int version)
 {
-    int size = (int)load_long(fp); /* proto count */
+    int size = load_count(vm, fp, "proto"); /* proto count */
     if (size) {
         bproto **p = be_malloc(vm, sizeof(bproto *) * size);
         memset(p, 0, sizeof(bproto *) * size);
         proto->ptab = p;
-        proto->nproto = size;
+        proto->nproto = (int16_t)size;
         while (size--) {
             load_proto(vm, fp, p++, info, version);
         }
@@ -541,15 +573,15 @@ static void load_proto_table(bvm *vm, void *fp, bproto *proto, int info, int ver
 
 static void load_upvals(bvm *vm, void *fp, bproto *proto)
 {
-    int size = (int)load_byte(fp);
+    int size = (int)load_byte(vm, fp);
     if (size) {
         bupvaldesc *uv, *end;
         proto->upvals = be_malloc(vm, sizeof(bupvaldesc) * size);
         proto->nupvals = (bbyte)size;
         uv = proto->upvals;
         for (end = uv + size; uv < end; ++uv) {
-            uv->instack = load_byte(fp);
-            uv->idx = load_byte(fp);
+            uv->instack = load_byte(vm, fp);
+            uv->idx = load_byte(vm, fp);
         }
     }
 }
@@ -567,11 +599,11 @@ static bbool load_proto(bvm *vm, void *fp, bproto **proto, int info, int version
 #else
         load_string(vm, fp);    /* discard name */
 #endif
-        (*proto)->argc = load_byte(fp);
-        (*proto)->nstack = load_byte(fp);
+        (*proto)->argc = load_byte(vm, fp);
+        (*proto)->nstack = load_byte(vm, fp);
         if (version > 1) {
-            (*proto)->varg = load_byte(fp);
-            load_byte(fp); /* discard reserved byte */
+            (*proto)->varg = load_byte(vm, fp);
+            load_byte(vm, fp); /* discard reserved byte */
         }
         load_bytecode(vm, fp, *proto, info);
         load_constant(vm, fp, *proto, version);
@@ -585,8 +617,8 @@ static bbool load_proto(bvm *vm, void *fp, bproto **proto, int info, int version
 void load_global_info(bvm *vm, void *fp)
 {
     int i;
-    int bcnt = (int)load_long(fp); /* builtin count */
-    int gcnt = (int)load_long(fp); /* global count */
+    int bcnt = (int)load_long(vm, fp); /* builtin count */
+    int gcnt = load_count(vm, fp, "global"); /* global count */
     if (bcnt > be_builtin_count(vm)) {
         bytecode_error(vm, be_pushfstring(vm,
             "inconsistent number of builtin objects."));
@@ -603,7 +635,7 @@ void load_global_info(bvm *vm, void *fp)
 
 bclosure* be_bytecode_load_from_fs(bvm *vm, void *fp)
 {
-    int version = load_head(fp);
+    int version = load_head(vm, fp);
     if (version == BYTECODE_VERSION) {
         bclosure *cl = be_newclosure(vm, 0);
         var_setclosure(vm->top, cl);

--- a/src/be_byteslib.c
+++ b/src/be_byteslib.c
@@ -331,14 +331,25 @@ static uint8_t buf_get1(buf_impl* attr, int offset)
 
 static void buf_set1(buf_impl* attr, size_t offset, uint8_t data)
 {
-    if ((int32_t)offset < attr->len) {
+    if (attr->len > 0 && offset < (size_t)attr->len) {
         attr->bufptr[offset] = data;
     }
 }
 
+/* The buf_set/get helpers below operate on a `size_t` offset coming from
+ * scripts. We use this helper to test that `offset + N` bytes are inside
+ * the buffer, with no signed overflow / negative-cast hazard. attr->len
+ * is non-negative (int32_t), so casting it to size_t is exact. */
+static inline bbool buf_room(buf_impl* attr, size_t offset, size_t need)
+{
+    return attr->len > 0
+        && offset < (size_t)attr->len
+        && need <= (size_t)attr->len - offset;
+}
+
 static void buf_set2_le(buf_impl* attr, size_t offset, uint16_t data)
 {
-    if ((int32_t)offset + 1 < attr->len) {
+    if (buf_room(attr, offset, 2)) {
         attr->bufptr[offset] = data & 0xFF;
         attr->bufptr[offset+1] = data >> 8;
     }
@@ -346,7 +357,7 @@ static void buf_set2_le(buf_impl* attr, size_t offset, uint16_t data)
 
 static void buf_set2_be(buf_impl* attr, size_t offset, uint16_t data)
 {
-    if ((int32_t)offset + 1 < attr->len) {
+    if (buf_room(attr, offset, 2)) {
         attr->bufptr[offset+1] = data & 0xFF;
         attr->bufptr[offset] = data >> 8;
     }
@@ -354,7 +365,7 @@ static void buf_set2_be(buf_impl* attr, size_t offset, uint16_t data)
 
 static uint16_t buf_get2_le(buf_impl* attr, size_t offset)
 {
-    if ((int32_t)offset + 1 < attr->len) {
+    if (buf_room(attr, offset, 2)) {
         return attr->bufptr[offset] | (attr->bufptr[offset+1] << 8);
     }
     return 0;
@@ -362,7 +373,7 @@ static uint16_t buf_get2_le(buf_impl* attr, size_t offset)
 
 static uint16_t buf_get2_be(buf_impl* attr, size_t offset)
 {
-    if ((int32_t)offset + 1 < attr->len) {
+    if (buf_room(attr, offset, 2)) {
         return attr->bufptr[offset+1] | (attr->bufptr[offset] << 8);
     }
     return 0;
@@ -370,7 +381,7 @@ static uint16_t buf_get2_be(buf_impl* attr, size_t offset)
 
 static uint32_t buf_get3_le(buf_impl* attr, size_t offset)
 {
-    if ((int32_t)offset + 2 < attr->len) {
+    if (buf_room(attr, offset, 3)) {
         return attr->bufptr[offset] | (attr->bufptr[offset+1] << 8) | (attr->bufptr[offset+2] << 16);
     }
     return 0;
@@ -378,7 +389,7 @@ static uint32_t buf_get3_le(buf_impl* attr, size_t offset)
 
 static uint32_t buf_get3_be(buf_impl* attr, size_t offset)
 {
-    if ((int32_t)offset + 2 < attr->len) {
+    if (buf_room(attr, offset, 3)) {
         return attr->bufptr[offset+2] | (attr->bufptr[offset+1] << 8) | (attr->bufptr[offset] << 16);
     }
     return 0;
@@ -386,7 +397,7 @@ static uint32_t buf_get3_be(buf_impl* attr, size_t offset)
 
 static void buf_set3_le(buf_impl* attr, size_t offset, uint32_t data)
 {
-    if ((int32_t)offset + 2 < attr->len) {
+    if (buf_room(attr, offset, 3)) {
         attr->bufptr[offset] = data & 0xFF;
         attr->bufptr[offset+1] = (data >> 8) & 0xFF;
         attr->bufptr[offset+2] = (data >> 16) & 0xFF;
@@ -395,7 +406,7 @@ static void buf_set3_le(buf_impl* attr, size_t offset, uint32_t data)
 
 static void buf_set3_be(buf_impl* attr, size_t offset, uint32_t data)
 {
-    if ((int32_t)offset + 2 < attr->len) {
+    if (buf_room(attr, offset, 3)) {
         attr->bufptr[offset+2] = data & 0xFF;
         attr->bufptr[offset+1] = (data >> 8) & 0xFF;
         attr->bufptr[offset] = (data >> 16) & 0xFF;
@@ -404,7 +415,7 @@ static void buf_set3_be(buf_impl* attr, size_t offset, uint32_t data)
 
 static void buf_set4_le(buf_impl* attr, size_t offset, uint32_t data)
 {
-    if ((int32_t)offset + 3 < attr->len) {
+    if (buf_room(attr, offset, 4)) {
         attr->bufptr[offset] = data & 0xFF;
         attr->bufptr[offset+1] = (data >> 8) & 0xFF;
         attr->bufptr[offset+2] = (data >> 16) & 0xFF;
@@ -414,7 +425,7 @@ static void buf_set4_le(buf_impl* attr, size_t offset, uint32_t data)
 
 static void buf_set4_be(buf_impl* attr, size_t offset, uint32_t data)
 {
-    if ((int32_t)offset + 3 < attr->len) {
+    if (buf_room(attr, offset, 4)) {
         attr->bufptr[offset+3] = data & 0xFF;
         attr->bufptr[offset+2] = (data >> 8) & 0xFF;
         attr->bufptr[offset+1] = (data >> 16) & 0xFF;
@@ -424,7 +435,7 @@ static void buf_set4_be(buf_impl* attr, size_t offset, uint32_t data)
 
 static uint32_t buf_get4_le(buf_impl* attr, size_t offset)
 {
-    if ((int32_t)offset + 3 < attr->len) {
+    if (buf_room(attr, offset, 4)) {
         return attr->bufptr[offset] | (attr->bufptr[offset+1] << 8) |
             (attr->bufptr[offset+2] << 16) | (attr->bufptr[offset+3] << 24);
     }
@@ -433,7 +444,7 @@ static uint32_t buf_get4_le(buf_impl* attr, size_t offset)
 
 static uint32_t buf_get4_be(buf_impl* attr, size_t offset)
 {
-    if ((int32_t)offset + 3 < attr->len) {
+    if (buf_room(attr, offset, 4)) {
         return attr->bufptr[offset+3] | (attr->bufptr[offset+2] << 8) |
             (attr->bufptr[offset+1] << 16) | (attr->bufptr[offset] << 24);
     }
@@ -1121,13 +1132,17 @@ static int m_setbytes(bvm *vm)
             if ((size_t)from_byte >= from_len_total) { from_byte = from_len_total; }
         }
 
-        int32_t from_len = from_len_total - from_byte;
+        int32_t from_len = (int32_t)(from_len_total - from_byte);
         if (argc >= 5 && be_isint(vm, 5)) {
             from_len = be_toint(vm, 5);
             if (from_len < 0) { from_len = 0; }
-            if (from_len > (int32_t)(from_len_total - from_byte)) { from_len = from_len_total - from_byte; }
+            /* clamp against the bytes available *after* from_byte, not the
+             * total source length, otherwise memmove reads past src */
+            if (from_len > (int32_t)(from_len_total - from_byte)) {
+                from_len = (int32_t)(from_len_total - from_byte);
+            }
         }
-        if (idx + from_len >= attr.len) { from_len = attr.len - idx; }
+        if (idx + from_len > attr.len) { from_len = attr.len - idx; }
 
         // all parameters ok
         if (from_len > 0) {
@@ -1168,7 +1183,8 @@ static int m_reverse(bvm *vm)
         len = be_toint(vm, 3);
         if (len < 0) { len = attr.len - idx; }  /* negative len means */
     }
-    if (idx + len >= attr.len) { len = attr.len - idx; }
+    /* clamp len without overflowing idx + len */
+    if (len > attr.len - idx) { len = attr.len - idx; }
 
     // truncate len to multiple of grouplen
     if (argc >= 4 && be_isint(vm, 4)) {
@@ -1335,8 +1351,13 @@ static int m_merge(bvm *vm)
             buf_len = strlen((const char *)buf);
         }
 
-        /* allocate new object */
-        bytes_new_object(vm, attr.len + buf_len);
+        /* allocate new object; do the size addition in size_t and reject
+         * obvious overflow before bytes_realloc clamps it down */
+        size_t total = (size_t)attr.len + (size_t)buf_len;
+        if (total > (size_t)vm->bytesmaxsize) {
+            be_raise(vm, "memory_error", "bytes object too large");
+        }
+        bytes_new_object(vm, (int32_t)total);
         buf_impl attr3 = m_read_attributes(vm, -1);
         check_ptr(vm, &attr3);
 
@@ -1663,7 +1684,9 @@ BERRY_API void * be_pushbytes(bvm *vm, const void * bytes, size_t len)
     bytes_new_object(vm, len);
     buf_impl attr = m_read_attributes(vm, -1);
     check_ptr(vm, &attr);
-    if ((int32_t)len > attr.size) { len = attr.size; } /* double check if the buffer allocated was smaller */
+    /* compare unsigned: a huge `len` (> INT32_MAX) must NOT be treated as
+     * negative and bypass the cap */
+    if (len > (size_t)attr.size) { len = (size_t)attr.size; }
     if (bytes) {  /* if bytes is null, buffer is filled with zeros */
         memmove((void*)attr.bufptr, bytes, len);
     } else {

--- a/src/be_code.c
+++ b/src/be_code.c
@@ -139,7 +139,7 @@ int be_code_allocregs(bfuncinfo *finfo, int count)
 {
     int base = finfo->freereg;
     allocstack(finfo, count);
-    finfo->freereg += (char)count;
+    finfo->freereg += count;
     return base;
 }
 
@@ -147,6 +147,9 @@ static void setjump(bfuncinfo *finfo, int pc, int dst)
 {
     binstruction *p = be_vector_at(&finfo->code, pc);
     int offset = dst - (pc + 1);
+    if (offset < IsBx_MIN || offset > IsBx_MAX) {
+        be_lexerror(finfo->lexer, "jump too far");
+    }
     /* instruction edit jump destination */
     *p = (*p & ~IBx_MASK) | ISET_sBx(offset);
 }

--- a/src/be_debuglib.c
+++ b/src/be_debuglib.c
@@ -108,9 +108,17 @@ static int m_caller(bvm *vm)
 {
     int depth = 1;
     if (be_top(vm) >= 1 && be_isint(vm, 1)) {
-        depth = be_toint(vm, 1);
-        if (depth < 0) {
-            depth = -depth;         /* take absolute value */
+        int d = be_toint(vm, 1);
+        int count = be_stack_count(&vm->callstack);
+        /* clamp |d| to the live frame count. Comparing d against -count
+         * first lets us safely negate only values that fit, avoiding the
+         * -INT_MIN sign-flip undefined behavior. */
+        if (d < -count || d > count) {
+            depth = count;
+        } else if (d < 0) {
+            depth = -d;
+        } else {
+            depth = d;
         }
     }
     bcallframe *cf = (bcallframe*)be_stack_top(&vm->callstack) - depth;

--- a/src/be_lexer.c
+++ b/src/be_lexer.c
@@ -247,6 +247,9 @@ static void tr_string(blexer *lexer)
             be_lexerror(lexer, "unfinished string");
             break;
         case '\\':
+            if (src >= end) {
+                be_lexerror(lexer, "invalid escape sequence");
+            }
             if (*src != 'u') {
                 switch (*src) {
                 case 'a': c = '\a'; break;
@@ -260,8 +263,17 @@ static void tr_string(blexer *lexer)
                 case '\'': c = '\''; break;
                 case '"': c = '"'; break;
                 case '?': c = '?'; break;
-                case 'x': c = read_hex(lexer, ++src); ++src; break;
+                case 'x':
+                    if (end - src < 3) {  /* need 'x' + 2 hex digits */
+                        be_lexerror(lexer, "invalid hexadecimal number");
+                    }
+                    c = read_hex(lexer, ++src);
+                    ++src;
+                    break;
                 default:
+                    if (end - src < 3) {  /* need 3 octal digits */
+                        be_lexerror(lexer, "invalid octal number");
+                    }
                     c = read_oct(lexer, src);
                     if (c != EOS) {
                         src += 2;
@@ -272,6 +284,9 @@ static void tr_string(blexer *lexer)
                 *dst++ = (char)c;
             } else {
                 /* unicode encoding, ex "\uF054" is equivalent to "\xEF\x81\x94"*/
+                if (end - src < 5) {  /* need 'u' + 4 hex digits */
+                    be_lexerror(lexer, "incorrect '\\u' encoding");
+                }
                 dst = be_load_unicode(dst, src + 1);
                 src += 5;
                 if (dst == NULL) {
@@ -300,6 +315,9 @@ static int skip_newline(blexer *lexer)
         next(lexer); /* skip "\n\r" or "\r\n" */
     }
     lexer->linenumber++;
+#if BE_USE_PREPROCESSOR
+    lexer->pp_at_line_start = btrue;
+#endif
     return lexer->reader.cursor;
 }
 
@@ -354,7 +372,9 @@ static btokentype scan_dot_real(blexer *lexer)
     if (is_digit(lgetc(lexer))) {
         match(lexer, is_digit);
         scan_realexp(lexer);
+        save_char(lexer, '\0');
         setreal(lexer, be_str2real(lexbuf(lexer), NULL));
+        --lexer->buf.len;  /* drop the trailing NUL we just added */
         return TokenReal;
     }
     return OptDot;

--- a/src/be_parser.c
+++ b/src/be_parser.c
@@ -73,7 +73,16 @@ typedef struct {
     bfuncinfo *finfo;
     bclosure *cl;
     bbyte islocal;
+    bbyte depth;  /* recursion depth for expr/block; bounded by BE_MAX_PARSER_DEPTH (must fit in bbyte) */
 } bparser;
+
+#define enter_recursion(parser) do { \
+    if (++(parser)->depth > BE_MAX_PARSER_DEPTH) { \
+        push_error((parser), "expression or block too deeply nested"); \
+    } \
+} while (0)
+
+#define leave_recursion(parser)  (--(parser)->depth)
 
 #if BE_USE_SCRIPT_COMPILER
 
@@ -1078,7 +1087,9 @@ static void cond_expr(bparser *parser, bexpdesc *e)
 static void sub_expr(bparser *parser, bexpdesc *e, int prio)
 {
     bfuncinfo *finfo = parser->finfo;
-    btokentype op = get_unary_op(parser);  /* check if first token in unary op */
+    btokentype op;
+    enter_recursion(parser);
+    op = get_unary_op(parser);  /* check if first token in unary op */
     if (op != OP_NOT_UNARY) {  /* unary op found */
         int line, res;
         scan_next_token(parser);  /* move to next token */
@@ -1116,6 +1127,7 @@ static void sub_expr(bparser *parser, bexpdesc *e, int prio)
     if (prio == ASSIGN_OP_PRIO) {
         cond_expr(parser, e);
     }
+    leave_recursion(parser);
 }
 
 static void walrus_expr(bparser *parser, bexpdesc *e)
@@ -1807,9 +1819,11 @@ static void stmtlist(bparser *parser)
 static void block(bparser *parser, int type)
 {
     bblockinfo binfo;
+    enter_recursion(parser);
     begin_block(parser->finfo, &binfo, type);
     stmtlist(parser);
     end_block(parser);
+    leave_recursion(parser);
 }
 
 static void mainfunc(bparser *parser, bclosure *cl)
@@ -1835,6 +1849,7 @@ bclosure* be_parser_source(bvm *vm,
     parser.finfo = NULL;
     parser.cl = cl;
     parser.islocal = (bbyte)islocal;
+    parser.depth = 0;
     var_setclosure(vm->top, cl);
     be_stackpush(vm);
     be_lexer_init(&parser.lexer, vm, fname, reader, data);

--- a/src/be_string.c
+++ b/src/be_string.c
@@ -8,6 +8,7 @@
 #include "be_string.h"
 #include "be_vm.h"
 #include "be_mem.h"
+#include "be_exec.h"
 #include "be_constobj.h"
 #include <string.h>
 
@@ -157,8 +158,16 @@ void be_string_deleteall(bvm *vm)
     be_free(vm, tab->table, tab->size * sizeof(bstring*));
 }
 
+/* Hard cap on string length. Well above any plausible string on an
+ * embedded target, but small enough that header + len + 1 cannot
+ * overflow size_t and len fits in blstring.llen (int). */
+#define BE_STRING_MAX_LEN  (16 * 1024 * 1024)  /* 16 MiB */
+
 static bstring* createstrobj(bvm *vm, size_t len, int islong)
 {
+    if (len > BE_STRING_MAX_LEN) {
+        be_raise(vm, "memory_error", "string too large");
+    }
     size_t size = (islong ? sizeof(blstring)
                 : sizeof(bsstring)) + len + 1;
     bgcobject *gco = be_gc_newstr(vm, size, islong);

--- a/tests/bytecode_corrupt.be
+++ b/tests/bytecode_corrupt.be
@@ -1,0 +1,68 @@
+# Tests that the bytecode loader fails cleanly on corrupt .bec input,
+# raising `bytecode_error` rather than crashing or silently producing
+# zero-filled bytecode.
+
+import os
+import global
+
+var tmpdir = '/tmp'
+var src_path = tmpdir + '/be_bc_src.be'
+var bec_path = tmpdir + '/be_bc.bec'
+
+# 1. Save a real .bec file and confirm it still round-trips through the loader.
+var f = open(src_path, 'w')
+f.write('def hello(x) return x + 1 end\n')
+f.close()
+
+var fn = compile(src_path, 'file')
+var fout = open(bec_path, 'w')
+fout.savecode(fn)
+fout.close()
+
+# Load it back: the new bytecode_error path must NOT fire on valid input.
+var loaded = compile(bec_path, 'file')
+assert(type(loaded) == 'function')
+loaded()  # executes the top-level, defining `hello` as a global
+assert(global.hello(41) == 42)
+
+# Read the saved .bec into a buffer for crafting variants.
+var fin = open(bec_path, 'r')
+var good = fin.readbytes()
+fin.close()
+assert(size(good) >= 16)
+
+def expect_bytecode_error(path, label)
+    var caught = false
+    try
+        compile(path, 'file')
+    except 'bytecode_error' as e, m
+        caught = true
+    end
+    assert(caught, 'expected bytecode_error for ' + label)
+end
+
+def write_bytes(path, b)
+    var w = open(path, 'w')
+    w.write(b)
+    w.close()
+end
+
+# 2. Truncate after the magic header (8 bytes). Any subsequent count read
+#    must hit EOF and raise bytecode_error.
+var truncated = good[0..7]
+write_bytes(bec_path, truncated)
+expect_bytecode_error(bec_path, 'header-only truncation')
+
+# 3. Truncate inside the body (keep some payload, drop the tail).
+write_bytes(bec_path, good[0..(size(good) / 2)])
+expect_bytecode_error(bec_path, 'mid-file truncation')
+
+# 4. Header is valid, but the global-count field is set to 0xFFFFFFFF.
+#    Layout: 8-byte header, then 4-byte builtin-count, then 4-byte gcnt.
+var corrupt_gcnt = good[0..7] + good[8..11] + bytes('FFFFFFFF')
+write_bytes(bec_path, corrupt_gcnt)
+expect_bytecode_error(bec_path, 'oversized global count')
+
+# Cleanup.
+os.remove(src_path)
+os.remove(bec_path)

--- a/tests/debug.be
+++ b/tests/debug.be
@@ -25,5 +25,19 @@ def guess_my_name__()
     return caller_name_chain()
 end
 chain = guess_my_name__()
+print(chain)
 assert(chain[0] == 'caller_name_chain')
 assert(chain[1] == 'guess_my_name__')
+
+# debug.caller() must not crash on out-of-range or pathological inputs.
+# Returns nil (or some valid frame) but never blows the stack / segfaults.
+def assert_no_crash(d)
+    debug.caller(d)  # value irrelevant, just must not crash
+end
+assert_no_crash(0)
+assert_no_crash(-1)
+assert_no_crash(99999)
+assert_no_crash(-99999)
+# INT_MIN-style edge: largest negative int that fits in a Berry int.
+# On 32-bit bint this is -0x80000000, the historical -INT_MIN UB trigger.
+assert_no_crash(-0x7FFFFFFF - 1)

--- a/tests/parser_robustness.be
+++ b/tests/parser_robustness.be
@@ -1,0 +1,30 @@
+# Tests that the parser refuses pathologically deep nesting cleanly,
+# rather than overflowing the C stack (B-08).
+
+def expect_syntax_error(src, hint)
+    var caught = false
+    try
+        compile(src)
+    except 'syntax_error' as e, m
+        caught = true
+    end
+    assert(caught, 'expected syntax_error for ' + hint)
+end
+
+# Deeply nested parens: the depth limit should kick in cleanly.
+# 100 is well past BE_MAX_PARSER_DEPTH (25) but cheap to construct.
+var deep_parens = ''
+for i : 0..99 deep_parens = deep_parens + '(' end
+deep_parens = deep_parens + '1'
+for i : 0..99 deep_parens = deep_parens + ')' end
+expect_syntax_error(deep_parens, 'deep parens')
+
+# Deeply nested if/end: same pressure on `block`.
+var deep_if = ''
+for i : 0..99 deep_if = deep_if + 'if 1 ' end
+deep_if = deep_if + '1 '
+for i : 0..99 deep_if = deep_if + 'end ' end
+expect_syntax_error(deep_if, 'deep if/end')
+
+# A normal-depth nested expression should still compile fine.
+compile('var a = (((((((((1 + 2)))))))))')


### PR DESCRIPTION
Harden VM and compiler against corrupt bytecode and hostile input, using extensively Claude

- Bytecode loader: every read now goes through load_bytes() and raises `bytecode_error` on EOF instead of silently returning 0, so truncated .bec files no longer produce zero-filled code that gets executed.
- Bytecode loader: counts (instructions, constants, protos, globals, class methods/vars) are validated against BYTECODE_MAX_COUNT (32767, the int16_t ceiling in bproto) before being used as allocation sizes.
- Bytecode loader: global indices in OP_GETGBL/OP_SETGBL are bounds-checked against the loaded global list, unknown constant types are rejected, and BE_NIL is handled explicitly. .bec files are now opened in binary mode.
- bytes: replaced the `(int32_t)offset + N < len` bounds tests with a buf_room() helper that compares in size_t. The old form sign-flipped on large script-supplied offsets and allowed out-of-bounds reads/writes.
- bytes: fixed off-by-one clamping in setbytes() and reverse() (`>=` vs `>` dropped the last valid byte and could overflow `idx + len`), and merge() now computes the combined size in size_t and rejects oversize results.
- be_pushbytes(): length is compared unsigned against the buffer cap, so a len above INT32_MAX can no longer read as negative and skip the clamp.
- Parser: added BE_MAX_PARSER_DEPTH (default 25) and enter/leave_recursion around sub_expr() and block(). Deeply nested source now raises a syntax_error instead of overflowing the native C stack.
- Lexer: escape sequence decoding checks remaining input before consuming it, so `\x`, `\<octal>`, `\u` and a trailing backslash at EOF no longer read past the end of the source buffer.
- Lexer: scan_dot_real() NUL-terminates the token buffer before calling be_str2real(), which previously read past the buffer end.
- Code generator: be_code_allocregs() no longer truncates the register count through `(char)`, and setjump() rejects offsets outside sBx range with "jump too far" instead of emitting a corrupt instruction.
- debug.caller(): the depth argument is clamped to the live frame count before negation, removing the -INT_MIN sign-flip UB and out-of-range callstack reads.
- Strings: createstrobj() caps length at 16 MiB so `header + len + 1` cannot overflow size_t.
- Tests: added tests/bytecode_corrupt.be and tests/parser_robustness.be, and extended tests/debug.be with out-of-range debug.caller() inputs.
