### PR TITLE
Expand json.dump()

### DIFF
--- a/src/be_jsonlib.c
+++ b/src/be_jsonlib.c
@@ -46,26 +46,6 @@ static const char* match_char(const char *json, int ch)
     return NULL;
 }
 
-static int is_object(bvm *vm, const char *class, int idx)
-{
-    if (be_isinstance(vm, idx)) {
-        be_pushvalue(vm, idx);
-        while (1) {
-            be_getsuper(vm, -1);
-            if (be_isnil(vm, -1)) {
-                be_pop(vm, 1);
-                break;
-            }
-            be_remove(vm, -2);
-        }
-        const char *name = be_classname(vm, -1);
-        bbool ret = !strcmp(name, class);
-        be_pop(vm, 1);
-        return ret;
-    }
-    return  0;
-}
-
 /* Calculate the actual buffer size needed for JSON string parsing
  * accounting for Unicode expansion and security limits */
 static size_t json_strlen_safe(const char *json, size_t *actual_len)
@@ -510,6 +490,75 @@ void string_dump(bvm *vm, int index)
     be_pushvalue(vm, index);
 }
 
+/* Custom serialization of instances through a `tojson()` method.
+ *
+ * Any instance can control how `json.dump()` serializes it by implementing:
+ *
+ *     def tojson(indent)
+ *
+ * Argument (optional, a `tojson()` declared without argument is valid since
+ * Berry silently ignores extra arguments):
+ *   `indent`: `nil` when `json.dump()` was called without the `"format"` option,
+ *             i.e. the output must be compact.
+ *             Otherwise an `int`, the current nesting level of this value, `0`
+ *             at top-level, each level being `INDENT_WIDTH` (2) spaces. The
+ *             opening indentation is already emitted by the caller, so only
+ *             continuation lines need to be indented (at `indent`, and
+ *             `indent+1` for nested content).
+ *             `nil` and `0` must be distinguished, hence `nil` rather than `0`
+ *             for the compact case: a top-level value is at level `0` in both
+ *             modes, so the type of `indent` is what carries the mode.
+ *             In compact mode the argument is simply not passed, and Berry
+ *             defaults it to `nil`, so a vararg `tojson(*a)` sees `[]`.
+ *
+ * Return value:
+ *   A `string` inserted *verbatim* in the output. No JSON syntax check is done,
+ *   and no quoting nor escaping is applied: the method is fully responsible for
+ *   emitting valid JSON. This is what allows returning a JSON object, array,
+ *   number or `null`, and not only a JSON string. Note that returning a JSON
+ *   string requires the quotes to be part of the returned value, and the content
+ *   to be escaped, e.g. `return '"hello"'`.
+ *   `nil` means "no custom serialization", and `json.dump()` falls back to its
+ *   default behavior for this value.
+ *   Any other type raises `type_error`.
+ *
+ * Instances without a `tojson()` method are unaffected and keep being dumped as
+ * the JSON string of their `tostring()` representation.
+ *
+ * This function returns `btrue` if the value was serialized by `tojson()`, and
+ * the resulting string is left on top of the stack. It returns `bfalse` if the
+ * value is not an instance, has no `tojson` method, or `tojson()` returned
+ * `nil`, and the stack is left unchanged. */
+static bbool instance_dump(bvm *vm, int *indent, int idx, int fmt)
+{
+    if (!be_isinstance(vm, idx)) { return bfalse; }
+    be_stack_require(vm, 3 + BE_STACK_FREE_MIN); /* method + self + 1 arg */
+    idx = be_absindex(vm, idx); /* we push values below, `idx` must not be relative */
+    if (!be_getmethod(vm, idx, "tojson")) {
+        be_pop(vm, 1); /* `be_getmethod` always pushes a value, remove it */
+        return bfalse;
+    }
+    be_pushvalue(vm, idx); /* push instance as first argument (self) */
+    int argc = 1; /* self */
+    if (fmt) {
+        be_pushint(vm, *indent);
+        argc++;
+    } /* else don't pass `indent` at all, Berry defaults missing arguments to `nil` */
+    be_call(vm, argc);
+    be_pop(vm, argc); /* remove self and arg, the return value is now on top */
+    if (be_isnil(vm, -1)) { /* `nil` means: use the default serialization */
+        be_pop(vm, 1);
+        return bfalse;
+    }
+    if (!be_isstring(vm, -1)) {
+        const char *name = be_classname(vm, idx);
+        be_raise(vm, "type_error", be_pushfstring(vm,
+            "the value of `%s::tojson()` is not a 'string'",
+            (name && strlen(name)) ? name : "<anonymous>"));
+    }
+    return btrue;
+}
+
 static void object_dump(bvm *vm, int *indent, int idx, int fmt)
 {
 
@@ -587,10 +636,15 @@ static void array_dump(bvm *vm, int *indent, int idx, int fmt)
 
 static void value_dump(bvm *vm, int *indent, int idx, int fmt)
 {
-    // be_stack_require(vm, 1 + BE_STACK_FREE_MIN);
-    if (is_object(vm, "map", idx)) { /* convert to json object */
+    be_stack_require(vm, 1 + BE_STACK_FREE_MIN); /* the isinstance checks below push 1 value */
+    /* `be_ismapinstance()` / `be_islistinstance()` walk the class hierarchy and
+     * compare against the actual builtin `map` / `list` classes, so subclasses
+     * are handled, and a user class that merely shares the name is not. */
+    if (instance_dump(vm, indent, idx, fmt)) { /* an explicit `tojson()` method takes precedence */
+        /* the result was pushed by `instance_dump` */
+    } else if (be_ismapinstance(vm, idx)) { /* convert to json object */
         object_dump(vm, indent, idx, fmt);
-    } else if (is_object(vm, "list", idx)) { /* convert to json array */
+    } else if (be_islistinstance(vm, idx)) { /* convert to json array */
         array_dump(vm, indent, idx, fmt);
     } else if (be_isnil(vm, idx)) { /* convert to json null */
         be_stack_require(vm, 1 + BE_STACK_FREE_MIN); 

--- a/tests/json.be
+++ b/tests/json.be
@@ -61,8 +61,8 @@ json.load(text) # do nothing, just check that it doesn't crash
 
 # dump tests
 
-def assert_dump(value, text, format)
-    assert(json.dump(value, format) == text)
+def assert_dump(value, text, fmt)
+    assert(json.dump(value, fmt) == text)
 end
 
 assert_dump(nil, 'null');
@@ -80,6 +80,111 @@ class map2 : map def init() super(self).init() end end
 var m = map2()
 m['key'] = 1
 assert_dump(m, '{"key":1}')
+
+# dump of instances implementing `tojson(format, indent)`
+
+def assert_dump_error(value, error_type, fmt)
+    try
+        json.dump(value, fmt)
+        assert(false, 'unexpected execution flow')
+    except .. as e, m
+        assert(e == error_type)
+    end
+end
+
+# the returned string is inserted verbatim, it can be any JSON fragment
+class J_str def tojson() return '"raw"' end end
+assert_dump(J_str(), '"raw"')
+class J_int def tojson() return '42' end end
+assert_dump(J_int(), '42')
+class J_null def tojson() return 'null' end end
+assert_dump(J_null(), 'null')
+class J_obj def tojson() return '{"a":1}' end end
+assert_dump(J_obj(), '{"a":1}')
+class J_arr def tojson() return '[1,2]' end end
+assert_dump(J_arr(), '[1,2]')
+# no JSON syntax check is done on the returned string
+class J_bad def tojson() return 'not json' end end
+assert_dump(J_bad(), 'not json')
+
+# nested in containers
+assert_dump([J_obj(), J_int()], '[{"a":1},42]')
+assert_dump({'k': J_obj()}, '{"k":{"a":1}}')
+assert_dump({'k': J_obj()}, '{\n  "k": {"a":1}\n}', 'format')
+
+# `tojson()` is not used for map keys, they are always `tostring()` of the key
+class J_key def tostring() return 'thekey' end def tojson() return '{"a":1}' end end
+assert_dump({J_key(): 1}, '{"thekey":1}')
+
+# the `indent` argument is `nil` for compact output, and the nesting level
+# (an `int`, `0` at top-level) when the 'format' option is used
+class J_args def tojson(indent) return string.format('"%s"', str(indent)) end end
+assert_dump(J_args(), '"nil"')
+assert_dump(J_args(), '"0"', 'format')
+assert_dump({'k': J_args()}, '{"k":"nil"}')
+assert_dump({'k': J_args()}, '{\n  "k": "1"\n}', 'format')
+# a top-level value is at level 0 in both modes, so the type of `indent`
+# (`nil` vs `int`) is what carries the mode, not its value
+assert_dump([[J_args()]], '[\n  [\n    "2"\n  ]\n]', 'format')
+assert_dump([[J_args()]], '[["nil"]]')
+# declaring `tojson()` without argument is valid, extra arguments are ignored
+class J_noargs def tojson() return '1' end end
+assert_dump(J_noargs(), '1')
+
+# returning `nil` falls back to the default serialization
+class J_nil def tojson() return nil end def tostring() return 'default' end end
+assert_dump(J_nil(), '"default"')
+class J_noreturn def tojson() end end
+assert_dump(J_noreturn(), '"<instance: J_noreturn()>"')
+# which allows opting out on a per-instance basis
+class J_cond var raw
+    def init(raw) self.raw = raw end
+    def tojson() if self.raw return '1' end return nil end
+    def tostring() return 'str' end
+end
+assert_dump([J_cond(true), J_cond(false)], '[1,"str"]')
+
+# any other return type raises `type_error`
+class J_err_int def tojson() return 42 end end
+assert_dump_error(J_err_int(), 'type_error')
+class J_err_list def tojson() return [1] end end
+assert_dump_error(J_err_list(), 'type_error')
+assert_dump_error([{'k': J_err_int()}], 'type_error')
+# exceptions raised by `tojson()` propagate
+class J_raise def tojson() raise 'custom_error' end end
+assert_dump_error(J_raise(), 'custom_error')
+
+# `tojson()` is inherited, and can be overridden
+class J_sub : J_obj end
+assert_dump(J_sub(), '{"a":1}')
+class J_sub2 : J_obj def tojson() return '{"b":2}' end end
+assert_dump(J_sub2(), '{"b":2}')
+
+# `tojson()` can be static
+class J_static static def tojson() return '"static"' end end
+assert_dump(J_static(), '"static"')
+
+# `tojson()` can be provided by a virtual `member()` method
+class J_virtual def member(name) if name == 'tojson' return def () return '"virtual"' end end end end
+assert_dump(J_virtual(), '"virtual"')
+
+# a `tojson` member which is not a function is ignored
+class J_notfunc var tojson def init() self.tojson = 12 end end
+assert_dump(J_notfunc(), '"<instance: J_notfunc()>"')
+
+# `tojson()` takes precedence over `map` and `list` sub-classes
+class J_map : map def init() super(self).init() end def tojson() return '"amap"' end end
+var jm = J_map()
+jm['k'] = 1
+assert_dump(jm, '"amap"')
+class J_list : list def init() super(self).init() end def tojson() return '"alist"' end end
+assert_dump(J_list(), '"alist"')
+
+# instances without `tojson()` are unaffected
+class J_plain end
+assert_dump(J_plain(), '"<instance: J_plain()>"')
+class J_tostr def tostring() return 'a "quoted" str' end end
+assert_dump(J_tostr(), '"a \\"quoted\\" str"')
 
 # sweep dumping nested arrays of diffrent sizes
 # this tests for any unexpanded stack conditions


### PR DESCRIPTION
Expand `json.dump()`:
- support dumping subclasses of `map` and `list` and not just `map` and `list` class
- whenever an instance contains `tojson()` use this method to expand to json (overrides being a subclass of `map` and `list`)

Below the documentation for the function:

Any instance can control how `json.dump()` serializes it by implementing:

```berry
def tojson(indent)
```

**Argument** (optional, a `tojson()` declared without argument is valid since
Berry silently ignores extra arguments):
- `indent`: `nil` when `json.dump()` was called without the `"format"` option,
  i.e. the output must be compact.
  Otherwise an `int`, the current nesting level of this value, `0`
  at top-level, each level being `INDENT_WIDTH` (2) spaces. The
  opening indentation is already emitted by the caller, so only
  continuation lines need to be indented (at `indent`, and
  `indent+1` for nested content).
  `nil` and `0` must be distinguished, hence `nil` rather than `0`
  for the compact case: a top-level value is at level `0` in both
  modes, so the type of `indent` is what carries the mode.
  In compact mode the argument is simply not passed, and Berry
  defaults it to `nil`, so a vararg `tojson(*a)` sees `[]`.

**Return value:**
A `string` inserted *verbatim* in the output. No JSON syntax check is done,
and no quoting nor escaping is applied: the method is fully responsible for
emitting valid JSON. This is what allows returning a JSON object, array,
number or `null`, and not only a JSON string. Note that returning a JSON
string requires the quotes to be part of the returned value, and the content
to be escaped, e.g. `return '"hello"'`.
`nil` means "no custom serialization", and `json.dump()` falls back to its
default behavior for this value.
Any other type raises `type_error`.

Instances without a `tojson()` method are unaffected and keep being dumped as
the JSON string of their `tostring()` representation.
